### PR TITLE
Fix multiple client connection and disconnection issues.

### DIFF
--- a/NebulaClient/MultiplayerClientSession.cs
+++ b/NebulaClient/MultiplayerClientSession.cs
@@ -2,9 +2,8 @@
 using NebulaModel.Networking;
 using NebulaModel.Networking.Serialization;
 using NebulaModel.Packets.Session;
+using NebulaModel.Utils;
 using NebulaWorld;
-using System.Collections.Generic;
-using System.Diagnostics;
 using UnityEngine;
 using WebSocketSharp;
 
@@ -57,7 +56,7 @@ namespace NebulaClient
         void Disconnect()
         {
             IsConnected = false;
-            clientSocket.Close();
+            clientSocket.Close((ushort)NebulaStatusCode.ClientRequestedDisconnect, "Player left the game");
         }
 
         public void DestroySession()
@@ -96,12 +95,38 @@ namespace NebulaClient
             IsConnected = false;
             serverConnection = null;
 
-            InGamePopup.ShowWarning(
-                "Connection Lost",
-                $"You have been disconnect of the server.\nReason{e.Reason}",
-                "Quit", "Reconnect",
-                () => { LocalPlayer.LeaveGame(); },
-                () => { Reconnect(); });
+            // If the client is Quitting by himself, we don't have to inform him of his disconnection.
+            if (e.Code == (ushort)NebulaStatusCode.ClientRequestedDisconnect)
+                return;
+
+            if (SimulatedWorld.IsGameLoaded)
+            {
+                UnityDispatchQueue.RunOnMainThread(() =>
+                {
+                    InGamePopup.ShowWarning(
+                        "Connection Lost",
+                        $"You have been disconnect of the server.\n{e.Reason}",
+                        "Quit", "Reconnect",
+                        () => { LocalPlayer.LeaveGame(); },
+                        () => { Reconnect(); });
+                });
+            }
+            else
+            {
+                UnityDispatchQueue.RunOnMainThread(() =>
+                {
+                    InGamePopup.ShowWarning(
+                        "Server Unavailable",
+                        $"Could not reach the server, please try again later.",
+                        "OK",
+                        () =>
+                        {
+                            GameObject overlayCanvasGo = GameObject.Find("Overlay Canvas");
+                            Transform multiplayerMenu = overlayCanvasGo?.transform?.Find("Nebula - Multiplayer Menu");
+                            multiplayerMenu?.gameObject?.SetActive(true);
+                        });
+                });
+            }
         }
 
         private void Update()

--- a/NebulaModel/NebulaModel.csproj
+++ b/NebulaModel/NebulaModel.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Logger\Log.cs" />
     <Compile Include="Networking\DelayedPacket.cs" />
     <Compile Include="Networking\NebulaConnection.cs" />
+    <Compile Include="Networking\NebulaStatusCode.cs" />
     <Compile Include="Packets\GameStates\GameStateUpdate.cs" />
     <Compile Include="Networking\PendingPacket.cs" />
     <Compile Include="Packets\Planet\FactoryData.cs" />
@@ -102,6 +103,7 @@
     <Compile Include="Networking\Serialization\NetSerializer.cs" />
     <Compile Include="Networking\Serialization\NetUtils.cs" />
     <Compile Include="Utils\TimeUtils.cs" />
+    <Compile Include="Utils\UnityDispatchQueue.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Networking\Serialization\LICENSE.txt" />

--- a/NebulaModel/Networking/NebulaStatusCode.cs
+++ b/NebulaModel/Networking/NebulaStatusCode.cs
@@ -1,0 +1,8 @@
+﻿namespace NebulaModel.Networking
+{
+    public enum NebulaStatusCode
+    {
+        HostStillLoading = 2000,
+        ClientRequestedDisconnect = 2001,
+    }
+}

--- a/NebulaModel/Utils/UnityDispatchQueue.cs
+++ b/NebulaModel/Utils/UnityDispatchQueue.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace NebulaModel.Utils
+{
+    public class UnityDispatchQueue : MonoBehaviour
+    {
+        private static UnityDispatchQueue _instance;
+        private static UnityDispatchQueue GetInstance() {
+            if (!_instance)
+            {
+                _instance = FindObjectOfType<UnityDispatchQueue>();
+            }
+
+            if (!_instance)
+            {
+                GameObject go = new GameObject(nameof(UnityDispatchQueue));
+                _instance = go.AddComponent<UnityDispatchQueue>();
+                DontDestroyOnLoad(_instance);
+            }
+
+            return _instance;
+        }
+
+        private Queue<Action> actionsQueue = new Queue<Action>();
+
+        public static void RunOnMainThread(Action action)
+        {
+            UnityDispatchQueue instance = GetInstance();
+            lock (instance.actionsQueue)
+            {
+                instance.actionsQueue.Enqueue(action);
+            }
+        }
+
+        private void Update()
+        {
+            lock (actionsQueue)
+            {
+                while(actionsQueue.Count > 0)
+                {
+                    actionsQueue.Dequeue().Invoke();
+                }
+            }
+        }
+
+        private void OnDestroy()
+        {
+            _instance = null;
+        }
+    }
+}

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -16,6 +16,7 @@ namespace NebulaWorld
         static Dictionary<ushort, RemotePlayerModel> remotePlayersModels;
 
         public static bool Initialized { get; private set; }
+        public static bool IsGameLoaded { get; private set; }
 
         public static void Initialize()
         {
@@ -35,6 +36,7 @@ namespace NebulaWorld
 
             remotePlayersModels.Clear();
             Initialized = false;
+            IsGameLoaded = false;
         }
 
         public static void UpdateGameState(GameState state)
@@ -186,6 +188,8 @@ namespace NebulaWorld
             // GameMain.mainPlayer.transform.eulerAngles = data.Rotation.ToUnity();
 
             LocalPlayer.SetReady();
+
+            IsGameLoaded = true;
         }
     }
 }


### PR DESCRIPTION
This PR include a bunch of fixes related to client connection and disconnection.
Fixes #26, fixes #46, fixes #56, fixes #57

- We now have a better handling of player connection and disconnection states.
- I also added the class `UnityDispatchQueue` which can be used to run code on the main unity thread.