### PR TITLE
Prebuilds Sync

### DIFF
--- a/NebulaClient/NebulaClient.csproj
+++ b/NebulaClient/NebulaClient.csproj
@@ -42,6 +42,7 @@
     <Compile Include="PacketProcessors\Factory\Assembler\AssemblerRecipeEventProcessor.cs" />
     <Compile Include="PacketProcessors\Factory\Assembler\AssemblerUpdateProducesProcessor.cs" />
     <Compile Include="PacketProcessors\Factory\Assembler\AssemblerUpdateStorageProcessor.cs" />
+    <Compile Include="PacketProcessors\Factory\CreatePrebuildsRequestProcessor.cs" />
     <Compile Include="PacketProcessors\Factory\Ejector\EjectorOrbitUpdateProcessor.cs" />
     <Compile Include="PacketProcessors\Factory\Ejector\EjectorStorageUpdateProcessor.cs" />
     <Compile Include="PacketProcessors\Factory\Inserter\InserterFilterUpdateProcessor.cs" />

--- a/NebulaClient/PacketProcessors/Factory/CreatePrebuildsRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/CreatePrebuildsRequestProcessor.cs
@@ -1,0 +1,43 @@
+﻿using NebulaModel.Attributes;
+using NebulaModel.Networking;
+using NebulaModel.Packets.Factory;
+using NebulaModel.Packets.Processors;
+using NebulaWorld.Factory;
+using HarmonyLib;
+using System.Collections.Generic;
+
+namespace NebulaClient.PacketProcessors.Factory
+{
+    [RegisterPacketProcessor]
+    class CreatePrebuildsRequestProcessor : IPacketProcessor<CreatePrebuildsRequest>
+    {
+        public void ProcessPacket(CreatePrebuildsRequest packet, NebulaConnection conn)
+        {
+            PlayerAction_Build pab = GameMain.mainPlayer.controller?.actionBuild;
+            if (pab != null)
+            {
+                //Make backup of values that are overwritten
+                List<BuildPreview> tmpList = pab.buildPreviews;
+                bool tmpConfirm = pab.waitConfirm;
+                UnityEngine.Vector3 tmpPos = pab.previewPose.position;
+                UnityEngine.Quaternion tmpRot = pab.previewPose.rotation;
+
+                //Create Prebuilds from incomming packet
+                pab.buildPreviews = packet.GetBuildPreviews();
+                pab.waitConfirm = true;
+                FactoryManager.EventFromServer = true;
+                pab.previewPose.position = new UnityEngine.Vector3(packet.PosePosition.x, packet.PosePosition.y, packet.PosePosition.z);
+                pab.previewPose.rotation = new UnityEngine.Quaternion(packet.PoseRotation.x, packet.PoseRotation.y, packet.PoseRotation.z, packet.PoseRotation.w);
+                AccessTools.Field(typeof(PlayerAction_Build), "factory").SetValue(GameMain.mainPlayer.controller.actionBuild, GameMain.localPlanet.factory);
+                pab.CreatePrebuilds();
+                FactoryManager.EventFromServer = false;
+
+                //Revert changes back
+                pab.buildPreviews = tmpList;
+                pab.waitConfirm = tmpConfirm;
+                pab.previewPose.position = tmpPos;
+                pab.previewPose.rotation = tmpRot;
+            }
+        }
+    }
+}

--- a/NebulaHost/NebulaHost.csproj
+++ b/NebulaHost/NebulaHost.csproj
@@ -43,6 +43,7 @@
     <Compile Include="PacketProcessors\Factory\Assembler\AssemblerRecipeEventProcessor.cs" />
     <Compile Include="PacketProcessors\Factory\Assembler\AssemblerUpdateProducesProcessor.cs" />
     <Compile Include="PacketProcessors\Factory\Assembler\AssemblerUpdateStorageProcessor.cs" />
+    <Compile Include="PacketProcessors\Factory\CreatePrebuildsRequestProcessor.cs" />
     <Compile Include="PacketProcessors\Factory\Ejector\EjectorOrbitUpdateProcessor.cs" />
     <Compile Include="PacketProcessors\Factory\Ejector\EjectorStorageUpdateProcessor.cs" />
     <Compile Include="PacketProcessors\Factory\Inserter\InserterFilterUpdateProcessor.cs" />

--- a/NebulaHost/PacketProcessors/Factory/CreatePrebuildsRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/CreatePrebuildsRequestProcessor.cs
@@ -1,0 +1,42 @@
+﻿using NebulaModel.Attributes;
+using NebulaModel.Networking;
+using NebulaModel.Packets.Factory;
+using NebulaModel.Packets.Processors;
+using NebulaWorld.Factory;
+using HarmonyLib;
+using System.Collections.Generic;
+
+namespace NebulaHost.PacketProcessors.Factory
+{
+    [RegisterPacketProcessor]
+    class CreatePrebuildsRequestProcessor : IPacketProcessor<CreatePrebuildsRequest>
+    {
+        public void ProcessPacket(CreatePrebuildsRequest packet, NebulaConnection conn)
+        {
+            PlayerAction_Build pab = GameMain.mainPlayer.controller?.actionBuild;
+            if (pab != null) {
+                //Make backup of values that are overwritten
+                List<BuildPreview> tmpList = pab.buildPreviews;
+                bool tmpConfirm = pab.waitConfirm;
+                UnityEngine.Vector3 tmpPos = pab.previewPose.position;
+                UnityEngine.Quaternion tmpRot = pab.previewPose.rotation;
+
+                //Create Prebuilds from incomming packet
+                pab.buildPreviews = packet.GetBuildPreviews();
+                pab.waitConfirm = true;
+                FactoryManager.EventFromServer = true;
+                pab.previewPose.position = new UnityEngine.Vector3(packet.PosePosition.x, packet.PosePosition.y, packet.PosePosition.z);
+                pab.previewPose.rotation = new UnityEngine.Quaternion(packet.PoseRotation.x, packet.PoseRotation.y, packet.PoseRotation.z, packet.PoseRotation.w);
+                AccessTools.Field(typeof(PlayerAction_Build), "factory").SetValue(GameMain.mainPlayer.controller.actionBuild, GameMain.localPlanet.factory);
+                pab.CreatePrebuilds();
+                FactoryManager.EventFromServer = false;
+
+                //Revert changes back
+                pab.buildPreviews = tmpList;
+                pab.waitConfirm = tmpConfirm;
+                pab.previewPose.position = tmpPos;
+                pab.previewPose.rotation = tmpRot;
+            }
+        }
+    }
+}

--- a/NebulaModel/NebulaModel.csproj
+++ b/NebulaModel/NebulaModel.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Networking\DisconnectionReason.cs" />
     <Compile Include="Packets\Factory\AddEntityPreviewRequest.cs" />
     <Compile Include="Packets\Factory\BuildEntityRequest.cs" />
+    <Compile Include="Packets\Factory\CreatePrebuildsRequest.cs" />
     <Compile Include="Packets\Factory\DestructEntityRequest.cs" />
     <Compile Include="Packets\Factory\Ejector\EjectorOrbitUpdatePacket.cs" />
     <Compile Include="Packets\Factory\Ejector\EjectorStorageUpdatePacket.cs" />

--- a/NebulaModel/Packets/Factory/CreatePrebuildsRequest.cs
+++ b/NebulaModel/Packets/Factory/CreatePrebuildsRequest.cs
@@ -1,0 +1,142 @@
+﻿using NebulaModel.DataStructures;
+using NebulaModel.Networking;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+namespace NebulaModel.Packets.Factory
+{
+    public class CreatePrebuildsRequest
+    {
+        public byte[] BuildPreviewData { get; set; }
+        public Float3 PosePosition { get; set; }
+        public Float4 PoseRotation { get; set; }
+        
+        public CreatePrebuildsRequest() { }
+
+        public CreatePrebuildsRequest(List<BuildPreview> buildPreviews, Pose pose)
+        {
+            PosePosition = new Float3(pose.position);
+            PoseRotation = new Float4(pose.rotation);
+            using (BinaryUtils.Writer writer = new BinaryUtils.Writer())
+            {
+                writer.BinaryWriter.Write(buildPreviews.Count);
+                for(int i = 0; i < buildPreviews.Count; i++)
+                {
+                    SerializeBuildPreview(buildPreviews[i], buildPreviews, writer.BinaryWriter);
+                }
+                BuildPreviewData = writer.CloseAndGetBytes();
+            }
+        }
+
+        public List<BuildPreview> GetBuildPreviews()
+        {
+            List<BuildPreview> result = new List<BuildPreview>();
+
+            using (BinaryUtils.Reader reader = new BinaryUtils.Reader(BuildPreviewData))
+            {
+                int previewCount = reader.BinaryReader.ReadInt32();
+                for (int i = 0; i < previewCount; i++)
+                {
+                    result.Add(new BuildPreview());
+                }
+                for (int i = 0; i < previewCount; i++)
+                {
+                    DeserializeBuildPreview(result[i], result, reader.BinaryReader);
+                }
+            }
+            return result;
+        }
+
+        private void DeserializeBuildPreview(BuildPreview buildPreview, List<BuildPreview> list, BinaryReader br)
+        {
+            int outputRef = br.ReadInt32();
+            buildPreview.output = outputRef == -1 ? null : list[outputRef];
+            int inputRef = br.ReadInt32();
+            buildPreview.input = inputRef == -1 ? null : list[inputRef];
+            buildPreview.objId = br.ReadInt32();
+            int num = br.ReadInt32();
+            buildPreview.nearestPowerObjId = num == 0 ? null : new int[num];
+            for (int i = 0; i < num; i++)
+            {
+                buildPreview.nearestPowerObjId[i] = br.ReadInt32();
+            }
+            buildPreview.coverObjId = br.ReadInt32();
+            buildPreview.willCover = br.ReadBoolean();
+            buildPreview.ignoreCollider = br.ReadBoolean();
+            buildPreview.outputObjId = br.ReadInt32();
+            buildPreview.inputObjId = br.ReadInt32();
+            buildPreview.outputToSlot = br.ReadInt32();
+            buildPreview.inputFromSlot = br.ReadInt32();
+            buildPreview.outputFromSlot = br.ReadInt32();
+            buildPreview.inputToSlot = br.ReadInt32();
+            buildPreview.outputOffset = br.ReadInt32();
+            buildPreview.inputOffset = br.ReadInt32();
+            buildPreview.recipeId = br.ReadInt32();
+            buildPreview.filterId = br.ReadInt32();
+            buildPreview.isConnNode = br.ReadBoolean();
+            buildPreview.desc = new PrefabDesc();
+            buildPreview.desc.modelIndex = br.ReadInt32();
+            buildPreview.item = new ItemProto();
+            buildPreview.item.ID = br.ReadInt32();
+            buildPreview.refCount = br.ReadInt32();
+            buildPreview.refArr = new int[buildPreview.refCount];
+            for (int i = 0; i < buildPreview.refCount; i++)
+            {
+                buildPreview.refArr[i] = br.ReadInt32();
+            }
+            buildPreview.lpos = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
+            buildPreview.lpos2 = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
+            buildPreview.lrot = new Quaternion(br.ReadSingle(), br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
+            buildPreview.lrot2 = new Quaternion(br.ReadSingle(), br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
+        }
+
+        private void SerializeBuildPreview(BuildPreview buildPreview, List<BuildPreview> list, BinaryWriter bw)
+        {
+            bw.Write(list.IndexOf(buildPreview.output));
+            bw.Write(list.IndexOf(buildPreview.input));
+            bw.Write(buildPreview.objId);
+            int num = buildPreview.nearestPowerObjId == null ? 0 : buildPreview.nearestPowerObjId.Length;
+            bw.Write(num);
+            for(int i = 0; i < num; i++)
+            {
+                bw.Write(buildPreview.nearestPowerObjId[i]);
+            }
+            bw.Write(buildPreview.coverObjId);
+            bw.Write(buildPreview.willCover);
+            bw.Write(buildPreview.ignoreCollider); 
+            bw.Write(buildPreview.outputObjId);
+            bw.Write(buildPreview.inputObjId);
+            bw.Write(buildPreview.outputToSlot);
+            bw.Write(buildPreview.inputFromSlot);
+            bw.Write(buildPreview.outputFromSlot);
+            bw.Write(buildPreview.inputToSlot);
+            bw.Write(buildPreview.outputOffset);
+            bw.Write(buildPreview.inputOffset);
+            bw.Write(buildPreview.recipeId);
+            bw.Write(buildPreview.filterId);
+            bw.Write(buildPreview.isConnNode);
+            bw.Write(buildPreview.desc.modelIndex);
+            bw.Write(buildPreview.item.ID);
+            bw.Write(buildPreview.refCount);
+            for (int i = 0; i < buildPreview.refCount; i++)
+            {
+                bw.Write(buildPreview.refArr[i]);
+            }
+            bw.Write(buildPreview.lpos.x);
+            bw.Write(buildPreview.lpos.y);
+            bw.Write(buildPreview.lpos.z);
+            bw.Write(buildPreview.lpos2.x);
+            bw.Write(buildPreview.lpos2.y);
+            bw.Write(buildPreview.lpos2.z);
+            bw.Write(buildPreview.lrot.x);
+            bw.Write(buildPreview.lrot.y);
+            bw.Write(buildPreview.lrot.z);
+            bw.Write(buildPreview.lrot.w);
+            bw.Write(buildPreview.lrot2.x);
+            bw.Write(buildPreview.lrot2.y);
+            bw.Write(buildPreview.lrot2.z);
+            bw.Write(buildPreview.lrot2.w);
+        }
+    }
+}

--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Patches\Dynamic\GPUInstancingManager_Patch.cs" />
     <Compile Include="Patches\Dynamic\GuideMissionStandardMode_Patch.cs" />
     <Compile Include="Patches\Dynamic\PlanetModelingManager_Patch.cs" />
+    <Compile Include="Patches\Dynamic\PlayerAction_Build_Patch.cs" />
     <Compile Include="Patches\Dynamic\ProductionStatistics_Patch.cs" />
     <Compile Include="Patches\Dynamic\SplitterComponent_Patch.cs" />
     <Compile Include="Patches\Dynamic\TrashContainer_Patch.cs" />
@@ -75,6 +76,8 @@
     <Compile Include="Patches\Dynamic\UISplitterWindow_Patch.cs" />
     <Compile Include="Patches\Dynamic\UIStorageWindow_Patch.cs" />
     <Compile Include="Patches\Dynamic\UITankWindow_Patch.cs" />
+    <Compile Include="Patches\Dynamic\VFInput_Patch.cs" />
+    <Compile Include="Patches\Transpilers\PlayerAction_Build_Patch.cs" />
     <Compile Include="Patches\Transpilers\PlayerAction_Mine_Patch.cs" />
     <Compile Include="Patches\Dynamic\UIEscMenu_Patch.cs" />
     <Compile Include="Patches\Dynamic\UIMainMenu_Patch.cs" />

--- a/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
@@ -9,27 +9,22 @@ namespace NebulaPatcher.Patches.Dynamic
     [HarmonyPatch(typeof(PlanetFactory))]
     class BuildFinally_patch
     {
-        [HarmonyPrefix]
-        [HarmonyPatch("AddPrebuildDataWithComponents")]
-        public static bool AddPrebuildDataWithComponents_Prefix(PlanetFactory __instance, PrebuildData prebuild)
-        {
-            if (!SimulatedWorld.Initialized)
-                return true;
+           [HarmonyPrefix]
+           [HarmonyPatch("AddPrebuildDataWithComponents")]
+           public static bool AddPrebuildDataWithComponents_Prefix(PlanetFactory __instance, PrebuildData prebuild)
+           {
+               if (!SimulatedWorld.Initialized)
+                   return true;
 
-            // If the host game called the method, we need to compute the PrebuildId ourself
-            if (LocalPlayer.IsMasterClient && !FactoryManager.EventFromClient)
-            {
-                int nextPrebuildId = FactoryManager.GetNextPrebuildId(__instance);
-                FactoryManager.SetPrebuildRequest(__instance.planetId, nextPrebuildId, LocalPlayer.PlayerId);
-            }
+               // If the host game called the method, we need to compute the PrebuildId ourself
+               if (LocalPlayer.IsMasterClient && !FactoryManager.EventFromClient)
+               {
+                   int nextPrebuildId = FactoryManager.GetNextPrebuildId(__instance);
+                   FactoryManager.SetPrebuildRequest(__instance.planetId, nextPrebuildId, LocalPlayer.PlayerId);
+               }
 
-            if (LocalPlayer.IsMasterClient || !FactoryManager.EventFromServer)
-            {
-                LocalPlayer.SendPacket(new AddEntityPreviewRequest(__instance.planetId, prebuild));
-            }
-
-            return LocalPlayer.IsMasterClient || FactoryManager.EventFromServer;
-        }
+               return true;
+           }
 
         [HarmonyPrefix]
         [HarmonyPatch("BuildFinally")]
@@ -59,7 +54,7 @@ namespace NebulaPatcher.Patches.Dynamic
 
             return LocalPlayer.IsMasterClient || FactoryManager.EventFromServer;
         }
-
+        
 
         [HarmonyPrefix]
         [HarmonyPatch("DestructFinally")]

--- a/NebulaPatcher/Patches/Dynamic/PlayerAction_Build_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlayerAction_Build_Patch.cs
@@ -1,0 +1,36 @@
+﻿using HarmonyLib;
+using NebulaModel.Packets.Factory;
+using NebulaWorld;
+using NebulaWorld.Factory;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(PlayerAction_Build))]
+    class PlayerAction_Build_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch("CreatePrebuilds")]
+        public static bool CreatePrebuilds_Prefix(PlayerAction_Build __instance)
+        {
+            if (__instance.waitConfirm && VFInput._buildConfirm.onDown && __instance.buildPreviews.Count > 0)
+            {
+                if (!SimulatedWorld.Initialized)
+                    return true;
+
+                //Host will just broadcast event to other players
+                if (LocalPlayer.IsMasterClient)
+                {
+                    LocalPlayer.SendPacketToLocalPlanet(new CreatePrebuildsRequest(__instance.buildPreviews, __instance.previewPose));
+                }
+
+                //If client builds, he need to first send request to the host and wait for reply
+                if (!LocalPlayer.IsMasterClient && !FactoryManager.EventFromServer)
+                {
+                    LocalPlayer.SendPacketToLocalPlanet(new CreatePrebuildsRequest(__instance.buildPreviews, __instance.previewPose));
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/VFInput_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/VFInput_Patch.cs
@@ -1,0 +1,21 @@
+﻿using HarmonyLib;
+using NebulaWorld.Factory;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(VFInput))]
+    class VFInput_Patch
+    {
+        [HarmonyPatch("_buildConfirm", MethodType.Getter)]
+        static bool Prefix(ref VFInput.InputValue __result)
+        {
+            if (FactoryManager.EventFromServer)
+            {
+                __result = default(VFInput.InputValue);
+                __result.onDown = true;
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Transpilers/PlayerAction_Build_Patch.cs
+++ b/NebulaPatcher/Patches/Transpilers/PlayerAction_Build_Patch.cs
@@ -1,0 +1,39 @@
+﻿using HarmonyLib;
+using NebulaWorld.Factory;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+
+namespace NebulaPatcher.Patches.Transpiler
+{
+    [HarmonyPatch(typeof(PlayerAction_Build))]
+    class PlayerAction_Build_Patch
+    {
+        [HarmonyTranspiler]
+        [HarmonyPatch("CreatePrebuilds")]
+        static IEnumerable<CodeInstruction> CreatePrebuilds_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var codes = new List<CodeInstruction>(instructions);
+
+            //Prevent spending items if user is not building
+            //insert:  if (!FactoryManager.EventFromServer)
+            //before check for resources to build
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (codes[i].operand?.ToString() == "System.Int32 coverObjId" &&
+                    codes[i + 1].opcode == OpCodes.Brfalse &&
+                    codes[i + 3].operand?.ToString() == "System.Boolean willCover" &&
+                    codes[i + 4].opcode == OpCodes.Brfalse &&
+                    codes[i + 6].operand?.ToString() == "ItemProto item")
+                {
+                    Label targetLabel = (Label)codes[i + 4].operand;
+                    codes.InsertRange(i - 1, new CodeInstruction[] {
+                        new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(FactoryManager), "get_EventFromServer")),
+                        new CodeInstruction(OpCodes.Brtrue_S, targetLabel)
+                        });
+                    break;
+                }
+            }
+            return codes;
+        }
+    }
+}


### PR DESCRIPTION
I have changed how Prebuilds is being synchronized:

1. When players click during building, he will send a list of `buildPreviews` to the host and the host will send it to all players.
2. I have to manually serialize and deserialize the `buildPreview` object.
3. Once the client receives the `buildPreviews`, it will call `CreatePrebuilds();` which will calculates all connections and final state/shape of the building.

Note: I have to add a transpiler to prevent taking items from the inventory if the player is not a builder but only a receiver.