### PR TITLE
Add initial sync of factory to player when they try to load it

### DIFF
--- a/NebulaClient/NebulaClient.csproj
+++ b/NebulaClient/NebulaClient.csproj
@@ -74,6 +74,7 @@
   <ItemGroup>
     <Compile Include="MultiplayerClientSession.cs" />
     <Compile Include="PacketProcessors\GameStates\GameStateUpdateProcessor.cs" />
+    <Compile Include="PacketProcessors\Planet\FactoryDataProcessor.cs" />
     <Compile Include="PacketProcessors\Planet\VegetationMinedProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerAnimationUpdateProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerColorChangeProcessor.cs" />

--- a/NebulaClient/PacketProcessors/Planet/FactoryDataProcessor.cs
+++ b/NebulaClient/PacketProcessors/Planet/FactoryDataProcessor.cs
@@ -1,0 +1,23 @@
+﻿using NebulaModel.Attributes;
+using NebulaModel.Logger;
+using NebulaModel.Networking;
+using NebulaModel.Packets.Planet;
+using NebulaModel.Packets.Processors;
+using NebulaWorld;
+
+namespace NebulaClient.PacketProcessors.Planet
+{
+    [RegisterPacketProcessor]
+    public class FactoryDataProcessor : IPacketProcessor<FactoryData>
+    {
+        public void ProcessPacket(FactoryData packet, NebulaConnection conn)
+        {
+            LocalPlayer.PendingFactories.Add(packet.PlanetId, packet.BinaryData);
+
+            lock(PlanetModelingManager.fctPlanetReqList)
+            {
+                PlanetModelingManager.fctPlanetReqList.Enqueue(GameMain.galaxy.PlanetById(packet.PlanetId));
+            }
+        }
+    }
+}

--- a/NebulaHost/NebulaHost.csproj
+++ b/NebulaHost/NebulaHost.csproj
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MultiplayerHostSession.cs" />
+    <Compile Include="PacketProcessors\Planet\FactoryLoadRequestProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerAnimationUpdateProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerColorChangedProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerMovementProcessor.cs" />

--- a/NebulaHost/PacketProcessors/Planet/FactoryLoadRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Planet/FactoryLoadRequestProcessor.cs
@@ -1,0 +1,28 @@
+﻿using NebulaModel.Attributes;
+using NebulaModel.Networking;
+using NebulaModel.Packets.Planet;
+using NebulaModel.Packets.Processors;
+using System.IO;
+
+namespace NebulaHost.PacketProcessors.Planet
+{
+    [RegisterPacketProcessor]
+    public class FactoryLoadRequestProcessor : IPacketProcessor<FactoryLoadRequest>
+    {
+        public void ProcessPacket(FactoryLoadRequest packet, NebulaConnection conn)
+        {
+            PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetID);
+            PlanetFactory factory = GameMain.data.GetOrCreateFactory(planet);
+
+            using(MemoryStream ms = new MemoryStream())
+            {
+                using(BinaryWriter bw = new BinaryWriter(ms))
+                {
+                    factory.Export(bw);
+                }
+
+                conn.SendPacket(new FactoryData(packet.PlanetID, ms.ToArray()));
+            }
+        }
+    }
+}

--- a/NebulaModel/NebulaModel.csproj
+++ b/NebulaModel/NebulaModel.csproj
@@ -66,6 +66,8 @@
     <Compile Include="Logger\Log.cs" />
     <Compile Include="Networking\NebulaConnection.cs" />
     <Compile Include="Packets\GameStates\GameStateUpdate.cs" />
+    <Compile Include="Packets\Planet\FactoryData.cs" />
+    <Compile Include="Packets\Planet\FactoryLoadRequest.cs" />
     <Compile Include="Packets\Players\PlayerAnimationUpdate.cs" />
     <Compile Include="Packets\Players\PlayerMovement.cs" />
     <Compile Include="Packets\Players\PlayerColorChanged.cs" />

--- a/NebulaModel/Packets/Planet/FactoryData.cs
+++ b/NebulaModel/Packets/Planet/FactoryData.cs
@@ -1,0 +1,15 @@
+﻿namespace NebulaModel.Packets.Planet
+{
+    public class FactoryData
+    {
+        public int PlanetId { get; set; }
+        public byte[] BinaryData { get; set; }
+
+        public FactoryData() { }
+        public FactoryData(int id, byte[] data)
+        {
+            this.PlanetId = id;
+            this.BinaryData = data;
+        }
+    }
+}

--- a/NebulaModel/Packets/Planet/FactoryLoadRequest.cs
+++ b/NebulaModel/Packets/Planet/FactoryLoadRequest.cs
@@ -1,0 +1,13 @@
+﻿namespace NebulaModel.Packets.Planet
+{
+    public class FactoryLoadRequest
+    {
+        public int PlanetID { get; set; }
+
+        public FactoryLoadRequest() { }
+        public FactoryLoadRequest(int planetID)
+        {
+            this.PlanetID = planetID;
+        }
+    }
+}

--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -82,8 +82,10 @@
     <Compile Include="Logger\BepInExLogger.cs" />
     <Compile Include="MonoBehaviours\NebulaBootstrapper.cs" />
     <Compile Include="NebulaPlugin.cs" />
+    <Compile Include="Patches\Dynamic\GameData_Patch.cs" />
     <Compile Include="Patches\Dynamic\GameLoader_Patch.cs" />
     <Compile Include="Patches\Dynamic\DSPGame_Patch.cs" />
+    <Compile Include="Patches\Dynamic\PlanetModelingManager_Patch.cs" />
     <Compile Include="Patches\Transpilers\PlayerAction_Mine_Patch.cs" />
     <Compile Include="Patches\Dynamic\UIEscMenu_Patch.cs" />
     <Compile Include="Patches\Dynamic\UIMainMenu_Patch.cs" />

--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -1,0 +1,54 @@
+﻿using HarmonyLib;
+using NebulaModel.Logger;
+using NebulaWorld;
+using System;
+using System.IO;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(GameData), "GetOrCreateFactory")]
+    class GameData_Patch
+    {
+        static bool Prefix(GameData __instance, PlanetFactory __result, PlanetData planet)
+        {
+            // We want the original method to run on the host client
+            if(LocalPlayer.IsMasterClient)
+            {
+                return true;
+            }
+
+            // Get the recieved bytes from the remote server that we will import
+            byte[] factoryBytes;
+            if(!LocalPlayer.PendingFactories.TryGetValue(planet.id, out factoryBytes))
+            {
+                // We messed up, just defer to the default behaviour on the client (will cause desync but not outright crash)
+                Log.Error($"PendingFactories did not have value we wanted, factory will not be synced!");
+                return true;
+            }
+
+            // Take it off the list, as we will process it now
+            LocalPlayer.PendingFactories.Remove(planet.id);
+
+            // TODO: Possibly rework this a little bit when we implement production stats to match the indexes host and client side
+            // Needs more investigation, as we use PlanetFactory.Import()
+
+            // Import the factory from the given bytes, which will have been gotten or created on the host by the original function
+            __instance.factories[__instance.factoryCount] = new PlanetFactory();
+            using (MemoryStream ms = new MemoryStream(factoryBytes))
+            using(BinaryReader br =  new BinaryReader(ms))
+            {
+                __instance.factories[__instance.factoryCount].Import(__instance.factoryCount, __instance, br);
+            }
+
+            // Bump the factory count up and clear the flag
+            __instance.factoryCount++;
+            planet.factoryLoading = false;
+
+            // Assign the factory to the result
+            __result = __instance.factories[__instance.factoryCount];
+
+            // Do not run the original method
+            return false;
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
@@ -1,0 +1,34 @@
+﻿using HarmonyLib;
+using NebulaModel.Logger;
+using NebulaModel.Packets.Planet;
+using NebulaWorld;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(PlanetModelingManager), "RequestLoadPlanetFactory")]
+    public class PlanetModelingManager_Patch
+    {
+        public static bool Prefix(PlanetData planet)
+        {
+            // Run the original method if this is the master client
+            if(LocalPlayer.IsMasterClient)
+            {
+                return true;
+            }
+
+            // Check to make sure it's not already loaded
+            if (planet.factoryLoaded || planet.factoryLoading)
+                return false;
+
+            // They appear to have conveniently left this flag in for us, but they don't use it anywhere
+            planet.factoryLoading = true;
+
+            // Request factory
+            Log.Info($"Requested factory for planet {planet.name} (ID: {planet.id}) from host");
+            LocalPlayer.SendPacket(new FactoryLoadRequest(planet.id));
+
+            // Skip running the actual method
+            return false;
+        }
+    }
+}

--- a/NebulaWorld/LocalPlayer.cs
+++ b/NebulaWorld/LocalPlayer.cs
@@ -3,6 +3,7 @@ using NebulaModel.DataStructures;
 using NebulaModel.Packets.Session;
 using NebulaWorld.MonoBehaviours;
 using NebulaWorld.MonoBehaviours.Local;
+using System.Collections.Generic;
 
 namespace NebulaWorld
 {
@@ -11,6 +12,8 @@ namespace NebulaWorld
         public static bool IsMasterClient { get; set; }
         public static ushort PlayerId => Data.PlayerId;
         public static PlayerData Data { get; private set; }
+
+        public static Dictionary<int, byte[]> PendingFactories { get; set; } = new Dictionary<int, byte[]>();
 
         private static INetworkProvider networkProvider;
 


### PR DESCRIPTION
This pull request means that clients request the factory from the host upon attempting to load it, whether that be an initial connection, or entering the solar system from another one. This does *not* encompass unloading of factories from memory when a solar system is left.

This is done by overriding the `GameData.GetOrCreateFactory()` and `PlanetModelingManager.RequestLoadPlanetFactory()` methods to prevent it from being generated locally, and only adding it to the queue to be loaded in when the host sends the data.

Note - as this uses `PlanetFactory.Import()`, as opposed to creating from scratch, production statistics will need a closer look when we look at updating them from the host, as the indexes may not match. It appears that the indexes are assigned on a first-come-first-served basis, so if people visit planets in a different order that could cause a mismatch.