### PR TITLE
Added latency simulation settings with our WebSocket implementation.

### DIFF
--- a/NebulaModel/NebulaModel.csproj
+++ b/NebulaModel/NebulaModel.csproj
@@ -73,6 +73,7 @@
     <Compile Include="DataStructures\PlayerData.cs" />
     <Compile Include="Logger\ILogger.cs" />
     <Compile Include="Logger\Log.cs" />
+    <Compile Include="Networking\DelayedPacket.cs" />
     <Compile Include="Networking\NebulaConnection.cs" />
     <Compile Include="Packets\GameStates\GameStateUpdate.cs" />
     <Compile Include="Networking\PendingPacket.cs" />

--- a/NebulaModel/Networking/DelayedPacket.cs
+++ b/NebulaModel/Networking/DelayedPacket.cs
@@ -2,7 +2,7 @@
 
 namespace NebulaModel.Networking
 {
-    public class DelayedPacket
+    public struct DelayedPacket
     {
         public PendingPacket Packet { get; }
         public DateTime DueTime { get; }

--- a/NebulaModel/Networking/DelayedPacket.cs
+++ b/NebulaModel/Networking/DelayedPacket.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace NebulaModel.Networking
+{
+    public class DelayedPacket
+    {
+        public PendingPacket Packet { get; }
+        public DateTime DueTime { get; }
+
+        public DelayedPacket(PendingPacket packet, DateTime dueTime)
+        {
+            this.Packet = packet;
+            this.DueTime = dueTime;
+        }
+    }
+}

--- a/NebulaModel/Networking/PendingPacket.cs
+++ b/NebulaModel/Networking/PendingPacket.cs
@@ -1,6 +1,6 @@
 ﻿namespace NebulaModel.Networking
 {
-    public class PendingPacket
+    public struct PendingPacket
     {
         public byte[] Data { get; }
         public object UserData { get; }

--- a/NebulaModel/Networking/PendingPacket.cs
+++ b/NebulaModel/Networking/PendingPacket.cs
@@ -3,12 +3,12 @@
     public class PendingPacket
     {
         public byte[] Data { get; }
-        public NebulaConnection Connection { get; }
+        public object UserData { get; }
 
-        public PendingPacket(byte[] data, NebulaConnection connection)
+        public PendingPacket(byte[] data, object userData)
         {
             this.Data = data;
-            this.Connection = connection;
+            this.UserData = userData;
         }
     }
 }

--- a/NebulaModel/Networking/Serialization/NetPacketProcessor.cs
+++ b/NebulaModel/Networking/Serialization/NetPacketProcessor.cs
@@ -43,7 +43,7 @@ namespace NebulaModel.Networking.Serialization
                 lock (delayedPackets)
                 {
                     PendingPacket packet = new PendingPacket(rawData, userData);
-                    DateTime dueTime = DateTime.Now.AddMilliseconds(simulationRandom.Next(SimulatedMinLatency, SimulatedMaxLatency));
+                    DateTime dueTime = DateTime.UtcNow.AddMilliseconds(simulationRandom.Next(SimulatedMinLatency, SimulatedMaxLatency));
                     delayedPackets.Add(new DelayedPacket(packet, dueTime));
                 }
             }
@@ -81,7 +81,7 @@ namespace NebulaModel.Networking.Serialization
         {
             lock (delayedPackets)
             {
-                var now = DateTime.Now;
+                var now = DateTime.UtcNow;
                 for (int i = delayedPackets.Count - 1; i >= 0; --i)
                 {
                     if (now >= delayedPackets[i].DueTime)

--- a/NebulaModel/Networking/Serialization/NetPacketProcessor.cs
+++ b/NebulaModel/Networking/Serialization/NetPacketProcessor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace NebulaModel.Networking.Serialization
 {
@@ -16,6 +17,14 @@ namespace NebulaModel.Networking.Serialization
         private readonly Dictionary<ulong, SubscribeDelegate> _callbacks = new Dictionary<ulong, SubscribeDelegate>();
         private readonly NetDataWriter _netDataWriter = new NetDataWriter();
 
+        private readonly Random simulationRandom = new Random();
+        private List<DelayedPacket> delayedPackets = new List<DelayedPacket>();
+        private Queue<PendingPacket> pendingPackets = new Queue<PendingPacket>();
+
+        public bool SimulateLatency = false;
+        public int SimulatedMinLatency = 20;
+        public int SimulatedMaxLatency = 50;
+
         public NetPacketProcessor()
         {
             _netSerializer = new NetSerializer();
@@ -24,6 +33,64 @@ namespace NebulaModel.Networking.Serialization
         public NetPacketProcessor(int maxStringLength)
         {
             _netSerializer = new NetSerializer(maxStringLength);
+        }
+
+        public void EnqueuePacketForProcessing(byte[] rawData, object userData)
+        {
+#if DEBUG
+            if (SimulateLatency)
+            {
+                lock (delayedPackets)
+                {
+                    PendingPacket packet = new PendingPacket(rawData, userData);
+                    DateTime dueTime = DateTime.Now.AddMilliseconds(simulationRandom.Next(SimulatedMinLatency, SimulatedMaxLatency));
+                    delayedPackets.Add(new DelayedPacket(packet, dueTime));
+                }
+            }
+            else
+            {
+                lock (pendingPackets)
+                {
+                    pendingPackets.Enqueue(new PendingPacket(rawData, userData));
+                }
+            }
+#else
+            lock (pendingPackets)
+            {
+                pendingPackets.Enqueue(new PendingPacket(rawData, userData));
+            }
+#endif
+        }
+
+        public void ProcessPacketQueue()
+        {
+            lock (pendingPackets)
+            {
+                ProcessDelayedPackets();
+
+                while (pendingPackets.Count > 0)
+                {
+                    PendingPacket packet = pendingPackets.Dequeue();
+                    ReadPacket(new NetDataReader(packet.Data), packet.UserData);
+                }
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private void ProcessDelayedPackets()
+        {
+            lock (delayedPackets)
+            {
+                var now = DateTime.Now;
+                for (int i = delayedPackets.Count - 1; i >= 0; --i)
+                {
+                    if (now >= delayedPackets[i].DueTime)
+                    {
+                        pendingPackets.Enqueue(delayedPackets[i].Packet);
+                        delayedPackets.RemoveAt(i);
+                    }
+                }
+            }
         }
 
         //FNV-1 64 bit hash


### PR DESCRIPTION
Since `WebSocketSharp` does not have latency simulation built-in, I added my own implementation to be able to have a more realistic latency when testing locally.

- Latency simulation can be enabled or disabled in `MultiplayerHostSession` and `MultiplayerClientSession`
- Latency simulation is only enabled in `DEBUG` builds
- Latency simulation will be enabled by default in `DEBUG` builds for both the Host and Client and they have a combined latency that ranges from 40ms to 100ms at random for each packet sent.

Note: I've also cleaned up the `PendingPacket` processing to be done inside the `PacketProcessor` class to share the same logic between the `Host` and `Client` code.