### PR TITLE
Storage System Synchronization

### DIFF
--- a/NebulaClient/NebulaClient.csproj
+++ b/NebulaClient/NebulaClient.csproj
@@ -40,6 +40,10 @@
   <ItemGroup>
     <Compile Include="MultiplayerClientSession.cs" />
     <Compile Include="PacketProcessors\Factory\EntityPlacedProcessor.cs" />
+    <Compile Include="PacketProcessors\Factory\StorageSyncRealtimeChangeProcessor.cs" />
+    <Compile Include="PacketProcessors\Factory\StorageSyncResponseProcessor.cs" />
+    <Compile Include="PacketProcessors\Factory\StorageSyncSetBansProcessor.cs" />
+    <Compile Include="PacketProcessors\Factory\StorageSyncSortProcessor.cs" />
     <Compile Include="PacketProcessors\GameHistory\GameHistoryDataResponseProcessor.cs" />
     <Compile Include="PacketProcessors\GameHistory\GameHistoryEnqueueTechProcessor.cs" />
     <Compile Include="PacketProcessors\GameHistory\GameHistoryNotificationProcessor.cs" />

--- a/NebulaClient/PacketProcessors/Factory/StorageSyncRealtimeChangeProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/StorageSyncRealtimeChangeProcessor.cs
@@ -1,0 +1,42 @@
+﻿using NebulaModel.Networking;
+using NebulaModel.Packets.Factory;
+using NebulaModel.Packets.Processors;
+using NebulaWorld.Factory;
+using NebulaModel.Attributes;
+
+namespace NebulaClient.PacketProcessors.Factory
+{
+    [RegisterPacketProcessor]
+    class StorageSyncRealtimeChangeProcessor : IPacketProcessor<StorageSyncRealtimeChangePacket>
+    {
+        public void ProcessPacket(StorageSyncRealtimeChangePacket packet, NebulaConnection conn)
+        {
+            StorageComponent storageComponent = null;
+            StorageComponent[] pool = GameMain.localPlanet?.factory?.factoryStorage?.storagePool;
+            if (pool != null && packet.StorageIndex != -1 && packet.StorageIndex < pool.Length)
+            {
+                storageComponent = pool[packet.StorageIndex];
+            }
+
+            if (storageComponent != null)
+            {
+                StorageManager.EventFromServer = true;
+                int itemId = packet.ItemId;
+                int count = packet.Count;
+                if (packet.StorageEvent == StorageSyncRealtimeChangeEvent.AddItem2)
+                {
+                    storageComponent.AddItem(packet.ItemId, packet.Count, packet.StartIndex, packet.Length);
+                }
+                else if (packet.StorageEvent == StorageSyncRealtimeChangeEvent.AddItemStacked)
+                {
+                    storageComponent.AddItemStacked(packet.ItemId, packet.Count);
+                }
+                else if (packet.StorageEvent == StorageSyncRealtimeChangeEvent.TakeItemFromGrid)
+                {
+                    storageComponent.TakeItemFromGrid(packet.Length, ref itemId, ref count);
+                }
+                StorageManager.EventFromServer = false;
+            }
+        }
+    }
+}

--- a/NebulaClient/PacketProcessors/Factory/StorageSyncResponseProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/StorageSyncResponseProcessor.cs
@@ -1,0 +1,38 @@
+﻿using NebulaModel.Networking;
+using NebulaModel.Packets.Factory;
+using NebulaModel.Packets.Processors;
+using NebulaWorld.Factory;
+using NebulaModel.Attributes;
+using HarmonyLib;
+
+namespace NebulaClient.PacketProcessors.Factory
+{
+    [RegisterPacketProcessor]
+    class StorageSyncResponseProcessor : IPacketProcessor<StorageSyncResponsePacket>
+    {
+        public void ProcessPacket(StorageSyncResponsePacket packet, NebulaConnection conn)
+        {
+            StorageComponent storageComponent = GameMain.data.factories[packet.FactoryIndex]?.factoryStorage?.storagePool[packet.StorageIndex];
+            if (storageComponent != null) {
+                using (BinaryUtils.Reader reader = new BinaryUtils.Reader(packet.StorageComponent))
+                {
+                    storageComponent.Import(reader.BinaryReader);
+                }
+                ItemProto itemProto = LDB.items.Select((int)GameMain.data.factories[packet.FactoryIndex].entityPool[storageComponent.entityId].protoId);
+
+                //Imitation of UIStorageWindow.OnStorageIdChange()
+                StorageManager.ActiveWindowTitle.text = itemProto.name;
+                StorageManager.ActiveUIStorageGrid._Free();
+                StorageManager.ActiveUIStorageGrid._Init(storageComponent);
+                StorageManager.ActiveStorageComponent = storageComponent;
+                MethodInvoker.GetHandler(AccessTools.Method(typeof(UIStorageGrid), "SetStorageData")).Invoke(StorageManager.ActiveUIStorageGrid, StorageManager.ActiveStorageComponent);
+                StorageManager.ActiveUIStorageGrid._Open();
+                StorageManager.ActiveUIStorageGrid.OnStorageDataChanged();
+                StorageManager.ActiveBansSlider.maxValue = (float)storageComponent.size; 
+                StorageManager.ActiveBansSlider.value = (float)(storageComponent.size - storageComponent.bans);
+                StorageManager.ActiveBansValueText.text = StorageManager.ActiveBansSlider.value.ToString();
+                GameMain.data.factories[packet.FactoryIndex].factoryStorage.storagePool[packet.StorageIndex] = storageComponent;
+            }
+        }
+    }
+}

--- a/NebulaClient/PacketProcessors/Factory/StorageSyncSetBansProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/StorageSyncSetBansProcessor.cs
@@ -1,0 +1,29 @@
+﻿using NebulaModel.Networking;
+using NebulaModel.Packets.Factory;
+using NebulaModel.Packets.Processors;
+using NebulaWorld.Factory;
+using NebulaModel.Attributes;
+
+namespace NebulaClient.PacketProcessors.Factory
+{
+    [RegisterPacketProcessor]
+    class StorageSyncSetBansProcessor : IPacketProcessor<StorageSyncSetBansPacket>
+    {
+        public void ProcessPacket(StorageSyncSetBansPacket packet, NebulaConnection conn)
+        {
+            StorageComponent storage = null;
+            StorageComponent[] pool = GameMain.localPlanet?.factory?.factoryStorage?.storagePool;
+            if (pool != null && packet.StorageIndex != -1 && packet.StorageIndex < pool.Length)
+            {
+                storage = pool[packet.StorageIndex];
+            }
+
+            if (storage != null)
+            {
+                StorageManager.EventFromClient = true;
+                storage.SetBans(packet.Bans);
+                StorageManager.EventFromClient = false;
+            }
+        }
+    }
+}

--- a/NebulaClient/PacketProcessors/Factory/StorageSyncSortProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/StorageSyncSortProcessor.cs
@@ -1,0 +1,29 @@
+﻿using NebulaModel.Networking;
+using NebulaModel.Packets.Factory;
+using NebulaModel.Packets.Processors;
+using NebulaWorld.Factory;
+using NebulaModel.Attributes;
+
+namespace NebulaClient.PacketProcessors.Factory
+{
+    [RegisterPacketProcessor]
+    class StorageSyncSortProcessor : IPacketProcessor<StorageSyncSortPacket>
+    {
+        public void ProcessPacket(StorageSyncSortPacket packet, NebulaConnection conn)
+        {
+            StorageComponent storage = null;
+            StorageComponent[] pool = GameMain.localPlanet?.factory?.factoryStorage?.storagePool;
+            if (pool != null && packet.StorageIndex != -1 && packet.StorageIndex < pool.Length)
+            {
+                storage = pool[packet.StorageIndex];
+            }
+
+            if (storage != null)
+            {
+                StorageManager.EventFromClient = true;
+                storage.Sort();
+                StorageManager.EventFromClient = false;
+            }
+        }
+    }
+}

--- a/NebulaHost/NebulaHost.csproj
+++ b/NebulaHost/NebulaHost.csproj
@@ -41,6 +41,10 @@
   <ItemGroup>
     <Compile Include="MultiplayerHostSession.cs" />
     <Compile Include="PacketProcessors\Factory\EntityPlacedProcessor.cs" />
+    <Compile Include="PacketProcessors\Factory\StorageSyncRealtimeChangeProcessor.cs" />
+    <Compile Include="PacketProcessors\Factory\StorageSyncRequestProcessor.cs" />
+    <Compile Include="PacketProcessors\Factory\StorageSyncSetBansProcessor.cs" />
+    <Compile Include="PacketProcessors\Factory\StorageSyncSortProcessor.cs" />
     <Compile Include="PacketProcessors\GameHistory\GameHistoryDataRequestProcessor.cs" />
     <Compile Include="PacketProcessors\GameHistory\GameHistoryEnqueueTechProcessor.cs" />
     <Compile Include="PacketProcessors\GameHistory\GameHistoryNotificationProcessor.cs" />
@@ -69,6 +73,7 @@
     <Compile Include="Player.cs" />
     <Compile Include="PlayerManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StorageSyncManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NebulaModel\NebulaModel.csproj">

--- a/NebulaHost/PacketProcessors/Factory/StorageSyncRealtimeChangeProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/StorageSyncRealtimeChangeProcessor.cs
@@ -1,0 +1,46 @@
+﻿using NebulaModel.Networking;
+using NebulaModel.Packets.Factory;
+using NebulaModel.Packets.Processors;
+using NebulaWorld.Factory;
+using NebulaModel.Attributes;
+
+namespace NebulaHost.PacketProcessors.Factory
+{
+    [RegisterPacketProcessor]
+    class StorageSyncRealtimeChangeProcessor : IPacketProcessor<StorageSyncRealtimeChangePacket>
+    {
+        public void ProcessPacket(StorageSyncRealtimeChangePacket packet, NebulaConnection conn)
+        {
+            int itemId = packet.ItemId;
+            int count = packet.Count;
+
+            StorageComponent storage = null;
+            StorageComponent[] pool = GameMain.localPlanet?.factory?.factoryStorage?.storagePool;
+            if (pool != null && packet.StorageIndex != -1 && packet.StorageIndex < pool.Length)
+            {
+                storage = pool[packet.StorageIndex];
+            }
+
+            if (storage != null)
+            {
+                StorageManager.EventFromClient = true;
+                if (packet.StorageEvent == StorageSyncRealtimeChangeEvent.TakeItemFromGrid)
+                {
+                    storage.TakeItemFromGrid(packet.Length, ref itemId, ref count);
+                    StorageSyncManager.SendToOtherPlayersOnTheSamePlanet(conn, packet, packet.PlanetId);
+                }
+                else if (packet.StorageEvent == StorageSyncRealtimeChangeEvent.AddItem2)
+                {
+                    storage.AddItem(itemId, count, packet.StartIndex, packet.Length);
+                    StorageSyncManager.SendToOtherPlayersOnTheSamePlanet(conn, packet, packet.PlanetId);
+                }
+                else if (packet.StorageEvent == StorageSyncRealtimeChangeEvent.AddItemStacked)
+                {
+                    int result = storage.AddItemStacked(itemId, count);
+                    StorageSyncManager.SendToOtherPlayersOnTheSamePlanet(conn, packet, packet.PlanetId);
+                }
+                StorageManager.EventFromClient = false;
+            }
+        }
+    }
+}

--- a/NebulaHost/PacketProcessors/Factory/StorageSyncRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/StorageSyncRequestProcessor.cs
@@ -1,0 +1,29 @@
+﻿using NebulaModel.Networking;
+using NebulaModel.Packets.Factory;
+using NebulaModel.Packets.Processors;
+using NebulaModel.Attributes;
+using NebulaWorld.Factory;
+
+namespace NebulaHost.PacketProcessors.Factory
+{
+    [RegisterPacketProcessor]
+    class StorageSyncRequestProcessor : IPacketProcessor<StorageSyncRequestPacket>
+    {
+        public void ProcessPacket(StorageSyncRequestPacket packet, NebulaConnection conn)
+        {
+            if (GameMain.galaxy.PlanetById(packet.PlanetId) != null)
+            {
+                int factoryIndex = GameMain.galaxy.PlanetById(packet.PlanetId).factoryIndex;
+                StorageComponent storageComponent = GameMain.data.factories[factoryIndex]?.factoryStorage?.storagePool[packet.StorageId];
+                if (storageComponent != null)
+                {
+                    using (BinaryUtils.Writer writer = new BinaryUtils.Writer())
+                    {
+                        storageComponent.Export(writer.BinaryWriter);
+                        conn.SendPacket(new StorageSyncResponsePacket(factoryIndex, packet.StorageId, writer.CloseAndGetBytes()));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/NebulaHost/PacketProcessors/Factory/StorageSyncSetBansProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/StorageSyncSetBansProcessor.cs
@@ -1,0 +1,29 @@
+﻿using NebulaModel.Networking;
+using NebulaModel.Packets.Factory;
+using NebulaModel.Packets.Processors;
+using NebulaWorld.Factory;
+using NebulaModel.Attributes;
+
+namespace NebulaHost.PacketProcessors.Factory
+{
+    [RegisterPacketProcessor]
+    class StorageSyncSetBansProcessor : IPacketProcessor<StorageSyncSetBansPacket>
+    {
+        public void ProcessPacket(StorageSyncSetBansPacket packet, NebulaConnection conn)
+        {
+            StorageComponent storage = null;
+            StorageComponent[] pool = GameMain.localPlanet?.factory?.factoryStorage?.storagePool;
+            if (pool != null && packet.StorageIndex != -1 && packet.StorageIndex < pool.Length)
+            {
+                storage = pool[packet.StorageIndex];
+            }
+
+            if (storage != null)
+            {
+                StorageManager.EventFromClient = true;
+                storage.SetBans(packet.Bans);
+                StorageManager.EventFromClient = false;
+            }
+        }
+    }
+}

--- a/NebulaHost/PacketProcessors/Factory/StorageSyncSortProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/StorageSyncSortProcessor.cs
@@ -1,0 +1,29 @@
+﻿using NebulaModel.Networking;
+using NebulaModel.Packets.Factory;
+using NebulaModel.Packets.Processors;
+using NebulaWorld.Factory;
+using NebulaModel.Attributes;
+
+namespace NebulaHost.PacketProcessors.Factory
+{
+    [RegisterPacketProcessor]
+    class StorageSyncSortProcessor : IPacketProcessor<StorageSyncSortPacket>
+    {
+        public void ProcessPacket(StorageSyncSortPacket packet, NebulaConnection conn)
+        {
+            StorageComponent storage = null;
+            StorageComponent[] pool = GameMain.localPlanet?.factory?.factoryStorage?.storagePool;
+            if (pool != null && packet.StorageIndex != -1 && packet.StorageIndex < pool.Length)
+            {
+                storage = pool[packet.StorageIndex];
+            }
+
+            if (storage != null)
+            {
+                StorageManager.EventFromClient = true;
+                storage.Sort();
+                StorageManager.EventFromClient = false;
+            }
+        }
+    }
+}

--- a/NebulaHost/StorageSyncManager.cs
+++ b/NebulaHost/StorageSyncManager.cs
@@ -1,0 +1,25 @@
+﻿using NebulaModel.Networking;
+using System.Collections.Generic;
+
+namespace NebulaHost
+{
+    public static class StorageSyncManager
+    {
+        public static void SendToPlayersOnTheSamePlanet<T>(T packet, int planetId) where T : class, new()
+        {
+            SendToOtherPlayersOnTheSamePlanet(null, packet, planetId);
+        }
+
+        public static void SendToOtherPlayersOnTheSamePlanet<T>(NebulaConnection originator, T packet, int planetId) where T : class, new()
+        {
+            //Send to players on the same planet
+            foreach(KeyValuePair<NebulaConnection, Player> player in MultiplayerHostSession.Instance.PlayerManager.ConnectedPlayers)
+            {
+                if (player.Value.Data.LocalPlanetId == planetId && player.Key != originator)
+                {
+                    player.Key.SendPacket(packet);
+                }
+            }
+        }
+    }
+}

--- a/NebulaModel/NebulaModel.csproj
+++ b/NebulaModel/NebulaModel.csproj
@@ -59,6 +59,11 @@
     <Compile Include="Networking\NebulaConnection.cs" />
     <Compile Include="Packets\Factory\EntityPlaced.cs" />
     <Compile Include="Networking\DisconnectionReason.cs" />
+    <Compile Include="Packets\Factory\StorageSyncRealtimeChangePacket.cs" />
+    <Compile Include="Packets\Factory\StorageSyncSetBansPacket.cs" />
+    <Compile Include="Packets\Factory\StorageSyncSortPacket.cs" />
+    <Compile Include="Packets\Factory\StorageSyncRequestPacket.cs" />
+    <Compile Include="Packets\Factory\StorageSyncResponsePacket.cs" />
     <Compile Include="Packets\GameHistory\GameHistoryDataRequest.cs" />
     <Compile Include="Packets\GameHistory\GameHistoryDataResponse.cs" />
     <Compile Include="Packets\GameHistory\GameHistoryEnqueueTechPacket.cs" />

--- a/NebulaModel/Packets/Factory/StorageSyncRealtimeChangePacket.cs
+++ b/NebulaModel/Packets/Factory/StorageSyncRealtimeChangePacket.cs
@@ -1,0 +1,86 @@
+﻿namespace NebulaModel.Packets.Factory
+{
+    public class StorageSyncRealtimeChangePacket
+    {
+        public StorageSyncRealtimeChangeEvent StorageEvent { get; set; }
+        public int ItemId { get; set; }
+        public int Count { get; set; }
+        public bool UseBan { get; set; }
+        public int StartIndex { get; set; }
+        public int Length { get; set; }
+        public int[] Needs { get; set; }
+        public int StorageIndex { get; set; }
+        public int FactoryIndex { get; set; }
+        public int PlanetId { get; set; }
+
+        public StorageSyncRealtimeChangePacket() { }
+
+        public StorageSyncRealtimeChangePacket(int storageIndex, StorageSyncRealtimeChangeEvent storageEvent, int itemId, int count)
+        {
+            StorageEvent = storageEvent;
+            ItemId = itemId;
+            Count = count;
+            StorageIndex = storageIndex;
+            FactoryIndex = GameMain.localPlanet?.factoryIndex ?? -1;
+            PlanetId = GameMain.localPlanet?.id ?? -1;
+        }
+
+        public StorageSyncRealtimeChangePacket(int storageIndex, StorageSyncRealtimeChangeEvent storageEvent, int itemId, int count, bool useBan)
+        {
+            StorageEvent = storageEvent;
+            ItemId = itemId;
+            Count = count;
+            UseBan = useBan;
+            StorageIndex = storageIndex;
+            FactoryIndex = GameMain.localPlanet?.factoryIndex ?? -1;
+            PlanetId = GameMain.localPlanet?.id ?? -1;
+        }
+
+        public StorageSyncRealtimeChangePacket(int storageIndex, StorageSyncRealtimeChangeEvent storageEvent, int itemId, int count, int[] needs, bool useBan)
+        {
+            StorageEvent = storageEvent;
+            ItemId = itemId;
+            Count = count;
+            Needs = needs;
+            UseBan = useBan;
+            StorageIndex = storageIndex;
+            FactoryIndex = GameMain.localPlanet?.factoryIndex ?? -1;
+            PlanetId = GameMain.localPlanet?.id ?? -1;
+        }
+
+        public StorageSyncRealtimeChangePacket(int storageIndex, StorageSyncRealtimeChangeEvent storageEvent, int gridIndex, int itemId, int count)
+        {
+            StorageEvent = storageEvent;
+            ItemId = itemId;
+            Count = count;
+            Length = gridIndex;
+            StorageIndex = storageIndex;
+            FactoryIndex = GameMain.localPlanet?.factoryIndex ?? -1;
+            PlanetId = GameMain.localPlanet?.id ?? -1;
+        }
+
+        public StorageSyncRealtimeChangePacket(int storageIndex, StorageSyncRealtimeChangeEvent storageEvent, int itemId, int count, int startIndex, int length)
+        {
+            StorageEvent = storageEvent;
+            ItemId = itemId;
+            Count = count;
+            StartIndex = startIndex;
+            Length = length;
+            StorageIndex = storageIndex;
+            FactoryIndex = GameMain.localPlanet?.factoryIndex ?? -1;
+            PlanetId = GameMain.localPlanet?.id ?? -1;
+        }
+    }
+
+    public enum StorageSyncRealtimeChangeEvent
+    {
+        AddItem1 = 1,
+        AddItem2 = 2,
+        AddItemStacked = 3,
+        TakeItem = 4,
+        TakeItemFromGrid = 5,
+        TakeHeadItems = 6,
+        TakeTailItems1 = 7,
+        TakeTailItems2 = 8
+    }
+}

--- a/NebulaModel/Packets/Factory/StorageSyncRequestPacket.cs
+++ b/NebulaModel/Packets/Factory/StorageSyncRequestPacket.cs
@@ -1,0 +1,16 @@
+﻿namespace NebulaModel.Packets.Factory
+{
+    public class StorageSyncRequestPacket
+    {
+        public int PlanetId { get; set; }
+        public int StorageId { get; set; }
+
+        public StorageSyncRequestPacket() { }
+
+        public StorageSyncRequestPacket(int planetId, int storageId)
+        {
+            PlanetId = planetId;
+            StorageId = storageId;
+        }
+    }
+}

--- a/NebulaModel/Packets/Factory/StorageSyncResponsePacket.cs
+++ b/NebulaModel/Packets/Factory/StorageSyncResponsePacket.cs
@@ -1,0 +1,18 @@
+﻿namespace NebulaModel.Packets.Factory
+{
+    public class StorageSyncResponsePacket
+    {
+        public byte[] StorageComponent { get; set; }
+        public int FactoryIndex { get; set; }
+        public int StorageIndex { get; set; }
+
+        public StorageSyncResponsePacket() { }
+
+        public StorageSyncResponsePacket(int factoryIndex, int storageIndex, byte[] storageComponent)
+        {
+            StorageIndex = storageIndex;
+            StorageComponent = storageComponent;
+            FactoryIndex = factoryIndex;
+        }
+    }
+}

--- a/NebulaModel/Packets/Factory/StorageSyncSetBansPacket.cs
+++ b/NebulaModel/Packets/Factory/StorageSyncSetBansPacket.cs
@@ -1,0 +1,18 @@
+﻿namespace NebulaModel.Packets.Factory
+{
+    public class StorageSyncSetBansPacket
+    {
+        public int StorageIndex { get; set; }
+        public int FactoryIndex { get; set; }
+        public int Bans { get; set; }
+
+        public StorageSyncSetBansPacket() { }
+
+        public StorageSyncSetBansPacket(int storageIndex, int factoryIndex, int bans)
+        {
+            StorageIndex = storageIndex;
+            FactoryIndex = factoryIndex;
+            Bans = bans;
+        }
+    }
+}

--- a/NebulaModel/Packets/Factory/StorageSyncSortPacket.cs
+++ b/NebulaModel/Packets/Factory/StorageSyncSortPacket.cs
@@ -1,0 +1,16 @@
+﻿namespace NebulaModel.Packets.Factory
+{
+    public class StorageSyncSortPacket
+    {
+        public int StorageIndex { get; set; }
+        public int FactoryIndex { get; set; }
+
+        public StorageSyncSortPacket() { }
+
+        public StorageSyncSortPacket(int storageIndex, int factoryIndex)
+        {
+            StorageIndex = storageIndex;
+            FactoryIndex = factoryIndex;
+        }
+    }
+}

--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -58,8 +58,10 @@
     <Compile Include="Patches\Dynamic\GuideMissionStandardMode_Patch.cs" />
     <Compile Include="Patches\Dynamic\PlanetModelingManager_Patch.cs" />
     <Compile Include="Patches\Dynamic\ProductionStatistics_Patch.cs" />
+    <Compile Include="Patches\Dynamic\StorageComponent_Patch.cs" />
     <Compile Include="Patches\Dynamic\UIProductionStatWindow_Patch.cs" />
     <Compile Include="Patches\Dynamic\UIPowerGizmo_OnUpdate_Patch.cs" />
+    <Compile Include="Patches\Dynamic\UIStorageWindow_Patch.cs" />
     <Compile Include="Patches\Transpilers\PlayerAction_Mine_Patch.cs" />
     <Compile Include="Patches\Dynamic\UIEscMenu_Patch.cs" />
     <Compile Include="Patches\Dynamic\UIMainMenu_Patch.cs" />

--- a/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using NebulaModel.Packets.Factory;
 using NebulaWorld;
+using NebulaWorld.Factory;
 using UnityEngine;
 
 namespace NebulaPatcher.Patches.Dynamic
@@ -40,6 +41,21 @@ namespace NebulaPatcher.Patches.Dynamic
             }
             OnEntityPlaced(prebuild.protoId, prebuild.pos, prebuild.rot, true);
             return true;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("GameTick")]
+        public static bool InternalUpdate_Prefix()
+        {
+            StorageManager.IsHumanInput = false;
+            return true;
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch("GameTick")]
+        public static void InternalUpdate_Postfix()
+        {
+            StorageManager.IsHumanInput = true;
         }
 
         private static void OnEntityPlaced(short protoId, Vector3 pos, Quaternion rot, bool isPrebuild)

--- a/NebulaPatcher/Patches/Dynamic/StorageComponent_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/StorageComponent_Patch.cs
@@ -1,0 +1,88 @@
+﻿using HarmonyLib;
+using NebulaModel.Packets.Factory;
+using NebulaWorld;
+using NebulaWorld.Factory;
+using System;
+using NebulaHost;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(StorageComponent))]
+    class StorageComponent_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch("AddItem", new Type[] { typeof(int), typeof(int), typeof(int), typeof(int) })]
+        public static bool AddItem_Prefix(StorageComponent __instance, int itemId, int count, int startIndex, int length)
+        {
+            //Run only in MP, if it is not triggered remotly and if this event was triggered manually by an user
+            if (SimulatedWorld.Initialized && !StorageManager.EventFromServer && !StorageManager.EventFromClient && StorageManager.IsHumanInput)
+            {
+                HandleUserInteraction(__instance, new StorageSyncRealtimeChangePacket(__instance.id, StorageSyncRealtimeChangeEvent.AddItem2, itemId, count, startIndex, length));
+            }
+            return true;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("AddItemStacked")]
+        public static bool AddItemStacked_Prefix(StorageComponent __instance, int itemId, int count)
+        {
+            //Run only in MP, if it is not triggered remotly and if this event was triggered manually by an user
+            if (SimulatedWorld.Initialized && !StorageManager.EventFromServer && !StorageManager.EventFromClient && StorageManager.IsHumanInput)
+            {
+                HandleUserInteraction(__instance, new StorageSyncRealtimeChangePacket(__instance.id, StorageSyncRealtimeChangeEvent.AddItemStacked, itemId, count));
+            }
+            return true;
+
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("TakeItemFromGrid")]
+        public static bool TakeItemFromGrid_Prefix(StorageComponent __instance, int gridIndex, ref int itemId, ref int count)
+        {
+            //Run only in MP, if it is not triggered remotly and if this event was triggered manually by an user
+            if (SimulatedWorld.Initialized && !StorageManager.EventFromServer && !StorageManager.EventFromClient && StorageManager.IsHumanInput)
+            {
+                HandleUserInteraction(__instance, new StorageSyncRealtimeChangePacket(__instance.id, StorageSyncRealtimeChangeEvent.TakeItemFromGrid, gridIndex, itemId, count));
+            }
+            return true;
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch("SetBans")]
+        public static void SetBans_Postfix(StorageComponent __instance, int _bans)
+        {
+            if (SimulatedWorld.Initialized && !StorageManager.EventFromServer && !StorageManager.EventFromClient)
+            {
+                HandleUserInteraction(__instance, new StorageSyncSetBansPacket(__instance.id, GameMain.data.localPlanet.factoryIndex, _bans));
+            }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch("Sort")]
+        public static void Sort_Postfix(StorageComponent __instance)
+        {
+            if (SimulatedWorld.Initialized && !StorageManager.EventFromServer && !StorageManager.EventFromClient)
+            {
+                HandleUserInteraction(__instance, new StorageSyncSortPacket(__instance.id, GameMain.data.localPlanet.factoryIndex));
+            }
+        }
+
+        public static void HandleUserInteraction<T>(StorageComponent __instance, T packet) where T : class, new()
+        {
+            //Skip if change was done in player's inventory
+            if (__instance.entityId == 0 && __instance.id == 0)
+            {
+                return;
+            }
+
+            if (LocalPlayer.IsMasterClient)
+            {
+                StorageSyncManager.SendToPlayersOnTheSamePlanet(packet, GameMain.data.localPlanet.id);
+            }
+            else
+            {
+                LocalPlayer.SendPacket(packet);
+            }
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/UIStorageWindow_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIStorageWindow_Patch.cs
@@ -1,0 +1,51 @@
+﻿using HarmonyLib;
+using NebulaModel.Packets.Factory;
+using NebulaWorld;
+using NebulaWorld.Factory;
+using UnityEngine.UI;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(UIStorageWindow))]
+    class UIStorageWindow_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch("OnStorageIdChange")]
+        public static bool OnStorageIdChange_Prefix(UIStorageWindow __instance)
+        {
+            if (SimulatedWorld.Initialized && !LocalPlayer.IsMasterClient && StorageManager.WindowOpened)
+            {
+                UIStorageGrid storageUI = (UIStorageGrid)AccessTools.Field(typeof(UIStorageWindow), "storageUI").GetValue(__instance);
+                StorageManager.ActiveUIStorageGrid = storageUI;
+                Text titleText = (Text)AccessTools.Field(typeof(UIStorageWindow), "titleText").GetValue(__instance);
+                StorageManager.ActiveStorageComponent = __instance.factoryStorage.storagePool[__instance.storageId];
+                StorageManager.ActiveWindowTitle = titleText;
+                StorageManager.ActiveBansSlider = (Slider)AccessTools.Field(typeof(UIStorageWindow), "bansSlider").GetValue(__instance);
+                StorageManager.ActiveBansValueText = (Text)AccessTools.Field(typeof(UIStorageWindow), "bansValueText").GetValue(__instance);
+                titleText.text = "Loading...";
+                storageUI._Free();
+                storageUI._Open();
+                storageUI.OnStorageDataChanged();
+                LocalPlayer.SendPacket(new StorageSyncRequestPacket(GameMain.data.localPlanet.id, __instance.storageId));
+                return false;
+            }
+            return true;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("_OnOpen")]
+        public static bool _OnOpen_Prefix()
+        {
+            StorageManager.WindowOpened = true;
+            return true;
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch("_OnClose")]
+        public static void _OnClose_Prefix()
+        {
+            StorageManager.WindowOpened = false;
+            StorageManager.ActiveStorageComponent = null;
+        }
+    }
+}

--- a/NebulaWorld/Factory/StorageManager.cs
+++ b/NebulaWorld/Factory/StorageManager.cs
@@ -1,0 +1,18 @@
+﻿using UnityEngine.UI;
+
+namespace NebulaWorld.Factory
+{
+    public static class StorageManager
+    {
+        public static StorageComponent ActiveStorageComponent;
+        public static UIStorageGrid ActiveUIStorageGrid;
+        public static Text ActiveWindowTitle;
+        public static Slider ActiveBansSlider;
+        public static Text ActiveBansValueText;
+
+        public static bool WindowOpened = false;
+        public static bool EventFromServer = false;
+        public static bool EventFromClient = false;
+        public static bool IsHumanInput = false;
+    }
+}

--- a/NebulaWorld/NebulaWorld.csproj
+++ b/NebulaWorld/NebulaWorld.csproj
@@ -40,6 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Factory\EntityManager.cs" />
+    <Compile Include="Factory\StorageManager.cs" />
     <Compile Include="GameDataHistory\GameDataHistoryManager.cs" />
     <Compile Include="INetworkProvider.cs" />
     <Compile Include="InGamePopup.cs" />


### PR DESCRIPTION
This is part of the #101 .

The following has been synchronized:

- When a user clicks on the storage, the loading message is displayed in the storage window. Once the server replies with the storage data, the loading message is replaced with the actual inventory.
  ![img](https://media.discordapp.net/attachments/823320768086671427/828283067965112360/unknown.png)
- If any user or host makes some storage transfer, the event is broadcasted to everyone on the same planet. 
- Storage inventory sorting
- Setting storage filter (maximum amount of items that can inserter insert.)

Video on [youtube](https://youtu.be/Vat8kwPUXrI).