### PR TITLE
Fix for the landing pod bug

### DIFF
--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Patches\Dynamic\GameData_Patch.cs" />
     <Compile Include="Patches\Dynamic\GameLoader_Patch.cs" />
     <Compile Include="Patches\Dynamic\DSPGame_Patch.cs" />
+    <Compile Include="Patches\Dynamic\GuideMissionStandardMode_Patch.cs" />
     <Compile Include="Patches\Dynamic\PlanetModelingManager_Patch.cs" />
     <Compile Include="Patches\Transpilers\PlayerAction_Mine_Patch.cs" />
     <Compile Include="Patches\Dynamic\UIEscMenu_Patch.cs" />

--- a/NebulaPatcher/Patches/Dynamic/GuideMissionStandardMode_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GuideMissionStandardMode_Patch.cs
@@ -1,0 +1,15 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(GuideMissionStandardMode), "Skip")]
+    class GuideMissionStandardMode_Patch
+    {
+        public static bool Prefix()
+        {
+            //This prevents spawning landing capsule and preparing spawn area for the clients in multiplayer.
+            return !SimulatedWorld.Initialized || LocalPlayer.IsMasterClient;
+        }
+    }
+}


### PR DESCRIPTION
This is a bug fix for the [issue 60](https://github.com/hubastard/nebula/issues/60).
The landing pod is already being synchronized as part of VegeData, so this fix just prevents spawning another landing pod on the client-side and also prevents calling "FlattenTerrain" method that was removing the received landing pod from the server.

Tested:

1. Host game in MP
2. When a client connects, he sees the landing pod.
3. Client disconnects
4. Host will mine and remove landing pod.
5. When a client connects, he does not see the landing pod anymore.