### PR TITLE
Fix remote players position in space

### DIFF
--- a/NebulaHost/MultiplayerHostSession.cs
+++ b/NebulaHost/MultiplayerHostSession.cs
@@ -58,7 +58,7 @@ namespace NebulaHost
             LocalPlayer.IsMasterClient = true;
 
             // TODO: Load saved player info here
-            LocalPlayer.SetPlayerData(new PlayerData(PlayerManager.GetNextAvailablePlayerId(), new Float3(1.0f, 0.6846404f, 0.243137181f)));
+            LocalPlayer.SetPlayerData(new PlayerData(PlayerManager.GetNextAvailablePlayerId(), GameMain.localPlanet?.id ?? -1, new Float3(1.0f, 0.6846404f, 0.243137181f)));
         }
 
         private void OnConnectionRequest(ConnectionRequest request)

--- a/NebulaHost/PacketProcessors/Players/PlayerMovementProcessor.cs
+++ b/NebulaHost/PacketProcessors/Players/PlayerMovementProcessor.cs
@@ -22,7 +22,8 @@ namespace NebulaHost.PacketProcessors.Players
             Player player = playerManager.GetPlayer(conn);
             if (player != null)
             {
-                player.Data.Position = packet.Position;
+                player.Data.LocalPlanetId = packet.LocalPlanetId;
+                player.Data.UPosition = packet.UPosition;
                 player.Data.Rotation = packet.Rotation;
                 player.Data.BodyRotation = packet.BodyRotation;
 

--- a/NebulaHost/PacketProcessors/Players/PlayerMovementProcessor.cs
+++ b/NebulaHost/PacketProcessors/Players/PlayerMovementProcessor.cs
@@ -22,7 +22,7 @@ namespace NebulaHost.PacketProcessors.Players
             if (player != null)
             {
                 player.Data.LocalPlanetId = packet.LocalPlanetId;
-                player.Data.UPosition = packet.Position;
+                player.Data.UPosition = packet.UPosition;
                 player.Data.Rotation = packet.Rotation;
                 player.Data.BodyRotation = packet.BodyRotation;
 

--- a/NebulaHost/PacketProcessors/Players/PlayerMovementProcessor.cs
+++ b/NebulaHost/PacketProcessors/Players/PlayerMovementProcessor.cs
@@ -23,7 +23,7 @@ namespace NebulaHost.PacketProcessors.Players
             if (player != null)
             {
                 player.Data.LocalPlanetId = packet.LocalPlanetId;
-                player.Data.UPosition = packet.UPosition;
+                player.Data.UPosition = packet.Position;
                 player.Data.Rotation = packet.Rotation;
                 player.Data.BodyRotation = packet.BodyRotation;
 

--- a/NebulaHost/PlayerManager.cs
+++ b/NebulaHost/PlayerManager.cs
@@ -83,7 +83,9 @@ namespace NebulaHost
             // TODO: Load old player state if we have one. We generate a random one for now.
             ushort playerId = GetNextAvailablePlayerId();
             Float3 randomColor = new Float3(Random.value, Random.value, Random.value);
-            PlayerData playerData = new PlayerData(playerId, randomColor);
+
+            // TODO: We will need to check if we know on which planet this player was
+            PlayerData playerData = new PlayerData(playerId, -1, randomColor);
 
             Player newPlayer = new Player(conn, playerData);
             pendingPlayers.Add(conn, newPlayer);

--- a/NebulaModel/DataStructures/Double3.cs
+++ b/NebulaModel/DataStructures/Double3.cs
@@ -1,0 +1,40 @@
+﻿using LiteNetLib.Utils;
+using NebulaModel.Attributes;
+
+namespace NebulaModel.DataStructures
+{
+    [RegisterNestedType]
+    public struct Double3 : INetSerializable
+    {
+        public double x;
+        public double y;
+        public double z;
+
+        public Double3(double x, double y, double z)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+
+        public void Serialize(NetDataWriter writer)
+        {
+            writer.Put(x);
+            writer.Put(y);
+            writer.Put(z);
+        }
+
+        public void Deserialize(NetDataReader reader)
+        {
+            x = reader.GetDouble();
+            y = reader.GetDouble();
+            z = reader.GetDouble();
+        }
+
+
+        public override string ToString()
+        {
+            return $"x: {x}, y: {y}, z: {z}";
+        }
+    }
+}

--- a/NebulaModel/DataStructures/Double3.cs
+++ b/NebulaModel/DataStructures/Double3.cs
@@ -1,5 +1,5 @@
-﻿using LiteNetLib.Utils;
-using NebulaModel.Attributes;
+﻿using NebulaModel.Attributes;
+using NebulaModel.Networking.Serialization;
 
 namespace NebulaModel.DataStructures
 {

--- a/NebulaModel/DataStructures/NetDataReaderExtensions.cs
+++ b/NebulaModel/DataStructures/NetDataReaderExtensions.cs
@@ -17,5 +17,12 @@ namespace NebulaModel.DataStructures
             value.Deserialize(reader);
             return value;
         }
+
+        public static Double3 GetDouble3(this NetDataReader reader)
+        {
+            Double3 value = new Double3();
+            value.Deserialize(reader);
+            return value;
+        }
     }
 }

--- a/NebulaModel/DataStructures/PlayerData.cs
+++ b/NebulaModel/DataStructures/PlayerData.cs
@@ -7,17 +7,19 @@ namespace NebulaModel.DataStructures
     public class PlayerData : INetSerializable
     {
         public ushort PlayerId { get; set; }
+        public int LocalPlanetId { get; set; }
         public Float3 Color { get; set; }
-        public Float3 Position { get; set; }
+        public Double3 UPosition { get; set; }
         public Float3 Rotation { get; set; }
         public Float3 BodyRotation { get; set; }
 
         public PlayerData() { }
-        public PlayerData(ushort playerId, Float3 color, Float3 position = new Float3(), Float3 rotation = new Float3(), Float3 bodyRotation = new Float3())
+        public PlayerData(ushort playerId, int localPlanetId, Float3 color, Double3 position = new Double3(), Float3 rotation = new Float3(), Float3 bodyRotation = new Float3())
         {
             PlayerId = playerId;
+            LocalPlanetId = localPlanetId;
             Color = color;
-            Position = position;
+            UPosition = position;
             Rotation = rotation;
             BodyRotation = bodyRotation;
         }
@@ -25,8 +27,9 @@ namespace NebulaModel.DataStructures
         public void Serialize(NetDataWriter writer)
         {
             writer.Put(PlayerId);
+            writer.Put(LocalPlanetId);
             Color.Serialize(writer);
-            Position.Serialize(writer);
+            UPosition.Serialize(writer);
             Rotation.Serialize(writer);
             BodyRotation.Serialize(writer);
         }
@@ -34,8 +37,9 @@ namespace NebulaModel.DataStructures
         public void Deserialize(NetDataReader reader)
         {
             PlayerId = reader.GetUShort();
+            LocalPlanetId = reader.GetInt();
             Color = reader.GetFloat3();
-            Position = reader.GetFloat3();
+            UPosition = reader.GetDouble3();
             Rotation = reader.GetFloat3();
             BodyRotation = reader.GetFloat3();
         }

--- a/NebulaModel/NebulaModel.csproj
+++ b/NebulaModel/NebulaModel.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Attributes\RegisterNestedTypeAttribute.cs" />
     <Compile Include="Attributes\RegisterPacketProcessorAttribute.cs" />
     <Compile Include="DataStructures\DataStructureExtensions.cs" />
+    <Compile Include="DataStructures\Double3.cs" />
     <Compile Include="DataStructures\Float3.cs" />
     <Compile Include="DataStructures\GameState.cs" />
     <Compile Include="DataStructures\NebulaAnimationState.cs" />

--- a/NebulaModel/Packets/Players/PlayerMovement.cs
+++ b/NebulaModel/Packets/Players/PlayerMovement.cs
@@ -13,11 +13,11 @@ namespace NebulaModel.Packets.Players
 
         public PlayerMovement() { }
 
-        public PlayerMovement(ushort playerId, int localPlanetId, Double3 uPosition, Float3 rotation, Float3 bodyRotation)
+        public PlayerMovement(ushort playerId, int localPlanetId, Double3 position, Float3 rotation, Float3 bodyRotation)
         {
             PlayerId = playerId;
             LocalPlanetId = localPlanetId;
-            Position = uPosition;
+            Position = position;
             Rotation = rotation;
             BodyRotation = bodyRotation;
         }

--- a/NebulaModel/Packets/Players/PlayerMovement.cs
+++ b/NebulaModel/Packets/Players/PlayerMovement.cs
@@ -7,7 +7,7 @@ namespace NebulaModel.Packets.Players
     {
         public ushort PlayerId { get; set; }
         public int LocalPlanetId { get; set; }
-        public Double3 UPosition { get; set; }
+        public Double3 Position { get; set; }
         public Float3 Rotation { get; set; }
         public Float3 BodyRotation { get; set; }
 
@@ -17,7 +17,7 @@ namespace NebulaModel.Packets.Players
         {
             PlayerId = playerId;
             LocalPlanetId = localPlanetId;
-            UPosition = uPosition;
+            Position = uPosition;
             Rotation = rotation;
             BodyRotation = bodyRotation;
         }

--- a/NebulaModel/Packets/Players/PlayerMovement.cs
+++ b/NebulaModel/Packets/Players/PlayerMovement.cs
@@ -7,17 +7,19 @@ namespace NebulaModel.Packets.Players
     {
         public ushort PlayerId { get; set; }
         public int LocalPlanetId { get; set; }
-        public Double3 Position { get; set; }
+        public Float3 LocalPlanetPosition { get; set; }
+        public Double3 UPosition { get; set; }
         public Float3 Rotation { get; set; }
         public Float3 BodyRotation { get; set; }
 
         public PlayerMovement() { }
 
-        public PlayerMovement(ushort playerId, int localPlanetId, Double3 position, Float3 rotation, Float3 bodyRotation)
+        public PlayerMovement(ushort playerId, int localPlanetId, Float3 localPlanetPosition, Double3 uPosition, Float3 rotation, Float3 bodyRotation)
         {
             PlayerId = playerId;
             LocalPlanetId = localPlanetId;
-            Position = position;
+            LocalPlanetPosition = localPlanetPosition;
+            UPosition = uPosition;
             Rotation = rotation;
             BodyRotation = bodyRotation;
         }

--- a/NebulaModel/Packets/Players/PlayerMovement.cs
+++ b/NebulaModel/Packets/Players/PlayerMovement.cs
@@ -6,18 +6,20 @@ namespace NebulaModel.Packets.Players
     public class PlayerMovement
     {
         public ushort PlayerId { get; set; }
-        public Float3 Position { get; set; }
+        public int LocalPlanetId { get; set; }
+        public Double3 UPosition { get; set; }
         public Float3 Rotation { get; set; }
         public Float3 BodyRotation { get; set; }
 
         public PlayerMovement() { }
 
-        public PlayerMovement(ushort playerId, Vector3 position, Vector3 rotation, Vector3 bodyRotation)
+        public PlayerMovement(ushort playerId, int localPlanetId, Double3 uPosition, Float3 rotation, Float3 bodyRotation)
         {
             PlayerId = playerId;
-            Position = new Float3(position);
-            Rotation = new Float3(rotation);
-            BodyRotation = new Float3(bodyRotation);
+            LocalPlanetId = localPlanetId;
+            UPosition = uPosition;
+            Rotation = rotation;
+            BodyRotation = bodyRotation;
         }
     }
 }

--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Logger\BepInExLogger.cs" />
     <Compile Include="MonoBehaviours\NebulaBootstrapper.cs" />
     <Compile Include="NebulaPlugin.cs" />
+    <Compile Include="Patches\Debugging.cs" />
     <Compile Include="Patches\Dynamic\GameData_Patch.cs" />
     <Compile Include="Patches\Dynamic\GameLoader_Patch.cs" />
     <Compile Include="Patches\Dynamic\DSPGame_Patch.cs" />

--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -82,7 +82,7 @@
     <Compile Include="Logger\BepInExLogger.cs" />
     <Compile Include="MonoBehaviours\NebulaBootstrapper.cs" />
     <Compile Include="NebulaPlugin.cs" />
-    <Compile Include="Patches\Debugging.cs" />
+    <Compile Include="Patches\Dynamic\Debugging.cs" />
     <Compile Include="Patches\Dynamic\GameData_Patch.cs" />
     <Compile Include="Patches\Dynamic\GameLoader_Patch.cs" />
     <Compile Include="Patches\Dynamic\DSPGame_Patch.cs" />

--- a/NebulaPatcher/Patches/Debugging.cs
+++ b/NebulaPatcher/Patches/Debugging.cs
@@ -1,0 +1,23 @@
+﻿using HarmonyLib;
+
+namespace NebulaPatcher.Patches
+{
+    [HarmonyPatch(typeof(GameHistoryData), "EnqueueTech")]
+    class patch
+    {
+        public static void Postfix(GameHistoryData __instance, int techId)
+        {
+            __instance.UnlockTech(techId);
+            GameMain.mainPlayer.mecha.corePowerGen = 10000000;
+        }
+    }
+
+    [HarmonyPatch(typeof(Mecha), "UseWarper")]
+    class patch2
+    {
+        public static void Postfix(ref bool __result)
+        {
+            __result = true;
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/Debugging.cs
+++ b/NebulaPatcher/Patches/Dynamic/Debugging.cs
@@ -1,7 +1,9 @@
 ﻿using HarmonyLib;
 
-namespace NebulaPatcher.Patches
+namespace NebulaPatcher.Patches.Dynamic
 {
+#if DEBUG
+
     [HarmonyPatch(typeof(GameHistoryData), "EnqueueTech")]
     class patch
     {
@@ -20,4 +22,5 @@ namespace NebulaPatcher.Patches
             __result = true;
         }
     }
+#endif
 }

--- a/NebulaWorld/MonoBehaviours/Local/LocalPlayerMovement.cs
+++ b/NebulaWorld/MonoBehaviours/Local/LocalPlayerMovement.cs
@@ -30,21 +30,8 @@ namespace NebulaWorld.MonoBehaviours.Local
                 var rotation = new Float3(rootTransform.eulerAngles);
                 var bodyRotation = new Float3(bodyTransform.eulerAngles);
 
-                var position = new Double3();
-                if (GameMain.localPlanet != null)
-                {
-                    position.x = rootTransform.position.x;
-                    position.y = rootTransform.position.y;
-                    position.z = rootTransform.position.z;
-                }
-                else
-                {
-                    position.x = GameMain.mainPlayer.uPosition.x;
-                    position.y = GameMain.mainPlayer.uPosition.y;
-                    position.z = GameMain.mainPlayer.uPosition.z;
-                }
-
-                LocalPlayer.SendPacket(new PlayerMovement(LocalPlayer.PlayerId, GameMain.localPlanet?.id ?? -1, position, rotation, bodyRotation));
+                Double3 uPosition = new Double3(GameMain.mainPlayer.uPosition.x, GameMain.mainPlayer.uPosition.y, GameMain.mainPlayer.uPosition.z);
+                LocalPlayer.SendPacket(new PlayerMovement(LocalPlayer.PlayerId, GameMain.localPlanet?.id ?? -1, rootTransform.position.ToNebula(), uPosition, rotation, bodyRotation));
             }
         }
     }

--- a/NebulaWorld/MonoBehaviours/Local/LocalPlayerMovement.cs
+++ b/NebulaWorld/MonoBehaviours/Local/LocalPlayerMovement.cs
@@ -1,5 +1,4 @@
 ﻿using NebulaModel.DataStructures;
-using NebulaModel.Logger;
 using NebulaModel.Packets.Players;
 using UnityEngine;
 
@@ -30,14 +29,14 @@ namespace NebulaWorld.MonoBehaviours.Local
 
                 var rotation = new Float3(rootTransform.eulerAngles);
                 var bodyRotation = new Float3(bodyTransform.eulerAngles);
-                
+
                 var position = new Double3();
                 if (GameMain.localPlanet != null)
                 {
                     position.x = rootTransform.position.x;
                     position.y = rootTransform.position.y;
                     position.z = rootTransform.position.z;
-                } 
+                }
                 else
                 {
                     position.x = GameMain.mainPlayer.uPosition.x;

--- a/NebulaWorld/MonoBehaviours/Local/LocalPlayerMovement.cs
+++ b/NebulaWorld/MonoBehaviours/Local/LocalPlayerMovement.cs
@@ -1,4 +1,6 @@
-﻿using NebulaModel.Packets.Players;
+﻿using NebulaModel.DataStructures;
+using NebulaModel.Logger;
+using NebulaModel.Packets.Players;
 using UnityEngine;
 
 namespace NebulaWorld.MonoBehaviours.Local
@@ -26,11 +28,24 @@ namespace NebulaWorld.MonoBehaviours.Local
             {
                 time = 0;
 
-                Vector3 position = rootTransform.position;
-                Vector3 rotation = rootTransform.eulerAngles;
-                Vector3 bodyRotation = bodyTransform.eulerAngles;
+                var rotation = new Float3(rootTransform.eulerAngles);
+                var bodyRotation = new Float3(bodyTransform.eulerAngles);
+                
+                var position = new Double3();
+                if (GameMain.localPlanet != null)
+                {
+                    position.x = rootTransform.position.x;
+                    position.y = rootTransform.position.y;
+                    position.z = rootTransform.position.z;
+                } 
+                else
+                {
+                    position.x = GameMain.mainPlayer.uPosition.x;
+                    position.y = GameMain.mainPlayer.uPosition.y;
+                    position.z = GameMain.mainPlayer.uPosition.z;
+                }
 
-                LocalPlayer.SendPacket(new PlayerMovement(LocalPlayer.PlayerId, position, rotation, bodyRotation), LiteNetLib.DeliveryMethod.Sequenced);
+                LocalPlayer.SendPacket(new PlayerMovement(LocalPlayer.PlayerId, GameMain.localPlanet?.id ?? -1, position, rotation, bodyRotation), LiteNetLib.DeliveryMethod.Sequenced);
             }
         }
     }

--- a/NebulaWorld/MonoBehaviours/Remote/RemotePlayerMovement.cs
+++ b/NebulaWorld/MonoBehaviours/Remote/RemotePlayerMovement.cs
@@ -79,6 +79,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
             snapshotBuffer[snapshotBuffer.Length - 1] = new Snapshot()
             {
                 Timestamp = TimeUtils.CurrentUnixTimestampMilliseconds(),
+                LocalPlanetId = movement.LocalPlanetId,
                 Position = movement.Position,
                 Rotation = Quaternion.Euler(movement.Rotation.ToUnity()),
                 BodyRotation = Quaternion.Euler(movement.BodyRotation.ToUnity()),
@@ -102,10 +103,10 @@ namespace NebulaWorld.MonoBehaviours.Remote
             {
                 return new Vector3((float)snapshot.Position.x, (float)snapshot.Position.y, (float)snapshot.Position.z);
             }
-
-            // If the remote player is in space, we need to calculate his current "universe position" relative to the local player position in his world.
+            
+            // If the remote player is in space, we need to calculate the remote player relative position from our local player position.
             VectorLF3 uPosition = new VectorLF3(snapshot.Position.x, snapshot.Position.y, snapshot.Position.z);
-            return (Vector3)Maths.QInvRotateLF(GameMain.data.relativeRot, uPosition - GameMain.data.relativePos);
+            return Maths.QInvRotateLF(GameMain.data.relativeRot, uPosition - GameMain.data.relativePos);
         }
     }
 }

--- a/NebulaWorld/MonoBehaviours/Remote/RemotePlayerMovement.cs
+++ b/NebulaWorld/MonoBehaviours/Remote/RemotePlayerMovement.cs
@@ -14,7 +14,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
         {
             public long Timestamp { get; set; }
             public int LocalPlanetId { get; set; }
-            public Double3 UPosition { get; set; }
+            public Double3 Position { get; set; }
             public Quaternion Rotation { get; set; }
             public Quaternion BodyRotation { get; set; }
         }
@@ -79,7 +79,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
             snapshotBuffer[snapshotBuffer.Length - 1] = new Snapshot()
             {
                 Timestamp = TimeUtils.CurrentUnixTimestampMilliseconds(),
-                UPosition = movement.UPosition,
+                Position = movement.Position,
                 Rotation = Quaternion.Euler(movement.Rotation.ToUnity()),
                 BodyRotation = Quaternion.Euler(movement.BodyRotation.ToUnity()),
             };
@@ -100,11 +100,12 @@ namespace NebulaWorld.MonoBehaviours.Remote
             // If we are on a local planet, the snapshot position is already in local planet space.
             if (snapshot.LocalPlanetId >= 0)
             {
-                return new Vector3((float)snapshot.UPosition.x, (float)snapshot.UPosition.y, (float)snapshot.UPosition.z);
+                return new Vector3((float)snapshot.Position.x, (float)snapshot.Position.y, (float)snapshot.Position.z);
             }
 
             // If the remote player is in space, we need to calculate his current "universe position" relative to the local player position in his world.
-            return (Vector3)Maths.QInvRotateLF(GameMain.data.relativeRot, new VectorLF3(snapshot.UPosition.x, snapshot.UPosition.y, snapshot.UPosition.z) - GameMain.data.relativePos);
+            VectorLF3 uPosition = new VectorLF3(snapshot.Position.x, snapshot.Position.y, snapshot.Position.z);
+            return (Vector3)Maths.QInvRotateLF(GameMain.data.relativeRot, uPosition - GameMain.data.relativePos);
         }
     }
 }

--- a/NebulaWorld/MonoBehaviours/Remote/RemotePlayerMovement.cs
+++ b/NebulaWorld/MonoBehaviours/Remote/RemotePlayerMovement.cs
@@ -103,7 +103,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
             {
                 return new Vector3((float)snapshot.Position.x, (float)snapshot.Position.y, (float)snapshot.Position.z);
             }
-            
+
             // If the remote player is in space, we need to calculate the remote player relative position from our local player position.
             VectorLF3 uPosition = new VectorLF3(snapshot.Position.x, snapshot.Position.y, snapshot.Position.z);
             return Maths.QInvRotateLF(GameMain.data.relativeRot, uPosition - GameMain.data.relativePos);


### PR DESCRIPTION
This PR fixes #33.

Since the local player becomes the center of the universe while in space and the universe literally revolves around him, we need to make sure to convert the remote player position received to be relative to the local player coordinate system.


Each local player will now send their LocalPlanetId and two positions in the Movement Packet, the `UPosition` and the `LocalPlayerPosition`.
 - When the player is in space or not on the same planet: we use the `UPosition` of the player which is the REAL absolute position of the player in the universe.
 - When the players are both on the same planet: we use the `LocalPlayerPosition` which is the position relative to the player's local planet. We can't rely on the `uPosition` here since the `uPosition` isn't as precise as the `LocalPlayerPosition` for planetary movement and it was causing the remote players model to clip a lot with the planet surface.


This PR also include a `Debugging_Patch` which is only applied in DEBUG build. It lets us unlock technologies instantly to quickly unlock the sailing upgrades.

In a separate PR and after we have all the @sp00ktober fixes and changes merges I will probably look at handling remote player visibility states. Since we should only render remote players when they are on the same planet then us or when we are both in space and close to each other.