### PR TITLE
Improve the player client side interpolation

### DIFF
--- a/NebulaClient/GameLogic/PlayerManager.cs
+++ b/NebulaClient/GameLogic/PlayerManager.cs
@@ -5,8 +5,8 @@ namespace NebulaClient.GameLogic
 {
     public class PlayerManager
     {
-        Dictionary<ushort, Player> remotePlayers;
-        Dictionary<ushort, RemotePlayerModel> remotePlayerModels;
+        readonly Dictionary<ushort, Player> remotePlayers;
+        readonly Dictionary<ushort, RemotePlayerModel> remotePlayerModels;
 
         public Player LocalPlayer { get; protected set; }
         public readonly LocalPlayerModel LocalPlayerModel = new LocalPlayerModel();

--- a/NebulaClient/MonoBehaviours/Local/LocalPlayerAnimation.cs
+++ b/NebulaClient/MonoBehaviours/Local/LocalPlayerAnimation.cs
@@ -6,12 +6,13 @@ namespace NebulaClient.MonoBehaviours.Local
 {
     public class LocalPlayerAnimation : MonoBehaviour
     {
-        public const float BROADCAST_INTERVAL = 0.2f; // 5 updates per seconds
+        public const int SEND_RATE = 5;
+        public const float BROADCAST_INTERVAL = 1f / SEND_RATE;
 
         private float time;
         private PlayerAnimator playerAnimator;
 
-        void Start()
+        void Awake()
         {
             playerAnimator = GetComponent<PlayerAnimator>();
         }

--- a/NebulaClient/MonoBehaviours/Local/LocalPlayerMovement.cs
+++ b/NebulaClient/MonoBehaviours/Local/LocalPlayerMovement.cs
@@ -5,13 +5,14 @@ namespace NebulaClient.MonoBehaviours.Local
 {
     public class LocalPlayerMovement : MonoBehaviour
     {
-        public const float BROADCAST_INTERVAL = 0.05f; // 20 updates per seconds
+        public const int SEND_RATE = 15;
+        private const float BROADCAST_INTERVAL = 1f / SEND_RATE;
 
         private float time;
         private Transform rootTransform;
         private Transform bodyTransform;
 
-        void Start()
+        void Awake()
         {
             rootTransform = GetComponent<Transform>();
             bodyTransform = rootTransform.Find("Model");

--- a/NebulaClient/MonoBehaviours/Local/LocalPlayerMovement.cs
+++ b/NebulaClient/MonoBehaviours/Local/LocalPlayerMovement.cs
@@ -6,7 +6,7 @@ namespace NebulaClient.MonoBehaviours.Local
     public class LocalPlayerMovement : MonoBehaviour
     {
         public const int SEND_RATE = 15;
-        private const float BROADCAST_INTERVAL = 1f / SEND_RATE;
+        public const float BROADCAST_INTERVAL = 1f / SEND_RATE;
 
         private float time;
         private Transform rootTransform;

--- a/NebulaModel/NebulaModel.csproj
+++ b/NebulaModel/NebulaModel.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\AssembliesUtils.cs" />
     <Compile Include="Utils\LiteNetLibUtils.cs" />
+    <Compile Include="Utils\TimeUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LiteNetLib\LiteNetLib\LiteNetLib.csproj">

--- a/NebulaModel/Utils/TimeUtils.cs
+++ b/NebulaModel/Utils/TimeUtils.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace NebulaModel.Utils
+{
+    public class TimeUtils
+    {
+        static readonly DateTime UNIX_EPOCH = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        public static long CurrentUnixTimestampMilliseconds()
+        {
+            return (long)(DateTime.UtcNow - UNIX_EPOCH).TotalMilliseconds;
+        }
+    }
+}

--- a/NebulaServer/Server.cs
+++ b/NebulaServer/Server.cs
@@ -24,6 +24,11 @@ namespace NebulaServer
             server = new NetManager(this)
             {
                 AutoRecycle = true,
+                // Settings below only works in DEBUG builds
+                SimulateLatency = true,
+                SimulatePacketLoss = true,
+                SimulationMinLatency = 20,
+                SimulationMaxLatency = 80,
             };
 
             playerManager = new PlayerManager();

--- a/NebulaServer/Server.cs
+++ b/NebulaServer/Server.cs
@@ -24,11 +24,12 @@ namespace NebulaServer
             server = new NetManager(this)
             {
                 AutoRecycle = true,
-                // Settings below only works in DEBUG builds
+#if DEBUG
                 SimulateLatency = true,
                 SimulatePacketLoss = true,
                 SimulationMinLatency = 20,
                 SimulationMaxLatency = 80,
+#endif
             };
 
             playerManager = new PlayerManager();


### PR DESCRIPTION
 I've improved the `RemotePlayerMovement` client side interpolation algorithm to make sure that we still have smooth player movement even with high latency connection.

With this implementation, during my tests, I had still pretty decent movement smoothness even in the 200-300ms latency range.

I've also added some default connection latency and drop packet simulation for a "standard" remote connection to make sure that we have a realistic testing environment.