### PR TITLE
Fix a few MSBuild re-evaluation issues

### DIFF
--- a/Nebula.sln
+++ b/Nebula.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		Directory.Build.targets = Directory.Build.targets
+		PluginImports.targets = PluginImports.targets
 		SharedConfig.targets = SharedConfig.targets
 	EndProjectSection
 EndProject

--- a/NebulaClient/NebulaClient.csproj
+++ b/NebulaClient/NebulaClient.csproj
@@ -34,9 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>

--- a/NebulaClient/NebulaClient.csproj
+++ b/NebulaClient/NebulaClient.csproj
@@ -38,42 +38,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\Libs\Assembly-CSharp.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
-    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.AnimationModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.ParticleSystemModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.ParticleSystemModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.PhysicsModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.UI.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UIElementsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.UIElementsModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.UIModule.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MultiplayerClientSession.cs" />
@@ -92,10 +57,12 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NebulaModel\NebulaModel.csproj">
+      <SpecificVersion>true</SpecificVersion>
       <Project>{c6237195-f77c-40c0-b06a-4ad51cad314d}</Project>
       <Name>NebulaModel</Name>
     </ProjectReference>
     <ProjectReference Include="..\NebulaWorld\NebulaWorld.csproj">
+      <SpecificVersion>true</SpecificVersion>
       <Project>{28aea139-fb22-4672-af51-28b728cf2978}</Project>
       <Name>NebulaWorld</Name>
     </ProjectReference>
@@ -110,7 +77,12 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetPath)" "$(DSPGameDir)\BepInEx\plugins\Nebula\$(TargetFileName)"</PostBuildEvent>
-  </PropertyGroup>
+  <Import Project="$(PluginImports)" />
+
+  <Target Name="AfterBuild">
+    <MakeDir Directories="$(DSPGameDir)BepInEx\plugins\Nebula\" />
+    <Copy SourceFiles="$(TargetPath)"
+          DestinationFolder="$(DSPGameDir)BepInEx\plugins\Nebula\"
+          SkipUnchangedFiles="true" />
+  </Target>
 </Project>

--- a/NebulaHost/NebulaHost.csproj
+++ b/NebulaHost/NebulaHost.csproj
@@ -30,9 +30,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/NebulaHost/NebulaHost.csproj
+++ b/NebulaHost/NebulaHost.csproj
@@ -34,21 +34,12 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\Libs\Assembly-CSharp.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine">
-      <HintPath>..\Libs\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\Libs\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MultiplayerHostSession.cs" />
@@ -67,14 +58,17 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NebulaModel\NebulaModel.csproj">
+      <SpecificVersion>true</SpecificVersion>
       <Project>{C6237195-F77C-40C0-B06A-4AD51CAD314D}</Project>
       <Name>NebulaModel</Name>
     </ProjectReference>
     <ProjectReference Include="..\NebulaWorld\NebulaWorld.csproj">
+      <SpecificVersion>true</SpecificVersion>
       <Project>{28aea139-fb22-4672-af51-28b728cf2978}</Project>
       <Name>NebulaWorld</Name>
     </ProjectReference>
     <ProjectReference Include="..\websocket-sharp\websocket-sharp\websocket-sharp.csproj">
+      <SpecificVersion>true</SpecificVersion>
       <Project>{b357bac7-529e-4d81-a0d2-71041b19c8de}</Project>
       <Name>websocket-sharp</Name>
     </ProjectReference>
@@ -85,9 +79,12 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetPath)" "$(DSPGameDir)\BepInEx\plugins\Nebula\$(TargetFileName)"
-copy /Y "$(TargetDir)/LZ4.dll" "$(DSPGameDir)\BepInEx\plugins\Nebula\LZ4.dll"
-copy /Y "$(TargetDir)/websocket-sharp.dll" "$(DSPGameDir)\BepInEx\plugins\Nebula\websocket-sharp.dll"</PostBuildEvent>
-  </PropertyGroup>
+  <Import Project="$(PluginImports)" />
+  
+  <Target Name="AfterBuild">
+    <MakeDir Directories="$(DSPGameDir)BepInEx\plugins\Nebula\" />
+    <Copy SourceFiles="$(TargetPath);$(TargetDir)\LZ4.dll;$(TargetDir)\websocket-sharp.dll"
+          DestinationFolder="$(DSPGameDir)BepInEx\plugins\Nebula\"
+          SkipUnchangedFiles="true" />
+  </Target>
 </Project>

--- a/NebulaModel/NebulaModel.csproj
+++ b/NebulaModel/NebulaModel.csproj
@@ -34,9 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>

--- a/NebulaModel/NebulaModel.csproj
+++ b/NebulaModel/NebulaModel.csproj
@@ -38,28 +38,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>..\Libs\0Harmony.dll</HintPath>
-    </Reference>
-    <Reference Include="BepInEx">
-      <HintPath>..\Libs\BepInEx.dll</HintPath>
-    </Reference>
-    <Reference Include="BepInEx.Harmony">
-      <HintPath>..\Libs\BepInEx.Harmony.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
-    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.AnimationModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attributes\RegisterNestedTypeAttribute.cs" />
@@ -119,7 +98,12 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetPath)" "$(DSPGameDir)\BepInEx\plugins\Nebula\$(TargetFileName)"</PostBuildEvent>
-  </PropertyGroup>
+  <Import Project="$(PluginImports)" />
+
+  <Target Name="AfterBuild">
+    <MakeDir Directories="$(DSPGameDir)BepInEx\plugins\Nebula\" />
+    <Copy SourceFiles="$(TargetPath)"
+          DestinationFolder="$(DSPGameDir)BepInEx\plugins\Nebula\"
+          SkipUnchangedFiles="true" />
+  </Target>
 </Project>

--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -33,9 +33,6 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>

--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -37,51 +37,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>..\Libs\0Harmony.dll</HintPath>
-    </Reference>
-    <Reference Include="Assembly-CSharp">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="BepInEx">
-      <HintPath>..\Libs\BepInEx.dll</HintPath>
-    </Reference>
-    <Reference Include="BepInEx.Harmony">
-      <HintPath>..\Libs\BepInEx.Harmony.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
-    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.IMGUIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.IMGUIModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.ParticleSystemModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.ParticleSystemModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>..\Libs\UnityEngine.PhysicsModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.UI.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UIElementsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.UIElementsModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.UIModule.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Logger\BepInExLogger.cs" />
@@ -104,18 +60,22 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NebulaClient\NebulaClient.csproj">
+      <SpecificVersion>true</SpecificVersion>
       <Project>{5be9c74b-7832-4ef1-a53d-bf461bbdb0be}</Project>
       <Name>NebulaClient</Name>
     </ProjectReference>
     <ProjectReference Include="..\NebulaHost\NebulaHost.csproj">
+      <SpecificVersion>true</SpecificVersion>
       <Project>{1927F7FF-230B-4B1B-B7ED-34B58730AFBE}</Project>
       <Name>NebulaHost</Name>
     </ProjectReference>
     <ProjectReference Include="..\NebulaModel\NebulaModel.csproj">
+      <SpecificVersion>true</SpecificVersion>
       <Project>{c6237195-f77c-40c0-b06a-4ad51cad314d}</Project>
       <Name>NebulaModel</Name>
     </ProjectReference>
     <ProjectReference Include="..\NebulaWorld\NebulaWorld.csproj">
+      <SpecificVersion>true</SpecificVersion>
       <Project>{28aea139-fb22-4672-af51-28b728cf2978}</Project>
       <Name>NebulaWorld</Name>
     </ProjectReference>
@@ -126,7 +86,12 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetPath)" "$(DSPGameDir)\BepInEx\plugins\Nebula\$(TargetFileName)"</PostBuildEvent>
-  </PropertyGroup>
+  <Import Project="$(PluginImports)" />
+
+  <Target Name="AfterBuild">
+    <MakeDir Directories="$(DSPGameDir)BepInEx\plugins\Nebula\" />
+    <Copy SourceFiles="$(TargetPath)"
+          DestinationFolder="$(DSPGameDir)BepInEx\plugins\Nebula\"
+          SkipUnchangedFiles="true" />
+  </Target>
 </Project>

--- a/NebulaWorld/NebulaWorld.csproj
+++ b/NebulaWorld/NebulaWorld.csproj
@@ -31,31 +31,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\Libs\Assembly-CSharp.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine">
-      <HintPath>..\Libs\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AnimationModule">
-      <HintPath>..\Libs\UnityEngine.AnimationModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\Libs\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.ParticleSystemModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.ParticleSystemModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>..\Libs\UnityEngine.PhysicsModule.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Factory\EntityManager.cs" />
@@ -74,12 +55,18 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NebulaModel\NebulaModel.csproj">
+      <SpecificVersion>true</SpecificVersion>
       <Project>{c6237195-f77c-40c0-b06a-4ad51cad314d}</Project>
       <Name>NebulaModel</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetPath)" "$(DSPGameDir)\BepInEx\plugins\Nebula\$(TargetFileName)"</PostBuildEvent>
-  </PropertyGroup>
+  <Import Project="$(PluginImports)" />
+
+  <Target Name="AfterBuild">
+    <MakeDir Directories="$(DSPGameDir)BepInEx\plugins\Nebula\" />
+    <Copy SourceFiles="$(TargetPath)"
+          DestinationFolder="$(DSPGameDir)BepInEx\plugins\Nebula\"
+          SkipUnchangedFiles="true" />
+  </Target>
 </Project>

--- a/PluginImports.targets
+++ b/PluginImports.targets
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <BepInExDir>$(DSPGameDir)BepInEx\core\</BepInExDir>
+    <DSPAssemblyDir>$(DSPGameDir)DSPGAME_Data\Managed\</DSPAssemblyDir>
+  </PropertyGroup>
+
+  <ItemGroup Label="BepInEx">
+    <Reference Include="$(BepInExDir)0Harmony.dll" Private="false" SpecificVersion="true" />
+    <Reference Include="$(BepInExDir)BepInEx.dll" Private="false" SpecificVersion="true" />
+    <Reference Include="$(BepInExDir)BepInEx.Harmony.dll" Private="false" SpecificVersion="true" />
+  </ItemGroup>
+  
+  <ItemGroup Label="Dyson Sphere Program">
+    <Reference Include="$(DSPAssemblyDir)Assembly-CSharp.dll" Private="false" SpecificVersion="true" />
+    <Reference Include="$(DSPAssemblyDir)UnityEngine.dll" Private="false" SpecificVersion="true" />
+    <Reference Include="$(DSPAssemblyDir)UnityEngine.AnimationModule.dll" Private="false" SpecificVersion="true" />
+    <Reference Include="$(DSPAssemblyDir)UnityEngine.CoreModule.dll" Private="false" SpecificVersion="true" />
+    <Reference Include="$(DSPAssemblyDir)UnityEngine.IMGUIModule.dll" Private="false" SpecificVersion="true" />
+    <Reference Include="$(DSPAssemblyDir)UnityEngine.ParticleSystemModule.dll" Private="false" SpecificVersion="true" />
+    <Reference Include="$(DSPAssemblyDir)UnityEngine.PhysicsModule.dll" Private="false" SpecificVersion="true" />
+    <Reference Include="$(DSPAssemblyDir)UnityEngine.UI.dll" Private="false" SpecificVersion="true" />
+    <Reference Include="$(DSPAssemblyDir)UnityEngine.UIElementsModule.dll" Private="false" SpecificVersion="true" />
+    <Reference Include="$(DSPAssemblyDir)UnityEngine.UIModule.dll" Private="false" SpecificVersion="true" />
+  </ItemGroup>
+</Project>

--- a/SharedConfig.targets
+++ b/SharedConfig.targets
@@ -4,6 +4,7 @@
     <DevEnv>DevEnv.targets</DevEnv>
     <DevEnvLoc>$(SolutionDir)\$(DevEnv)</DevEnvLoc>
     <DSPGameDir Condition="!Exists('$(DevEnvLoc)')">C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\</DSPGameDir>
+    <PluginImports>$(MSBuildThisFileDirectory)PluginImports.targets</PluginImports>
   </PropertyGroup>
 
   <Import Project="$(DevEnvLoc)" Condition="Exists('$(DevEnvLoc)')" />
@@ -28,6 +29,6 @@
   <!-- Using DependsOnTarget with Conditional targets as an if else structure... -->
   <!-- Note that this is the first target, called by InitialTargets -->
   <Target Name="TestDSPGameFolder"
-          DependsOnTargets="MaybeCopyDevEnv;DevEnvInvalid"
+          DependsOnTargets="MaybeCopyDevEnv;DevEnvInvalid;CreatePluginDirectory"
           Condition="!Exists('$(DSPGameDir)')" />
 </Project>

--- a/SharedConfig.targets
+++ b/SharedConfig.targets
@@ -3,22 +3,31 @@
   <PropertyGroup>
     <DevEnv>DevEnv.targets</DevEnv>
     <DevEnvLoc>$(SolutionDir)\$(DevEnv)</DevEnvLoc>
-    <DSPGameDir Condition="!Exists('$(DevEnvLoc)')">C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program</DSPGameDir>
+    <DSPGameDir Condition="!Exists('$(DevEnvLoc)')">C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\</DSPGameDir>
   </PropertyGroup>
 
   <Import Project="$(DevEnvLoc)" Condition="Exists('$(DevEnvLoc)')" />
 
-  <Target Name="MaybeCopyDevEnv" Condition="!Exists('$(DSPGameDir)') and !Exists('$(DevEnvLoc)')">
-    <Copy SourceFiles="$(DevEnvLoc).example" DestinationFiles="$(DevEnvLoc)" />
+  <Target Name="MaybeCopyDevEnv"
+          Inputs="$(MSBuildAllProjects)"
+          Outputs="$(DevEnvLoc)"
+          Condition="!Exists('$(DSPGameDir)') and !Exists('$(DevEnvLoc)')">
+
+    <Copy SourceFiles="$(DevEnvLoc).example"
+          DestinationFiles="$(DevEnvLoc)"
+          SkipUnchangedFiles="true" />
     <Error Text="It appears your Dyson Sphere Program installation is not in the default Steam directory. Please set the path correctly in $(DevEnv) (it has been created for you)." />
   </Target>
 
-  <Target Name="DevEnvInvalid" Condition="!Exists('$(DSPGameDir)') and Exists('$(DevEnvLoc)')">
+  <Target Name="DevEnvInvalid"
+          Condition="!Exists('$(DSPGameDir)') and Exists('$(DevEnvLoc)')">
     <!-- If the default path is overriden in DevEnv, and it doesn't exist -->
-    <Error Text="Your Dyson Sphere Program installation folder has not been found at the path defined in $(DevEnv). Please set it correctly." Condition="Exists('$(DevEnvLoc)')" />
+    <Error Text="Your Dyson Sphere Program installation folder has not been found at the path defined in $(DevEnv). Please set it correctly." />
   </Target>
 
   <!-- Using DependsOnTarget with Conditional targets as an if else structure... -->
   <!-- Note that this is the first target, called by InitialTargets -->
-  <Target Name="TestDSPGameFolder" DependsOnTargets="MaybeCopyDevEnv;DevEnvInvalid" Condition="!Exists('$(DSPGameDir)')" />
+  <Target Name="TestDSPGameFolder"
+          DependsOnTargets="MaybeCopyDevEnv;DevEnvInvalid"
+          Condition="!Exists('$(DSPGameDir)')" />
 </Project>


### PR DESCRIPTION
The code now doesn't run redundantly to generate the environment
It is no longer required to downgrade the dlls.
All references happen in a shared place.
Output directory is created automatically.