### PR TITLE
fix for NRE at StationComponent.InternalTickRemote

### DIFF
--- a/NebulaClient/PacketProcessors/Planet/FactoryDataProcessor.cs
+++ b/NebulaClient/PacketProcessors/Planet/FactoryDataProcessor.cs
@@ -2,6 +2,7 @@
 using NebulaModel.Networking;
 using NebulaModel.Packets.Planet;
 using NebulaModel.Packets.Processors;
+using NebulaModel.Logger;
 using NebulaWorld;
 
 namespace NebulaClient.PacketProcessors.Planet
@@ -11,11 +12,35 @@ namespace NebulaClient.PacketProcessors.Planet
     {
         public void ProcessPacket(FactoryData packet, NebulaConnection conn)
         {
+            bool factoryJustForImport = false;
+
             LocalPlayer.PendingFactories.Add(packet.PlanetId, packet.BinaryData);
 
-            lock (PlanetModelingManager.fctPlanetReqList)
+            for(int i = 0; i < packet.PlanetIdsWithLogistics.Length && !LocalPlayer.IsMasterClient; i++)
             {
-                PlanetModelingManager.fctPlanetReqList.Enqueue(GameMain.galaxy.PlanetById(packet.PlanetId));
+                // if we have no loading queued and have not already loaded the factory data from server.
+                PlanetData pData = GameMain.galaxy.PlanetById(packet.PlanetIdsWithLogistics[i]);
+                if (!LocalPlayer.PendingFactories.ContainsKey(pData.id) && pData.factory == null && !pData.factoryLoading && !LocalPlayer.requestedAllLogistics)
+                {
+                    Log.Info($"Requested factory for planet (ID: {packet.PlanetIdsWithLogistics[i]}) from host because it contains logistic towers");
+                    LocalPlayer.SendPacket(new FactoryLoadRequest(packet.PlanetIdsWithLogistics[i]));
+                }
+                else if(packet.PlanetId == packet.PlanetIdsWithLogistics[i] && i != 0)
+                {
+                    // if its data for a factory we requested because of Logistics just import its data but do not really load it.
+                    // planet id at index 0 should always be the planet we spawn on so load it.
+                    GameMain.data.GetOrCreateFactory(pData);
+                    factoryJustForImport = true;
+                }
+            }
+            LocalPlayer.requestedAllLogistics = true;
+
+            if (!factoryJustForImport)
+            {
+                lock (PlanetModelingManager.fctPlanetReqList)
+                {
+                    PlanetModelingManager.fctPlanetReqList.Enqueue(GameMain.galaxy.PlanetById(packet.PlanetId));
+                }
             }
         }
     }

--- a/NebulaHost/PacketProcessors/Planet/FactoryLoadRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Planet/FactoryLoadRequestProcessor.cs
@@ -3,6 +3,7 @@ using NebulaModel.Attributes;
 using NebulaModel.Networking;
 using NebulaModel.Packets.Planet;
 using NebulaModel.Packets.Processors;
+using NebulaWorld;
 using System.IO;
 using System.IO.Compression;
 
@@ -25,7 +26,7 @@ namespace NebulaHost.PacketProcessors.Planet
                     factory.Export(bw);
                 }
 
-                conn.SendPacket(new FactoryData(packet.PlanetID, ms.ToArray()));
+                conn.SendPacket(new FactoryData(packet.PlanetID, ms.ToArray(), LocalPlayer.PlanetIdsWithLogistics.ToArray()));
             }
         }
     }

--- a/NebulaModel/Packets/Planet/FactoryData.cs
+++ b/NebulaModel/Packets/Planet/FactoryData.cs
@@ -1,15 +1,20 @@
-﻿namespace NebulaModel.Packets.Planet
+﻿using System;
+
+namespace NebulaModel.Packets.Planet
 {
     public class FactoryData
     {
         public int PlanetId { get; set; }
         public byte[] BinaryData { get; set; }
+        public int[] PlanetIdsWithLogistics { get; set; }
 
         public FactoryData() { }
-        public FactoryData(int id, byte[] data)
+        public FactoryData(int id, byte[] data, int[] PlanetIdsWithLogistics)
         {
             this.PlanetId = id;
             this.BinaryData = data;
+            this.PlanetIdsWithLogistics = new int[PlanetIdsWithLogistics.Length];
+            Array.Copy(PlanetIdsWithLogistics, this.PlanetIdsWithLogistics, PlanetIdsWithLogistics.Length);
         }
     }
 }

--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -40,6 +40,7 @@
     <Compile Include="Logger\BepInExLogger.cs" />
     <Compile Include="MonoBehaviours\NebulaBootstrapper.cs" />
     <Compile Include="NebulaPlugin.cs" />
+    <Compile Include="Patches\Dynamic\GalacticTransport_Patch.cs" />
     <Compile Include="Patches\Dynamic\PlanetFactory_Patch.cs" />
     <Compile Include="Patches\Dynamic\Debugging.cs" />
     <Compile Include="Patches\Dynamic\ArriveLeavePlanet_Patch.cs" />

--- a/NebulaPatcher/Patches/Dynamic/GalacticTransport_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GalacticTransport_Patch.cs
@@ -1,0 +1,21 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(GalacticTransport), "AddStationComponent")]
+    class GalacticTransport_Patch
+    {
+        public static void Postfix(int planetId, StationComponent station)
+        {
+            foreach(int i in LocalPlayer.PlanetIdsWithLogistics)
+            {
+                if(i == planetId)
+                {
+                    return;
+                }
+            }
+            LocalPlayer.PlanetIdsWithLogistics.Add(planetId);
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
@@ -5,7 +5,6 @@ using NebulaWorld;
 using System.Collections.Generic;
 using System.Linq;
 using NebulaModel.Packets.Universe;
-using UnityEngine;
 
 namespace NebulaPatcher.Patches.Dynamic
 {

--- a/NebulaWorld/LocalPlayer.cs
+++ b/NebulaWorld/LocalPlayer.cs
@@ -13,6 +13,8 @@ namespace NebulaWorld
         public static PlayerData Data { get; private set; }
         public static Dictionary<int, byte[]> PendingFactories { get; set; } = new Dictionary<int, byte[]>();
         public static Dictionary<PrebuildData, int> prebuildReceivedList { get; set; } = new Dictionary<PrebuildData, int>();
+        public static List<int> PlanetIdsWithLogistics { get; set; } = new List<int>();
+        public static bool requestedAllLogistics = false;
 
         private static INetworkProvider networkProvider;
 


### PR DESCRIPTION
This fixes #59 by requesting the needed `FactoryData` of Planets that contain ILS/PLS stations when joining the game.