### PR TITLE
Bug Fixes + Prebuild Enhancement

### DIFF
--- a/NebulaClient/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
@@ -3,6 +3,7 @@ using NebulaModel.Attributes;
 using NebulaModel.Networking;
 using NebulaModel.Packets.Factory;
 using NebulaModel.Packets.Processors;
+using NebulaWorld;
 using NebulaWorld.Factory;
 using System.Collections.Generic;
 
@@ -30,6 +31,7 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                 UnityEngine.Vector3 tmpPos = pab.previewPose.position;
                 UnityEngine.Quaternion tmpRot = pab.previewPose.rotation;
                 PlanetFactory tmpFactory = (PlanetFactory)AccessTools.Field(typeof(PlayerAction_Build), "factory").GetValue(GameMain.mainPlayer.controller.actionBuild);
+                PlanetPhysics tmpPlanetPhysics = (PlanetPhysics)AccessTools.Field(typeof(PlayerAction_Build), "planetPhysics").GetValue(pab);
 
                 //Create Prebuilds from incomming packet
                 pab.buildPreviews = packet.GetBuildPreviews();
@@ -39,11 +41,37 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                 pab.previewPose.position = new UnityEngine.Vector3(packet.PosePosition.x, packet.PosePosition.y, packet.PosePosition.z);
                 pab.previewPose.rotation = new UnityEngine.Quaternion(packet.PoseRotation.x, packet.PoseRotation.y, packet.PoseRotation.z, packet.PoseRotation.w);
                 AccessTools.Field(typeof(PlayerAction_Build), "factory").SetValue(GameMain.mainPlayer.controller.actionBuild, planet.factory);
+                //Create temporary physics for spawning building's colliders
+                if (planet.physics == null)
+                {
+                    planet.physics = new PlanetPhysics(planet);
+                    planet.physics.Init();
+                }
+                    
+                //Take item from the inventory if player is author of the build
+                if (packet.AuthorId == LocalPlayer.PlayerId)
+                {
+                    foreach (BuildPreview buildPreview in pab.buildPreviews)
+                    {
+                        if (GameMain.mainPlayer.inhandItemId == buildPreview.item.ID && GameMain.mainPlayer.inhandItemCount > 0)
+                        {
+                            GameMain.mainPlayer.UseHandItems(1);
+                        }
+                        else
+                        {
+                            int num = 1;
+                            GameMain.mainPlayer.package.TakeTailItems(ref buildPreview.item.ID, ref num, false);
+                        }
+                    }
+                }
+
+                AccessTools.Field(typeof(PlayerAction_Build), "planetPhysics").SetValue(GameMain.mainPlayer.controller.actionBuild, planet.physics);
                 pab.CreatePrebuilds();
                 FactoryManager.EventFromServer = false;
                 FactoryManager.EventFactory = null;
 
                 //Revert changes back
+                AccessTools.Field(typeof(PlayerAction_Build), "planetPhysics").SetValue(GameMain.mainPlayer.controller.actionBuild, tmpPlanetPhysics);
                 AccessTools.Field(typeof(PlayerAction_Build), "factory").SetValue(GameMain.mainPlayer.controller.actionBuild, tmpFactory);
                 pab.buildPreviews = tmpList;
                 pab.waitConfirm = tmpConfirm;

--- a/NebulaClient/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
@@ -2,6 +2,7 @@
 using NebulaModel.Networking;
 using NebulaModel.Packets.Factory;
 using NebulaModel.Packets.Processors;
+using NebulaWorld;
 using NebulaWorld.Factory;
 
 namespace NebulaClient.PacketProcessors.Factory.Entity
@@ -12,13 +13,27 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
         public void ProcessPacket(DestructEntityRequest packet, NebulaConnection conn)
         {
             PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
-
             // We only execute the code if the client has loaded the factory at least once.
             // Else it will get it once it goes to the planet for the first time. 
             if (planet.factory != null)
             {
                 int protoId = 0;
                 FactoryManager.EventFromServer = true;
+                FactoryManager.DoNotAddItemsFromBuildingOnDestruct = packet.AuthorId != LocalPlayer.PlayerId;
+                if (packet.AuthorId == LocalPlayer.PlayerId)
+                {
+                    //I am author so I will take item as a building
+                    PlayerAction_Build pab = GameMain.mainPlayer.controller?.actionBuild;
+                    if (pab != null) {
+                        int itemId = (packet.ObjId > 0 ? LDB.items.Select((int)planet.factory.entityPool[packet.ObjId].protoId) : LDB.items.Select((int)planet.factory.prebuildPool[-packet.ObjId].protoId))?.ID ?? -1;
+                        //Todo: Check for the full accumulator building
+                        if (itemId != -1)
+                        {
+                            GameMain.mainPlayer.TryAddItemToPackage(itemId, 1, true, packet.ObjId);
+                            UIItemup.Up(itemId, 1);
+                        }
+                    }
+                }
                 planet.factory.DestructFinally(GameMain.mainPlayer, packet.ObjId, ref protoId);
                 FactoryManager.EventFromServer = false;
             }

--- a/NebulaHost/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
@@ -81,8 +81,6 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                 {
                     FactoryManager.PacketAuthor = packet.AuthorId;
                     pab.CreatePrebuilds();
-                    planet.physics.Update();
-                    planet.physics.GameTick();
                     FactoryManager.PacketAuthor = -1;
                     FactoryManager.EventFromServer = false;
                     FactoryManager.EventFactory = null;

--- a/NebulaHost/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
@@ -14,7 +14,11 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
             int protoId = 0;
             FactoryManager.EventFromClient = true;
             PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
+            FactoryManager.DoNotAddItemsFromBuildingOnDestruct = true;
+            FactoryManager.PacketAuthor = packet.AuthorId;
             planet.factory.DestructFinally(GameMain.mainPlayer, packet.ObjId, ref protoId);
+            FactoryManager.PacketAuthor = -1;
+            FactoryManager.DoNotAddItemsFromBuildingOnDestruct = false;
             FactoryManager.EventFromClient = false;
         }
     }

--- a/NebulaModel/Packets/Factory/CreatePrebuildsRequest.cs
+++ b/NebulaModel/Packets/Factory/CreatePrebuildsRequest.cs
@@ -12,11 +12,13 @@ namespace NebulaModel.Packets.Factory
         public byte[] BuildPreviewData { get; set; }
         public Float3 PosePosition { get; set; }
         public Float4 PoseRotation { get; set; }
+        public int AuthorId { get; set; }
 
         public CreatePrebuildsRequest() { }
 
-        public CreatePrebuildsRequest(int planetId, List<BuildPreview> buildPreviews, Pose pose)
+        public CreatePrebuildsRequest(int planetId, List<BuildPreview> buildPreviews, Pose pose, int playerId)
         {
+            AuthorId = playerId;
             PlanetId = planetId;
             PosePosition = new Float3(pose.position);
             PoseRotation = new Float4(pose.rotation);
@@ -79,8 +81,62 @@ namespace NebulaModel.Packets.Factory
             buildPreview.isConnNode = br.ReadBoolean();
             buildPreview.desc = new PrefabDesc();
             buildPreview.desc.modelIndex = br.ReadInt32();
+
+            //Import more data about the Prefab to properly validate the build condition on server-side
+            buildPreview.desc.isBelt = br.ReadBoolean();
+            buildPreview.desc.isInserter = br.ReadBoolean();
+            buildPreview.desc.oilMiner = br.ReadBoolean();
+            buildPreview.desc.isTank = br.ReadBoolean();
+            buildPreview.desc.isStorage = br.ReadBoolean();
+            buildPreview.desc.isLab = br.ReadBoolean();
+            buildPreview.desc.isSplitter = br.ReadBoolean();
+            buildPreview.desc.isPowerNode = br.ReadBoolean();
+            buildPreview.desc.isAccumulator = br.ReadBoolean();
+            buildPreview.desc.powerConnectDistance = br.ReadSingle();
+            buildPreview.desc.windForcedPower = br.ReadBoolean();
+            buildPreview.desc.isPowerGen = br.ReadBoolean();
+            buildPreview.desc.isCollectStation = br.ReadBoolean();
+            buildPreview.desc.stationCollectSpeed = br.ReadInt32();
+            buildPreview.desc.workEnergyPerTick = br.ReadInt64();
+            buildPreview.desc.isStation = br.ReadBoolean();
+            buildPreview.desc.isStellarStation = br.ReadBoolean();
+            buildPreview.desc.cullingHeight = br.ReadSingle();
+            buildPreview.desc.isEjector = br.ReadBoolean();
+            buildPreview.desc.multiLevel = br.ReadBoolean();
+            buildPreview.desc.veinMiner = br.ReadBoolean();
+
+            //Import information about the position of build (land / sea)
+            num = br.ReadInt32();
+            buildPreview.desc.landPoints = new Vector3[num];
+            for (int i = 0; i < num; i++)
+            {
+                buildPreview.desc.landPoints[i] = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
+            }
+            num = br.ReadInt32();
+            buildPreview.desc.waterPoints = new Vector3[num];
+            for (int i = 0; i < num; i++)
+            {
+                buildPreview.desc.waterPoints[i] = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
+            }
+
+            //Import information about the collider to check the collisions
+            buildPreview.desc.hasBuildCollider = br.ReadBoolean();
+            num = br.ReadInt32();
+            buildPreview.desc.buildColliders = new ColliderData[num];
+            for (int i = 0; i < num; i++)
+            {
+                buildPreview.desc.buildColliders[i].pos = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
+                buildPreview.desc.buildColliders[i].ext = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
+                buildPreview.desc.buildColliders[i].q = new Quaternion(br.ReadSingle(), br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
+                buildPreview.desc.buildColliders[i].radius = br.ReadSingle();
+                buildPreview.desc.buildColliders[i].idType = br.ReadInt32();
+                buildPreview.desc.buildColliders[i].link = br.ReadInt32();
+            }
+
             buildPreview.item = new ItemProto();
             buildPreview.item.ID = br.ReadInt32();
+            buildPreview.item.BuildMode = br.ReadInt32();
+
             buildPreview.refCount = br.ReadInt32();
             buildPreview.refArr = new int[buildPreview.refCount];
             for (int i = 0; i < buildPreview.refCount; i++)
@@ -119,7 +175,70 @@ namespace NebulaModel.Packets.Factory
             bw.Write(buildPreview.filterId);
             bw.Write(buildPreview.isConnNode);
             bw.Write(buildPreview.desc.modelIndex);
+
+            //Export more data about the Prefab to properly validate the build condition on server-side
+            bw.Write(buildPreview.desc.isBelt);
+            bw.Write(buildPreview.desc.isInserter);
+            bw.Write(buildPreview.desc.oilMiner);
+            bw.Write(buildPreview.desc.isTank);
+            bw.Write(buildPreview.desc.isStorage);
+            bw.Write(buildPreview.desc.isLab);
+            bw.Write(buildPreview.desc.isSplitter);
+            bw.Write(buildPreview.desc.isPowerNode);
+            bw.Write(buildPreview.desc.isAccumulator);
+            bw.Write(buildPreview.desc.powerConnectDistance);
+            bw.Write(buildPreview.desc.windForcedPower);
+            bw.Write(buildPreview.desc.isPowerGen);
+            bw.Write(buildPreview.desc.isCollectStation);
+            bw.Write(buildPreview.desc.stationCollectSpeed);
+            bw.Write(buildPreview.desc.workEnergyPerTick);
+            bw.Write(buildPreview.desc.isStation);
+            bw.Write(buildPreview.desc.isStellarStation);
+            bw.Write(buildPreview.desc.cullingHeight);
+            bw.Write(buildPreview.desc.isEjector);
+            bw.Write(buildPreview.desc.multiLevel);
+            bw.Write(buildPreview.desc.veinMiner);
+
+            //Export information about the position of build (land / sea)
+            num = buildPreview.desc.landPoints.Length;
+            bw.Write(num);
+            for (int i = 0; i < num; i++)
+            {
+                bw.Write(buildPreview.desc.landPoints[i].x);
+                bw.Write(buildPreview.desc.landPoints[i].y);
+                bw.Write(buildPreview.desc.landPoints[i].z);
+            }
+            num = buildPreview.desc.waterPoints.Length;
+            bw.Write(num);
+            for (int i = 0; i < num; i++)
+            {
+                bw.Write(buildPreview.desc.waterPoints[i].x);
+                bw.Write(buildPreview.desc.waterPoints[i].y);
+                bw.Write(buildPreview.desc.waterPoints[i].z);
+            }
+            //Export information about the collider to check the collisions
+            bw.Write(buildPreview.desc.hasBuildCollider);
+            num = buildPreview.desc.buildColliders.Length;
+            bw.Write(num);
+            for (int i = 0; i < num; i++)
+            {
+                bw.Write(buildPreview.desc.buildColliders[i].pos.x);
+                bw.Write(buildPreview.desc.buildColliders[i].pos.y);
+                bw.Write(buildPreview.desc.buildColliders[i].pos.z);
+                bw.Write(buildPreview.desc.buildColliders[i].ext.x);
+                bw.Write(buildPreview.desc.buildColliders[i].ext.y);
+                bw.Write(buildPreview.desc.buildColliders[i].ext.z);
+                bw.Write(buildPreview.desc.buildColliders[i].q.x);
+                bw.Write(buildPreview.desc.buildColliders[i].q.y);
+                bw.Write(buildPreview.desc.buildColliders[i].q.z);
+                bw.Write(buildPreview.desc.buildColliders[i].q.w);
+                bw.Write(buildPreview.desc.buildColliders[i].radius);
+                bw.Write(buildPreview.desc.buildColliders[i].idType);
+                bw.Write(buildPreview.desc.buildColliders[i].link);
+            }
+
             bw.Write(buildPreview.item.ID);
+            bw.Write(buildPreview.item.BuildMode);
             bw.Write(buildPreview.refCount);
             for (int i = 0; i < buildPreview.refCount; i++)
             {

--- a/NebulaModel/Packets/Factory/DestructEntityRequest.cs
+++ b/NebulaModel/Packets/Factory/DestructEntityRequest.cs
@@ -4,10 +4,12 @@
     {
         public int PlanetId { get; set; }
         public int ObjId { get; set; }
+        public int AuthorId { get; set; }
 
         public DestructEntityRequest() { }
-        public DestructEntityRequest(int planetId, int objId)
+        public DestructEntityRequest(int planetId, int objId, int authorId)
         {
+            AuthorId = authorId;
             PlanetId = planetId;
             ObjId = objId;
         }

--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Patches\Dynamic\UIStorageWindow_Patch.cs" />
     <Compile Include="Patches\Dynamic\UITankWindow_Patch.cs" />
     <Compile Include="Patches\Dynamic\VFInput_Patch.cs" />
+    <Compile Include="Patches\Transpilers\PlanetFactory_Patch.cs" />
     <Compile Include="Patches\Transpilers\PlayerAction_Build_Patch.cs" />
     <Compile Include="Patches\Transpilers\PlayerAction_Mine_Patch.cs" />
     <Compile Include="Patches\Dynamic\UIEscMenu_Patch.cs" />

--- a/NebulaPatcher/Patches/Dynamic/ArriveLeavePlanet_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/ArriveLeavePlanet_Patch.cs
@@ -57,6 +57,34 @@ namespace NebulaPatcher.Patches.Dynamic
                 return false;
             }
         }
+
+        public static bool RefreshMissingMeshes = false;
+
+        [HarmonyPostfix]
+        [HarmonyPatch("ArrivePlanet")]
+        public static void ArrivePlanet_Postfix(GameData __instance, PlanetData planet)
+        {
+            RefreshMissingMeshes = true;
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch("GameTick")]
+        public static void GameTick_Postfix(GameData __instance)
+        {
+            if (SimulatedWorld.Initialized && RefreshMissingMeshes && __instance.localPlanet != null)
+            {
+                PlanetData planetData = __instance.localPlanet;
+                for (int i = 0; i < planetData.meshColliders.Length; i++)
+                {
+                    if (planetData.meshColliders[i].sharedMesh == null)
+                    {
+                        planetData.meshColliders[i].sharedMesh = planetData.meshes[i];
+                    }
+                }
+                RefreshMissingMeshes = false;
+            }
+        }
+
     }
 }
 

--- a/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
@@ -79,7 +79,7 @@ namespace NebulaPatcher.Patches.Dynamic
 
             if (LocalPlayer.IsMasterClient || !FactoryManager.EventFromServer)
             {
-                LocalPlayer.SendPacket(new DestructEntityRequest(__instance.planetId, objId));
+                LocalPlayer.SendPacket(new DestructEntityRequest(__instance.planetId, objId, FactoryManager.PacketAuthor == -1 ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor));
             }
 
             return LocalPlayer.IsMasterClient || FactoryManager.EventFromServer;

--- a/NebulaPatcher/Patches/Dynamic/PlayerAction_Build_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlayerAction_Build_Patch.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using NebulaModel.Logger;
 using NebulaModel.Packets.Factory;
 using NebulaWorld;
 using NebulaWorld.Factory;
@@ -22,7 +23,7 @@ namespace NebulaPatcher.Patches.Dynamic
                 if (LocalPlayer.IsMasterClient)
                 {
                     int planetId = FactoryManager.EventFactory?.planetId ?? GameMain.localPlanet?.id ?? -1;
-                    LocalPlayer.SendPacket(new CreatePrebuildsRequest(planetId, __instance.buildPreviews, __instance.previewPose));
+                    LocalPlayer.SendPacket(new CreatePrebuildsRequest(planetId, __instance.buildPreviews, __instance.previewPose, FactoryManager.PacketAuthor == -1 ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor));
                 }
 
                 //If client builds, he need to first send request to the host and wait for reply
@@ -48,6 +49,11 @@ namespace NebulaPatcher.Patches.Dynamic
                                 __instance.player.package.TakeTailItems(ref id, ref num, false);
                             }
                             flag = (num == 1);
+                            if (flag)
+                            {
+                                //Give item back to player inventory and wait for the response from the server
+                                __instance.player.package.AddItem(id, num);
+                            }
                         }
                         if (flag)
                         {
@@ -55,11 +61,27 @@ namespace NebulaPatcher.Patches.Dynamic
                         }
                     }
 
-                    LocalPlayer.SendPacket(new CreatePrebuildsRequest(GameMain.localPlanet?.id ?? -1, canBuild, __instance.previewPose));
+                    LocalPlayer.SendPacket(new CreatePrebuildsRequest(GameMain.localPlanet?.id ?? -1, canBuild, __instance.previewPose, FactoryManager.PacketAuthor == -1 ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor));
                     return false;
                 }
             }
             return true;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("DoDestructObject")]
+        public static bool DoDestructObject_Prefix(PlayerAction_Build __instance, int objId)
+        {
+            if (!SimulatedWorld.Initialized)
+                return true;
+
+            //Clients needs to send destruction packet here
+            if (!LocalPlayer.IsMasterClient)
+            {
+                LocalPlayer.SendPacket(new DestructEntityRequest(__instance.player.planetId, objId, LocalPlayer.PlayerId));
+            }
+
+            return LocalPlayer.IsMasterClient || FactoryManager.EventFromServer;
         }
     }
 }

--- a/NebulaPatcher/Patches/Transpilers/PlanetFactory_Patch.cs
+++ b/NebulaPatcher/Patches/Transpilers/PlanetFactory_Patch.cs
@@ -1,0 +1,45 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+using NebulaWorld.Factory;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+
+namespace NebulaPatcher.Patches.Transpiler
+{
+    [HarmonyPatch(typeof(PlanetFactory))]
+    class PlanetFactory_Patch
+    {
+        /* Change:
+             this.TakeBackItemsInEntity(player, objId);
+         * 
+         * To:
+            if (!FactoryManager.DoNotAddItemsFromBuildingOnDestruct) {
+			    this.TakeBackItemsInEntity(player, objId);
+			}
+         */
+        [HarmonyTranspiler]
+        [HarmonyPatch("DestructFinally")]
+        static IEnumerable<CodeInstruction> DestructFinally_Transpiler(ILGenerator gen, IEnumerable<CodeInstruction> instructions)
+        {
+            var codes = new List<CodeInstruction>(instructions);
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (codes[i].opcode == OpCodes.Callvirt && codes[i].operand.ToString() == "Void NotifyObjectDestruct(EObjectType, Int32)" &&
+                    codes[i - 1].opcode == OpCodes.Ldloc_0 &&
+                    codes[i - 2].opcode == OpCodes.Ldc_I4_0 &&
+                    codes[i - 3].opcode == OpCodes.Ldfld)
+                {
+                    Label targetLabel = gen.DefineLabel();
+                    codes[i + 5].labels.Add(targetLabel);
+
+                    codes.InsertRange(i + 1, new CodeInstruction[] {
+                                    new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(FactoryManager), "get_DoNotAddItemsFromBuildingOnDestruct")),
+                                    new CodeInstruction(OpCodes.Brtrue_S, targetLabel),
+                                    });
+                    break;
+                }
+            }
+            return codes;
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Transpilers/PlayerAction_Build_Patch.cs
+++ b/NebulaPatcher/Patches/Transpilers/PlayerAction_Build_Patch.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using NebulaWorld.Factory;
+using System;
 using System.Collections.Generic;
 using System.Reflection.Emit;
 
@@ -33,6 +34,79 @@ namespace NebulaPatcher.Patches.Transpiler
                     break;
                 }
             }
+            return codes;
+        }
+
+
+        /* Insert:
+         * if (!FactoryManager.IgnoreBasicBuildConditionChecks) {...}
+         * for the inventory check and ground condition check
+         */
+        [HarmonyTranspiler]
+        [HarmonyPatch("CheckBuildConditions")]
+        static IEnumerable<CodeInstruction> CheckBuildConditions_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var codes = new List<CodeInstruction>(instructions);
+            
+            //Apply Ignoring of inventory check
+            for (int i = 5; i < codes.Count-2; i++)
+            {
+                if (codes[i].opcode == OpCodes.Ldfld && codes[i].operand?.ToString() == "System.Boolean willCover" &&
+                    codes[i + 1].opcode == OpCodes.Brfalse &&
+                    codes[i - 1].opcode == OpCodes.Ldloc_3 &&
+                    codes[i - 2].opcode == OpCodes.Brfalse &&
+                    codes[i - 3].opcode == OpCodes.Ldfld && codes[i - 3].operand?.ToString() == "System.Int32 coverObjId" &&
+                    codes[i - 4].opcode == OpCodes.Ldloc_3 &&
+                    codes[i - 5].opcode == OpCodes.Br &&
+                    codes[i + 2].opcode == OpCodes.Ldloc_3)
+                {
+                    Label targetLabel = (Label)codes[i + 1].operand;
+                    codes.InsertRange(i - 3, new CodeInstruction[] {
+                                    new CodeInstruction(OpCodes.Pop),
+                                    new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(FactoryManager), "get_IgnoreBasicBuildConditionChecks")),
+                                    new CodeInstruction(OpCodes.Brtrue_S, targetLabel),
+                                    new CodeInstruction(OpCodes.Ldloc_3)
+                                    });
+                    break;
+                }
+            }
+
+            //Apply ignoring of 3 ground checks
+            for (int i = 3; i < codes.Count-4; i++)
+            {
+                if (codes[i - 1].opcode == OpCodes.Ldc_I4_S &&
+                    codes[i].opcode == OpCodes.Stfld && codes[i].operand?.ToString() == "EBuildCondition condition" &&
+                    codes[i + 1].opcode == OpCodes.Br &&
+                    codes[i + 2].opcode == OpCodes.Ldloca_S && codes[i + 2].operand?.ToString() == "UnityEngine.RaycastHit (125)" &&
+                    codes[i + 3].opcode == OpCodes.Call &&
+                    codes[i + 4].opcode == OpCodes.Stloc_S)
+                {
+                    int numOfPathes = 3;
+                    for (int a = i; a < i+100; a++)
+                    {
+                        
+                        if (codes[a].opcode == OpCodes.Stfld && 
+                            codes[a].operand?.ToString() == "EBuildCondition condition" &&
+                            codes[a + 1].opcode == OpCodes.Br)
+                        {
+                            codes.InsertRange(a - 2, new CodeInstruction[] {
+                                new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(FactoryManager), "get_IgnoreBasicBuildConditionChecks")),
+                                new CodeInstruction(OpCodes.Brtrue_S, codes[a-3].operand),
+                            });
+                            a += 5;
+                            numOfPathes--;
+                            UnityEngine.Debug.Log($"{codes[a].opcode} - {codes[a].operand}");
+                            if (numOfPathes <= 0)
+                            {
+                                break;
+                            }
+                        }
+                        
+                    }
+                    break;
+                }
+            }
+
             return codes;
         }
     }

--- a/NebulaWorld/Factory/FactoryManager.cs
+++ b/NebulaWorld/Factory/FactoryManager.cs
@@ -11,12 +11,18 @@ namespace NebulaWorld.Factory
         public static bool EventFromServer { get; set; }
         public static bool EventFromClient { get; set; }
         public static PlanetFactory EventFactory { get; set; }
+        public static bool IgnoreBasicBuildConditionChecks { get; set; }
+        public static bool DoNotAddItemsFromBuildingOnDestruct { get; set; }
+        public static int PacketAuthor { get; set; }
 
         public static void Initialize()
         {
             prebuildRequests = new ThreadSafeDictionary<PrebuildOwnerKey, ushort>();
             EventFromServer = false;
             EventFromClient = false;
+            IgnoreBasicBuildConditionChecks = false;
+            DoNotAddItemsFromBuildingOnDestruct = false;
+            PacketAuthor = -1;
         }
 
         public static void SetPrebuildRequest(int planetId, int prebuildId, ushort playerId)


### PR DESCRIPTION
This PR contains bug fixes for:

- #132 **(All players will receive items in the storage of the building when it is destroyed.)**
  - I have added `AuthorId` value to the destroy request packet. Once the server confirms that the building is destroyed, the author will get its items.
  
- #127 **(Clients are able to duplicate buildings by destroying their prebuild with a double click.)**
  - Client is not getting the building item immediately upon click on the building. They have to wait for the confirmation packet from the server
 
- #115 **(Clients were able to stack research labs above the current stack limit.)**
  - Added a new implementation of validation if the client can build the building. The server test's the building placement by calling the original method `CheckBuildConditions()` and then it decides if the building packet should be confirmed or not.

- #94 **(sinking under the terrain bug)**
  - Added null check for mesh colliders when player arrives to planet:
```cs
 if (planetData.meshColliders[i].sharedMesh == null)
  {
    planetData.meshColliders[i].sharedMesh = planetData.meshes[i];
  }
```