### PR TITLE
Bug Fix: Save on exit

### DIFF
--- a/NebulaHost/MultiplayerHostSession.cs
+++ b/NebulaHost/MultiplayerHostSession.cs
@@ -43,6 +43,7 @@ namespace NebulaHost
             {
                 SaveManager.LoadServerData();
             }
+            SaveManager.SaveOnExit = true;
             PacketProcessor = new NetPacketProcessor();
             StatisticsManager = new StatisticsManager();
 

--- a/NebulaHost/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
@@ -44,6 +44,10 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                     planet.physics = new PlanetPhysics(planet);
                     planet.physics.Init();
                 }
+                if (AccessTools.Field(typeof(CargoTraffic), "beltRenderingBatch").GetValue(planet.factory.cargoTraffic) == null)
+                {
+                    planet.factory.cargoTraffic.CreateRenderingBatches();
+                }
                 pab.CreatePrebuilds();
                 FactoryManager.EventFromServer = false;
                 FactoryManager.EventFactory = null;

--- a/NebulaHost/SaveManager.cs
+++ b/NebulaHost/SaveManager.cs
@@ -12,6 +12,7 @@ namespace NebulaHost
         private const string FILE_EXTENSION = ".server";
         private static string lastFileName = "";
 
+        public static bool SaveOnExit = false;
         public static void SaveServerData(string saveName)
         {
             string path = GameConfig.gameSaveFolder + saveName + FILE_EXTENSION;
@@ -27,7 +28,7 @@ namespace NebulaHost
                 data.Value.Serialize(netDataWriter);
             }
             //Add host's data
-            netDataWriter.Put(CryptoUtils.GetCurrentUserPublicKeyHash());
+            netDataWriter.Put(CryptoUtils.GetCurrentUserPublicKeyHash()); 
             LocalPlayer.Data.Serialize(netDataWriter);
 
             File.WriteAllBytes(path, netDataWriter.Data);

--- a/NebulaPatcher/Patches/Dynamic/GameSave_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameSave_Patch.cs
@@ -11,9 +11,10 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPatch("SaveCurrentGame")]
         public static bool SaveCurrentGame_Prefix(string saveName)
         {
-            if (SimulatedWorld.Initialized && LocalPlayer.IsMasterClient)
+            if (SaveManager.SaveOnExit || SimulatedWorld.Initialized && LocalPlayer.IsMasterClient)
             {
                 SaveManager.SaveServerData(saveName);
+                SaveManager.SaveOnExit = false;
             }
 
             if (SimulatedWorld.Initialized && !LocalPlayer.IsMasterClient)


### PR DESCRIPTION
This is fix for the #117 

As mentioned, the server was not saving data, since on exit the `SimulatedWorld.Initialized` was already `false`.

```cs
if (SimulatedWorld.Initialized && LocalPlayer.IsMasterClient)
{
SaveManager.SaveServerData(saveName);
}
```

Now, it is working: [video](https://www.youtube.com/watch?v=CfTpamde0L0)