### PR TITLE
Fix multi-clients issues

### DIFF
--- a/NebulaClient/NebulaClient.csproj
+++ b/NebulaClient/NebulaClient.csproj
@@ -48,6 +48,7 @@
     <Compile Include="PacketProcessors\Players\PlayerColorChangeProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerMovementProcessor.cs" />
     <Compile Include="PacketProcessors\Session\HandshakeResponseProcessor.cs" />
+    <Compile Include="PacketProcessors\Session\PlayerDisconnectedProcessor.cs" />
     <Compile Include="PacketProcessors\Session\PlayerJoiningProcessor.cs" />
     <Compile Include="PacketProcessors\Session\SyncCompleteProcessor.cs" />
     <Compile Include="PacketProcessors\Universe\DysonSphereDataProcessor.cs" />
@@ -76,11 +77,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(PluginImports)" />
-
   <Target Name="AfterBuild">
     <MakeDir Directories="$(DSPGameDir)BepInEx\plugins\Nebula\" />
-    <Copy SourceFiles="$(TargetPath)"
-          DestinationFolder="$(DSPGameDir)BepInEx\plugins\Nebula\"
-          SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(DSPGameDir)BepInEx\plugins\Nebula\" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/NebulaClient/PacketProcessors/Session/HandshakeResponseProcessor.cs
+++ b/NebulaClient/PacketProcessors/Session/HandshakeResponseProcessor.cs
@@ -19,11 +19,6 @@ namespace NebulaClient.PacketProcessors.Session
             LocalPlayer.SetPlayerData(packet.LocalPlayerData);
 
             InGamePopup.ShowInfo("Loading", "Loading state from server, please wait", null);
-
-            foreach (var playerData in packet.OtherPlayers)
-            {
-                SimulatedWorld.SpawnRemotePlayerModel(playerData);
-            }
         }
     }
 }

--- a/NebulaClient/PacketProcessors/Session/PlayerDisconnectedProcessor.cs
+++ b/NebulaClient/PacketProcessors/Session/PlayerDisconnectedProcessor.cs
@@ -7,12 +7,11 @@ using NebulaWorld;
 namespace NebulaClient.PacketProcessors.Session
 {
     [RegisterPacketProcessor]
-    public class PlayerJoiningProcessor : IPacketProcessor<PlayerJoining>
+    public class PlayerDisconnectedProcessor : IPacketProcessor<PlayerDisconnected>
     {
-        public void ProcessPacket(PlayerJoining packet, NebulaConnection conn)
+        public void ProcessPacket(PlayerDisconnected packet, NebulaConnection conn)
         {
-            SimulatedWorld.SpawnRemotePlayerModel(packet.PlayerData);
-            SimulatedWorld.OnPlayerJoining();
+            SimulatedWorld.DestroyRemotePlayerModel(packet.PlayerId);
         }
     }
 }

--- a/NebulaClient/PacketProcessors/Session/SyncCompleteProcessor.cs
+++ b/NebulaClient/PacketProcessors/Session/SyncCompleteProcessor.cs
@@ -11,8 +11,16 @@ namespace NebulaClient.PacketProcessors.Session
     {
         public void ProcessPacket(SyncComplete packet, NebulaConnection conn)
         {
-            InGamePopup.FadeOut();
-            GameMain.Resume();
+            // Everyone is now connected, we can safely spawn the player model of all the other players that are currently connected
+            foreach (var playerData in packet.AllPlayers)
+            {
+                if (playerData.PlayerId != LocalPlayer.PlayerId)
+                {
+                    SimulatedWorld.SpawnRemotePlayerModel(playerData);
+                }
+            }
+
+            SimulatedWorld.OnAllPlayersSyncCompleted();
         }
     }
 }

--- a/NebulaHost/MultiplayerHostSession.cs
+++ b/NebulaHost/MultiplayerHostSession.cs
@@ -88,29 +88,7 @@ namespace NebulaHost
                 this.playerManager = playerManager;
                 this.packetProcessor = packetProcessor;
             }
-
-            protected override void OnClose(CloseEventArgs e)
-            {
-                // If the reason of a client disonnect is because we are still loading the game,
-                // we don't need to inform the other clients since the disconnected client never
-                // joined the game in the first place.
-                if (e.Code == (short)NebulaStatusCode.HostStillLoading)
-                    return;
-
-                NebulaModel.Logger.Log.Info($"Client disconnected: {this.Context.UserEndPoint}, reason: {e.Reason}");
-                playerManager.PlayerDisconnected(new NebulaConnection(this.Context.WebSocket, packetProcessor));
-            }
-
-            protected override void OnError(ErrorEventArgs e)
-            {
-                // TODO: Decide what to do here - does OnClose get called too?
-            }
-
-            protected override void OnMessage(MessageEventArgs e)
-            {
-                packetProcessor.EnqueuePacketForProcessing(e.RawData, new NebulaConnection(this.Context.WebSocket, packetProcessor));
-            }
-
+           
             protected override void OnOpen()
             {
                 if (SimulatedWorld.IsGameLoaded == false)
@@ -120,9 +98,31 @@ namespace NebulaHost
                     return;
                 }
 
-                NebulaModel.Logger.Log.Info($"Client connected ID: {this.ID}, {this.Context.UserEndPoint}");
-                NebulaConnection conn = new NebulaConnection(this.Context.WebSocket, packetProcessor);
+                NebulaModel.Logger.Log.Info($"Client connected ID: {ID}, {Context.UserEndPoint}");
+                NebulaConnection conn = new NebulaConnection(Context.WebSocket, Context.UserEndPoint, packetProcessor);
                 playerManager.PlayerConnected(conn);
+            }
+
+            protected override void OnMessage(MessageEventArgs e)
+            {
+                packetProcessor.EnqueuePacketForProcessing(e.RawData, new NebulaConnection(Context.WebSocket, Context.UserEndPoint, packetProcessor));
+            }
+
+            protected override void OnClose(CloseEventArgs e)
+            {
+                // If the reason of a client disonnect is because we are still loading the game,
+                // we don't need to inform the other clients since the disconnected client never
+                // joined the game in the first place.
+                if (e.Code == (short)NebulaStatusCode.HostStillLoading)
+                    return;
+
+                NebulaModel.Logger.Log.Info($"Client disconnected: {Context.UserEndPoint}, reason: {e.Reason}");
+                playerManager.PlayerDisconnected(new NebulaConnection(Context.WebSocket, Context.UserEndPoint, packetProcessor));
+            }
+
+            protected override void OnError(ErrorEventArgs e)
+            {
+                // TODO: Decide what to do here - does OnClose get called too?
             }
         }
     }

--- a/NebulaHost/NebulaHost.csproj
+++ b/NebulaHost/NebulaHost.csproj
@@ -78,11 +78,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(PluginImports)" />
-  
   <Target Name="AfterBuild">
     <MakeDir Directories="$(DSPGameDir)BepInEx\plugins\Nebula\" />
-    <Copy SourceFiles="$(TargetPath);$(TargetDir)\LZ4.dll;$(TargetDir)\websocket-sharp.dll"
-          DestinationFolder="$(DSPGameDir)BepInEx\plugins\Nebula\"
-          SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(TargetPath);$(TargetDir)\LZ4.dll;$(TargetDir)\websocket-sharp.dll" DestinationFolder="$(DSPGameDir)BepInEx\plugins\Nebula\" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/NebulaHost/PacketProcessors/Players/PlayerColorChangedProcessor.cs
+++ b/NebulaHost/PacketProcessors/Players/PlayerColorChangedProcessor.cs
@@ -22,7 +22,7 @@ namespace NebulaHost.PacketProcessors.Players
             Player player = playerManager.GetPlayer(conn);
             if (player == null)
             {
-                Log.Warn($"Received PlayerColorChanged packet from unknown player {packet.PlayerId}");
+                Log.Info($"Received PlayerColorChanged packet from unknown player {packet.PlayerId}");
                 return;
             }
 

--- a/NebulaHost/PacketProcessors/Session/HandshakeRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Session/HandshakeRequestProcessor.cs
@@ -5,7 +5,6 @@ using NebulaModel.Packets.Processors;
 using NebulaModel.Packets.Session;
 using NebulaWorld;
 using System.Linq;
-using System.Reflection;
 
 namespace NebulaHost.PacketProcessors.Session
 {
@@ -36,9 +35,7 @@ namespace NebulaHost.PacketProcessors.Session
                 conn.Disconnect();
             }
 
-            //
-            typeof(GameMain).GetField("_paused", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(GameMain.instance, true);
-            InGamePopup.ShowInfo("Loading", "Player joining the game, please wait", null);
+            SimulatedWorld.OnPlayerJoining();
 
             // Make sure that each player that is currently in the game receives that a new player as join so they can create its RemotePlayerCharacter
             foreach (Player activePlayer in playerManager.GetConnectedPlayers())
@@ -49,13 +46,8 @@ namespace NebulaHost.PacketProcessors.Session
             // Add the new player to the list
             playerManager.SyncingPlayers.Add(conn, player);
 
-            // TODO: This should be our actual GameDesc and not an hardcoded value.
-            var inGamePlayersIds = playerManager.GetAllPlayerIdsIncludingHost();
-
             var gameDesc = GameMain.data.gameDesc;
-            player.SendPacket(new HandshakeResponse(gameDesc.galaxyAlgo, gameDesc.galaxySeed, gameDesc.starCount, gameDesc.resourceMultiplier, player.Data, inGamePlayersIds.ToArray()));
-
-            SimulatedWorld.SpawnRemotePlayerModel(player.Data);
+            player.SendPacket(new HandshakeResponse(gameDesc.galaxyAlgo, gameDesc.galaxySeed, gameDesc.starCount, gameDesc.resourceMultiplier, player.Data));
         }
     }
 }

--- a/NebulaModel/DataStructures/ThreadSafeDictionnary.cs
+++ b/NebulaModel/DataStructures/ThreadSafeDictionnary.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 
 namespace NebulaModel.DataStructures
@@ -14,7 +13,22 @@ namespace NebulaModel.DataStructures
             dictionary = new Dictionary<TKey, TValue>();
         }
 
-        public TValue this[TKey key] { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public TValue this[TKey key] {
+            get 
+            {
+                lock(lockObj)
+                {
+                    return dictionary[key];
+                }
+            }
+            set 
+            {
+                lock (lockObj)
+                {
+                    dictionary[key] = value;
+                }
+            }
+        }
 
         public ICollection<TKey> Keys
         {

--- a/NebulaModel/DataStructures/ThreadSafeDictionnary.cs
+++ b/NebulaModel/DataStructures/ThreadSafeDictionnary.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace NebulaModel.DataStructures
+{
+    public class ThreadSafeDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+    {
+        private readonly IDictionary<TKey, TValue> dictionary;
+        private readonly object lockObj = new object();
+
+        public ThreadSafeDictionary()
+        {
+            dictionary = new Dictionary<TKey, TValue>();
+        }
+
+        public TValue this[TKey key] { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public ICollection<TKey> Keys
+        {
+            get
+            {
+                lock (lockObj)
+                {
+                    return new List<TKey>(dictionary.Keys);
+                }
+            }
+        }
+
+        public ICollection<TValue> Values
+        {
+            get
+            {
+                lock (lockObj)
+                {
+                    return new List<TValue>(dictionary.Values);
+                }
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                lock (lockObj)
+                {
+                    return dictionary.Count;
+                }
+            }
+        }
+
+        public bool IsReadOnly { get; } = false;
+
+        public void Add(TKey key, TValue value)
+        {
+            lock (lockObj)
+            {
+                dictionary.Add(key, value);
+            }
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            lock (lockObj)
+            {
+                dictionary.Add(item);
+            }
+        }
+
+        public void Clear()
+        {
+            lock (lockObj)
+            {
+                dictionary.Clear();
+            }
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            lock (lockObj)
+            {
+                return dictionary.Contains(item);
+            }
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            lock (lockObj)
+            {
+                return dictionary.ContainsKey(key);
+            }
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            lock (lockObj)
+            {
+                dictionary.CopyTo(array, arrayIndex);
+            }
+        }
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            lock (lockObj)
+            {
+                return new Dictionary<TKey, TValue>(dictionary).GetEnumerator();
+            }
+        }
+
+        public bool Remove(TKey key)
+        {
+            lock (lockObj)
+            {
+                return dictionary.Remove(key);
+            }
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            lock (lockObj)
+            {
+                return dictionary.Remove(item);
+            }
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            lock (lockObj)
+            {
+                return dictionary.TryGetValue(key, out value);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/NebulaModel/DataStructures/ThreadSafeQueue.cs
+++ b/NebulaModel/DataStructures/ThreadSafeQueue.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace NebulaModel.DataStructures
+{
+    public class ThreadSafeQueue<T>
+    {
+        private readonly Queue<T> queue;
+        private readonly object lockObj = new object();
+
+        public ThreadSafeQueue()
+        {
+            queue = new Queue<T>();
+        }
+
+        public int Count {
+            get
+            {
+                lock (lockObj)
+                {
+                    return queue.Count;
+                }
+            }
+        }
+
+        public void Clear()
+        {
+            lock(lockObj)
+            {
+                queue.Clear();
+            }
+        }
+
+        public bool Contains(T item)
+        {
+            lock(lockObj)
+            {
+                return queue.Contains(item);
+            }
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            lock (lockObj)
+            {
+                queue.CopyTo(array, arrayIndex);
+            }
+        }
+
+        public T Dequeue()
+        {
+            lock (lockObj)
+            {
+                return queue.Dequeue();
+            }
+        }
+
+        public void Enqueue(T item)
+        {
+            lock (lockObj)
+            {
+                queue.Enqueue(item);
+            }
+        }
+
+        public T Peek()
+        {
+            lock(lockObj)
+            {
+                return queue.Peek();
+            }
+        }
+
+        public T[] ToArray()
+        {
+            lock (lockObj)
+            {
+                return queue.ToArray();
+            }
+        }
+
+        public void TrimExcess()
+        {
+            lock (lockObj)
+            {
+                queue.TrimExcess();
+            }
+        }
+    }
+}

--- a/NebulaModel/NebulaModel.csproj
+++ b/NebulaModel/NebulaModel.csproj
@@ -48,6 +48,8 @@
     <Compile Include="DataStructures\Float4.cs" />
     <Compile Include="DataStructures\NetDataReaderExtensions.cs" />
     <Compile Include="DataStructures\PlayerData.cs" />
+    <Compile Include="DataStructures\ThreadSafeDictionnary.cs" />
+    <Compile Include="DataStructures\ThreadSafeQueue.cs" />
     <Compile Include="Logger\ILogger.cs" />
     <Compile Include="Logger\Log.cs" />
     <Compile Include="Networking\DelayedPacket.cs" />
@@ -98,11 +100,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(PluginImports)" />
-
   <Target Name="AfterBuild">
     <MakeDir Directories="$(DSPGameDir)BepInEx\plugins\Nebula\" />
-    <Copy SourceFiles="$(TargetPath)"
-          DestinationFolder="$(DSPGameDir)BepInEx\plugins\Nebula\"
-          SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(DSPGameDir)BepInEx\plugins\Nebula\" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/NebulaModel/Networking/NebulaConnection.cs
+++ b/NebulaModel/Networking/NebulaConnection.cs
@@ -1,22 +1,21 @@
-﻿using HarmonyLib;
-using NebulaModel.Logger;
+﻿using NebulaModel.Logger;
 using NebulaModel.Networking.Serialization;
-using System.Reflection;
+using System.Net;
 using WebSocketSharp;
 
 namespace NebulaModel.Networking
 {
     public class NebulaConnection
     {
+        private readonly IPEndPoint peerEndpoint;
         private readonly WebSocket peerSocket;
         private readonly NetPacketProcessor packetProcessor;
 
-        private readonly FieldInfo webSocket_base64Key = AccessTools.Field(typeof(WebSocket), "_base64Key");
-
         public bool IsAlive => peerSocket?.IsAlive ?? false;
 
-        public NebulaConnection(WebSocket peerSocket, NetPacketProcessor packetProcessor)
+        public NebulaConnection(WebSocket peerSocket, IPEndPoint peerEndpoint, NetPacketProcessor packetProcessor)
         {
+            this.peerEndpoint = peerEndpoint;
             this.peerSocket = peerSocket;
             this.packetProcessor = packetProcessor;
         }
@@ -29,7 +28,7 @@ namespace NebulaModel.Networking
             }
             else
             {
-                Log.Info($"Cannot send packet {packet?.GetType()} to a closed connection {peerSocket?.Url}");
+                Log.Warn($"Cannot send packet {packet?.GetType()} to a closed connection {peerSocket?.Url}"); 
             }
         }
 
@@ -63,19 +62,12 @@ namespace NebulaModel.Networking
             {
                 return false;
             }
-            return Equals((NebulaConnection)obj);
+            return (obj as NebulaConnection).peerEndpoint.Equals(this.peerEndpoint);
         }
 
         public override int GetHashCode()
         {
-            return peerSocket == null ? 0 : ((string)webSocket_base64Key.GetValue(peerSocket)).GetHashCode();
-        }
-
-        protected bool Equals(NebulaConnection other)
-        {
-            return string.Equals((string)webSocket_base64Key.GetValue(peerSocket), (string)webSocket_base64Key.GetValue(other.peerSocket));
-            // TODO: Check if this works
-            //return peerSocket == other.peerSocket;
+            return peerEndpoint?.GetHashCode() ?? 0;
         }
     }
 }

--- a/NebulaModel/Packets/Session/HandshakeResponse.cs
+++ b/NebulaModel/Packets/Session/HandshakeResponse.cs
@@ -9,18 +9,16 @@ namespace NebulaModel.Packets.Session
         public int StarCount { get; set; }
         public float ResourceMultiplier { get; set; }
         public PlayerData LocalPlayerData { get; set; }
-        public PlayerData[] OtherPlayers { get; set; }
 
         public HandshakeResponse() { }
 
-        public HandshakeResponse(int algoVersion, int galaxySeed, int starCount, float resourceMultiplier, PlayerData localPlayerData, PlayerData[] otherPlayers)
+        public HandshakeResponse(int algoVersion, int galaxySeed, int starCount, float resourceMultiplier, PlayerData localPlayerData)
         {
             AlgoVersion = algoVersion;
             GalaxySeed = galaxySeed;
             StarCount = starCount;
             ResourceMultiplier = resourceMultiplier;
             LocalPlayerData = localPlayerData;
-            OtherPlayers = otherPlayers;
         }
     }
 }

--- a/NebulaModel/Packets/Session/SyncComplete.cs
+++ b/NebulaModel/Packets/Session/SyncComplete.cs
@@ -1,7 +1,15 @@
-﻿namespace NebulaModel.Packets.Session
+﻿using NebulaModel.DataStructures;
+
+namespace NebulaModel.Packets.Session
 {
     public class SyncComplete
     {
+        public PlayerData[] AllPlayers { get; set; }
 
+        public SyncComplete() { AllPlayers = new PlayerData[] { }; }
+        public SyncComplete(PlayerData[] otherPlayers)
+        {
+            AllPlayers = otherPlayers;
+        }
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/GameMain_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameMain_Patch.cs
@@ -7,9 +7,14 @@ namespace NebulaPatcher.Patches.Dynamic
     {
         public static bool Prefix()
         {
+            // TODO: We cannot really do that since it will prevent the Esc Menu from opening and the
+            // players won't be able to exit the game or change their game settings. We should instead
+            // Wopen the menu, but unpause the game under the hood.
+            return true;
+
             //Do not pause game in the multiplayer
             //Pausing game has to be done via: GameMain.instance._paused = true;
-            return !SimulatedWorld.Initialized;
+            //return !SimulatedWorld.Initialized;
         }
     }
 }

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -19,6 +19,7 @@ namespace NebulaWorld
 
         public static bool Initialized { get; private set; }
         public static bool IsGameLoaded { get; private set; }
+        public static bool IsPlayerJoining { get; set; }
 
         public static void Initialize()
         {
@@ -39,6 +40,24 @@ namespace NebulaWorld
             remotePlayersModels.Clear();
             Initialized = false;
             IsGameLoaded = false;
+            IsPlayerJoining = false;
+        }
+
+        public static void OnPlayerJoining()
+        {
+            if (!IsPlayerJoining)
+            {
+                IsPlayerJoining = true;
+                GameMain.Pause();
+                InGamePopup.ShowInfo("Loading", "Player joining the game, please wait", null);
+            }
+        }
+
+        public static void OnAllPlayersSyncCompleted()
+        {
+            IsPlayerJoining = false;
+            InGamePopup.FadeOut();
+            GameMain.Resume();
         }
 
         public static void UpdateGameState(GameState state)
@@ -53,8 +72,12 @@ namespace NebulaWorld
 
         public static void SpawnRemotePlayerModel(PlayerData playerData)
         {
-            RemotePlayerModel model = new RemotePlayerModel(playerData.PlayerId);
-            remotePlayersModels.Add(playerData.PlayerId, model);
+            if (!remotePlayersModels.ContainsKey(playerData.PlayerId))
+            {
+                RemotePlayerModel model = new RemotePlayerModel(playerData.PlayerId);
+                remotePlayersModels.Add(playerData.PlayerId, model);
+            }
+            
             UpdatePlayerColor(playerData.PlayerId, playerData.Color);
         }
 


### PR DESCRIPTION
### Fixes
- Fixed issue #63 when there was 2 players joining at the same time.
- Fixed thread safety issues with the `PlayerManager` that was throwing exceptions on the Host when a client disconnected.
- Fixed multiple "Pause" event that was called if 2 players were joining at the same time.

### Changes
- We now only send the `SyncCompleted` packet when ALL the syncing players are ready.
- We now send the list of already connected players in the `SyncCompleted` packet instead of being in the `HandshakeResponse`
- We now specify the peer `IPEndpoint` in the `NebulaConnection` to fix an issue when we were comparing 2 `NebulaConnection` after a socket disconnection.