### PR TITLE
Added a way to host any single player game from within the in-game Esc Menu

### DIFF
--- a/NebulaHost/PacketProcessors/Session/HandshakeRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Session/HandshakeRequestProcessor.cs
@@ -50,7 +50,9 @@ namespace NebulaHost.PacketProcessors.Session
 
             // TODO: This should be our actual GameDesc and not an hardcoded value.
             var inGamePlayersIds = playerManager.GetAllPlayerIdsIncludingHost();
-            player.SendPacket(new HandshakeResponse(UniverseGen.algoVersion, 1, 64, 1f, player.Data, inGamePlayersIds.ToArray()));
+
+            var gameDesc = GameMain.data.gameDesc;
+            player.SendPacket(new HandshakeResponse(gameDesc.galaxyAlgo, gameDesc.galaxySeed, gameDesc.starCount, gameDesc.resourceMultiplier, player.Data, inGamePlayersIds.ToArray()));
 
             SimulatedWorld.SpawnRemotePlayerModel(player.Data);
         }

--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -1,7 +1,6 @@
 ﻿using HarmonyLib;
 using NebulaModel.Logger;
 using NebulaWorld;
-using System;
 using System.IO;
 
 namespace NebulaPatcher.Patches.Dynamic
@@ -9,10 +8,10 @@ namespace NebulaPatcher.Patches.Dynamic
     [HarmonyPatch(typeof(GameData), "GetOrCreateFactory")]
     class GameData_Patch
     {
-        static bool Prefix(GameData __instance, PlanetFactory __result, PlanetData planet)
+        public static bool Prefix(GameData __instance, PlanetFactory __result, PlanetData planet)
         {
-            // We want the original method to run on the host client
-            if(LocalPlayer.IsMasterClient)
+            // We want the original method to run on the host client or in single player games
+            if(!SimulatedWorld.Initialized || LocalPlayer.IsMasterClient)
             {
                 return true;
             }

--- a/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
@@ -10,8 +10,8 @@ namespace NebulaPatcher.Patches.Dynamic
     {
         public static bool Prefix(PlanetData planet)
         {
-            // Run the original method if this is the master client
-            if(LocalPlayer.IsMasterClient)
+            // Run the original method if this is the master client or in single player games
+            if (!SimulatedWorld.Initialized || LocalPlayer.IsMasterClient)
             {
                 return true;
             }

--- a/NebulaPatcher/Patches/Dynamic/UIEscMenu_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIEscMenu_Patch.cs
@@ -54,6 +54,9 @@ namespace NebulaPatcher.Patches.Dynamic
 
         private static void OnHostCurrentGameClick()
         {
+            // Make sure to save the game before enabling the multiplayer mod
+            GameSave.AutoSave();
+
             // TODO: This port should come from the server.config file.
             int port = 8469;
 
@@ -65,7 +68,6 @@ namespace NebulaPatcher.Patches.Dynamic
             SimulatedWorld.OnGameLoadCompleted();
 
             GameMain.Resume();
-            InGamePopup.ShowInfo("Multiplayer", "Server started successfully!", "OK");
         }
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/UIEscMenu_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIEscMenu_Patch.cs
@@ -1,15 +1,71 @@
 ﻿using HarmonyLib;
+using NebulaModel.Logger;
+using NebulaPatcher.MonoBehaviours;
 using NebulaWorld;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.UI;
 
 namespace NebulaPatcher.Patches.Dynamic
 {
-    [HarmonyPatch(typeof(UIEscMenu), "OnButton5Click")]
-    [HarmonyPatch(typeof(UIEscMenu), "OnButton6Click")]
+    [HarmonyPatch(typeof(UIEscMenu))]
     class UIEscMenu_Patch
     {
-        public static void Postfix()
+        private static RectTransform hostGameButton;
+
+        [HarmonyPrefix]
+        [HarmonyPatch("_OnOpen")]
+        public static void _OnOpen()
         {
-            LocalPlayer.LeaveGame();
+            // If we are in a multiplayer game already make sure to hide the host game button
+            if (SimulatedWorld.Initialized)
+            {
+                hostGameButton?.gameObject.SetActive(false);
+                return;
+            }
+
+            if (hostGameButton != null)
+            {
+                hostGameButton.gameObject.SetActive(true);
+                hostGameButton.GetComponentInChildren<Text>().text = "Host Game";
+                return;
+            }
+
+            RectTransform buttonTemplate = GameObject.Find("Esc Menu/button (6)").GetComponent<RectTransform>();
+            hostGameButton = Object.Instantiate(buttonTemplate, buttonTemplate.parent, false);
+            hostGameButton.name = "button-host-game";
+            hostGameButton.anchoredPosition = new Vector2(buttonTemplate.anchoredPosition.x, buttonTemplate.anchoredPosition.y - buttonTemplate.sizeDelta.y * 2);
+            hostGameButton.GetComponentInChildren<Text>().text = "Host Game";
+
+            hostGameButton.GetComponent<Button>().onClick.RemoveAllListeners();
+            hostGameButton.GetComponent<Button>().onClick.AddListener(new UnityAction(OnHostCurrentGameClick));
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("OnButton5Click")]
+        [HarmonyPatch("OnButton6Click")]
+        public static void OnGameQuit()
+        {
+            if (SimulatedWorld.Initialized)
+            {
+                LocalPlayer.LeaveGame();
+            }
+        }
+
+        private static void OnHostCurrentGameClick()
+        {
+            // TODO: This port should come from the server.config file.
+            int port = 8469;
+
+            Log.Info($"Listening server on port {port}");
+            var session = NebulaBootstrapper.Instance.CreateMultiplayerHostSession();
+            session.StartServer(port);
+
+            // Manually call the OnGameLoadCompleted here since we are already in a game.
+            SimulatedWorld.OnGameLoadCompleted();
+
+            GameMain.Resume();
+            InGamePopup.ShowInfo("Multiplayer", "Server started successfully!", "OK");
         }
     }
 }

--- a/NebulaWorld/LocalPlayer.cs
+++ b/NebulaWorld/LocalPlayer.cs
@@ -49,6 +49,8 @@ namespace NebulaWorld
         public static void LeaveGame()
         {
             networkProvider.DestroySession();
+            PendingFactories.Clear();
+            IsMasterClient = false;
             SimulatedWorld.Clear();
 
             if (!UIRoot.instance.backToMainMenu)


### PR DESCRIPTION
- Added a Host Game button inside the Esc Menu (in-game pause menu). That way we can now start a server from within any single player save files.
- Change the code to make sure that the host will send it's current `GameDesc` info to make sure that the clients loads with the right seed.
- Added some fixes to our patches methods to make sure we don't run them if we are not in a multiplayer session (`SimulatedWorld.Initialized == false`)