### PR TITLE
Add loading of planet data prior to computing planet

### DIFF
--- a/NebulaClient/NebulaClient.csproj
+++ b/NebulaClient/NebulaClient.csproj
@@ -75,6 +75,7 @@
     <Compile Include="MultiplayerClientSession.cs" />
     <Compile Include="PacketProcessors\GameStates\GameStateUpdateProcessor.cs" />
     <Compile Include="PacketProcessors\Planet\FactoryDataProcessor.cs" />
+    <Compile Include="PacketProcessors\Planet\PlanetDataResponseProcessor.cs" />
     <Compile Include="PacketProcessors\Planet\VegetationMinedProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerAnimationUpdateProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerColorChangeProcessor.cs" />
@@ -97,6 +98,11 @@
       <Project>{b357bac7-529e-4d81-a0d2-71041b19c8de}</Project>
       <Name>websocket-sharp</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="lz4net">
+      <Version>1.0.15.93</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/NebulaClient/PacketProcessors/Planet/PlanetDataResponseProcessor.cs
+++ b/NebulaClient/PacketProcessors/Planet/PlanetDataResponseProcessor.cs
@@ -1,0 +1,44 @@
+﻿using LZ4;
+using NebulaModel.Attributes;
+using NebulaModel.Logger;
+using NebulaModel.Networking;
+using NebulaModel.Packets.Planet;
+using NebulaModel.Packets.Processors;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace NebulaClient.PacketProcessors.Planet
+{
+    [RegisterPacketProcessor]
+    public class PlanetDataResponseProcessor : IPacketProcessor<PlanetDataResponse>
+    {
+        public void ProcessPacket(PlanetDataResponse packet, NebulaConnection conn)
+        {
+            // We have to track the offset we are currently at in the flattened jagged array as we decode
+            int currentOffset = 0;
+
+            for(int i = 0; i < packet.PlanetDataIDs.Length; i++)
+            {
+                PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetDataIDs[i]);
+
+                Log.Info($"Parsing {packet.PlanetDataBytesLengths[i]} bytes of data for planet {planet.name} (ID: {planet.id})");
+
+                using (MemoryStream ms = new MemoryStream(packet.PlanetDataBytes.Skip(currentOffset).Take(packet.PlanetDataBytesLengths[i]).ToArray()))
+                using (LZ4Stream ls = new LZ4Stream(ms, CompressionMode.Decompress))
+                using (BufferedStream bs = new BufferedStream(ls, 8192))
+                using (BinaryReader br = new BinaryReader(bs))
+                {
+                    planet.ImportRuntime(br);
+                }
+
+                lock (PlanetModelingManager.genPlanetReqList)
+                {
+                    PlanetModelingManager.genPlanetReqList.Enqueue(planet);
+                }
+
+                currentOffset += packet.PlanetDataBytesLengths[i];
+            }
+        }
+    }
+}

--- a/NebulaHost/NebulaHost.csproj
+++ b/NebulaHost/NebulaHost.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <Compile Include="MultiplayerHostSession.cs" />
     <Compile Include="PacketProcessors\Planet\FactoryLoadRequestProcessor.cs" />
+    <Compile Include="PacketProcessors\Planet\PlanetDataRequestProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerAnimationUpdateProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerColorChangedProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerMovementProcessor.cs" />

--- a/NebulaHost/PacketProcessors/Planet/PlanetDataRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Planet/PlanetDataRequestProcessor.cs
@@ -1,0 +1,66 @@
+﻿using LZ4;
+using NebulaModel.Attributes;
+using NebulaModel.Logger;
+using NebulaModel.Networking;
+using NebulaModel.Packets.Planet;
+using NebulaModel.Packets.Processors;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+
+namespace NebulaHost.PacketProcessors.Planet
+{
+    [RegisterPacketProcessor]
+    public class PlanetDataRequestProcessor : IPacketProcessor<PlanetDataRequest>
+    {
+        public void ProcessPacket(PlanetDataRequest packet, NebulaConnection conn)
+        {
+            Dictionary<int, byte[]> planetDataToReturn = new Dictionary<int, byte[]>();
+
+            foreach(int planetId in packet.PlanetIDs)
+            {
+                PlanetData planet = GameMain.galaxy.PlanetById(planetId);
+                Log.Info($"Returning terrain for {planet.name}");
+
+                // NOTE: The following has been picked-n-mixed from "PlanetModelingManager.PlanetComputeThreadMain()"
+                // This method is **costly** - do not run it more than is required!
+                // It generates the planet on the host and then sends it to the client
+
+                PlanetAlgorithm planetAlgorithm = PlanetModelingManager.Algorithm(planet);
+
+                if (planet.data == null)
+                {
+                    planet.data = new PlanetRawData(planet.precision);
+                    planet.modData = planet.data.InitModData(planet.modData);
+                    planet.data.CalcVerts();
+                    planet.aux = new PlanetAuxData(planet);
+                    planetAlgorithm.GenerateTerrain(planet.mod_x, planet.mod_y);
+                    planetAlgorithm.CalcWaterPercent();
+                }
+
+                if (planet.factory == null)
+                {
+                    if (planet.type != EPlanetType.Gas)
+                    {
+                        planetAlgorithm.GenerateVegetables();
+                        planetAlgorithm.GenerateVeins(false);
+                    }
+                }
+
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    using (LZ4Stream ls = new LZ4Stream(ms, CompressionMode.Compress))
+                    using (BufferedStream bs = new BufferedStream(ls, 8192))
+                    using (BinaryWriter bw = new BinaryWriter(bs))
+                    {
+                        planet.ExportRuntime(bw);
+                    }
+
+                    planetDataToReturn.Add(planetId, ms.ToArray());
+                }
+            }
+
+            conn.SendPacket(new PlanetDataResponse(planetDataToReturn));
+        }
+    }
+}

--- a/NebulaModel/NebulaModel.csproj
+++ b/NebulaModel/NebulaModel.csproj
@@ -81,6 +81,8 @@
     <Compile Include="Networking\PendingPacket.cs" />
     <Compile Include="Packets\Planet\FactoryData.cs" />
     <Compile Include="Packets\Planet\FactoryLoadRequest.cs" />
+    <Compile Include="Packets\Planet\PlanetDataRequest.cs" />
+    <Compile Include="Packets\Planet\PlanetDataResponse.cs" />
     <Compile Include="Packets\Players\PlayerAnimationUpdate.cs" />
     <Compile Include="Packets\Players\PlayerMovement.cs" />
     <Compile Include="Packets\Players\PlayerColorChanged.cs" />

--- a/NebulaModel/Packets/Planet/PlanetDataRequest.cs
+++ b/NebulaModel/Packets/Planet/PlanetDataRequest.cs
@@ -1,0 +1,14 @@
+﻿namespace NebulaModel.Packets.Planet
+{
+    public class PlanetDataRequest
+    {
+        public int[] PlanetIDs { get; set; }
+
+        public PlanetDataRequest() { }
+
+        public PlanetDataRequest(int[] planetIDs)
+        {
+            this.PlanetIDs = planetIDs;
+        }
+    }
+}

--- a/NebulaModel/Packets/Planet/PlanetDataResponse.cs
+++ b/NebulaModel/Packets/Planet/PlanetDataResponse.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace NebulaModel.Packets.Planet
+{
+    public class PlanetDataResponse
+    {
+        public int[] PlanetDataIDs { get; set; }
+        public byte[] PlanetDataBytes { get; set; }
+        public int[] PlanetDataBytesLengths { get; set; }
+
+        public PlanetDataResponse() { }
+
+        public PlanetDataResponse(Dictionary<int, byte[]> planetData) 
+        {
+            this.PlanetDataIDs = planetData.Keys.ToArray();
+
+            // Can't use a jagged array because LNL serializer says no, so flattening and separate offset array it is
+            // TODO: Possibly register a type with the serializer instead of doing this manually
+            this.PlanetDataBytes = planetData.Values.SelectMany(x => x).ToArray();
+            this.PlanetDataBytesLengths = planetData.Values.Select(x => x.Length).ToArray();
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -30,11 +30,9 @@ namespace NebulaPatcher.Patches.Dynamic
             // Take it off the list, as we will process it now
             LocalPlayer.PendingFactories.Remove(planet.id);
 
-            // TODO: Possibly rework this a little bit when we implement production stats to match the indexes host and client side
-            // Needs more investigation, as we use PlanetFactory.Import()
-
             // Import the factory from the given bytes, which will have been gotten or created on the host by the original function
             __instance.factories[__instance.factoryCount] = new PlanetFactory();
+
             using (MemoryStream ms = new MemoryStream(factoryBytes))
             using (LZ4Stream ls = new LZ4Stream(ms, CompressionMode.Decompress))
             using (BufferedStream bs = new BufferedStream(ls, 8192))
@@ -43,12 +41,17 @@ namespace NebulaPatcher.Patches.Dynamic
                 __instance.factories[__instance.factoryCount].Import(__instance.factoryCount, __instance, br);
             }
 
+            // Assign the factory to the result
+            __result = __instance.factories[__instance.factoryCount];
+
+            // TODO: Possibly rework this a little bit when we implement production stats to match the indexes host and client side
+            // Loading factories in a different order will cause the indexes to mismatch
+            planet.factory = __result;
+            planet.factoryIndex = __instance.factoryCount;
+
             // Bump the factory count up and clear the flag
             __instance.factoryCount++;
             planet.factoryLoading = false;
-
-            // Assign the factory to the result
-            __result = __instance.factories[__instance.factoryCount];
 
             // Do not run the original method
             return false;

--- a/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
@@ -2,13 +2,17 @@
 using NebulaModel.Logger;
 using NebulaModel.Packets.Planet;
 using NebulaWorld;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NebulaPatcher.Patches.Dynamic
 {
-    [HarmonyPatch(typeof(PlanetModelingManager), "RequestLoadPlanetFactory")]
+    [HarmonyPatch(typeof(PlanetModelingManager))]
     public class PlanetModelingManager_Patch
     {
-        public static bool Prefix(PlanetData planet)
+        [HarmonyPrefix]
+        [HarmonyPatch("RequestLoadPlanetFactory")]
+        public static bool RequestLoadPlanetFactory(PlanetData planet)
         {
             // Run the original method if this is the master client or in single player games
             if (!SimulatedWorld.Initialized || LocalPlayer.IsMasterClient)
@@ -29,6 +33,64 @@ namespace NebulaPatcher.Patches.Dynamic
 
             // Skip running the actual method
             return false;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("RequestLoadPlanet")]
+        public static bool RequestLoadPlanet(PlanetData planet)
+        {
+            // NOTE: This does not appear to ever be called in the game code, but just in case, let's override it
+            // RequestLoadStar takes care of these instead currently
+
+            // Run the original method if this is the master client or in single player games
+            if (!SimulatedWorld.Initialized || LocalPlayer.IsMasterClient)
+            {
+                return true;
+            }
+
+            InternalLoadPlanetsRequestGenerator(new[] { planet });
+
+            return false;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("RequestLoadStar")]
+        public static bool RequestLoadStar(StarData star)
+        {
+            // Run the original method if this is the master client or in single player games
+            if (!SimulatedWorld.Initialized || LocalPlayer.IsMasterClient)
+            {
+                return true;
+            }
+
+            InternalLoadPlanetsRequestGenerator(star.planets);
+
+            return false;
+        }
+
+        private static void InternalLoadPlanetsRequestGenerator(PlanetData[] planetsToLoad)
+        {
+            lock (PlanetModelingManager.genPlanetReqList)
+            {
+                List<int> planetsToRequest = new List<int>();
+
+                foreach(PlanetData planet in planetsToLoad)
+                {
+                    planet.wanted = true;
+                    if (planet.loaded || planet.loading)
+                        continue;
+
+                    planet.loading = true;
+
+                    Log.Info($"Requesting planet model for {planet.name} (ID: {planet.id}) from host");
+                    planetsToRequest.Add(planet.id);
+                }
+
+                if(planetsToRequest.Any())
+                {
+                    LocalPlayer.SendPacket(new PlanetDataRequest(planetsToRequest.ToArray()));
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This gets the planet data from the host when a client tries to load a star system/planet, before the planet is computed on the client.

This means that the mesh is correctly rendered on the client when it loads a factory, so factories are no longer floating in the air or half buried underground, and are aligned correctly with the terrain.

It also takes care of the case where a player might enter a star system that has not yet been entered by the host, so data is generated.