### PR TITLE
Add player username syncing

### DIFF
--- a/NebulaClient/MultiplayerClientSession.cs
+++ b/NebulaClient/MultiplayerClientSession.cs
@@ -100,7 +100,7 @@ namespace NebulaClient
             serverConnection = new NebulaConnection(clientSocket, serverEndpoint, PacketProcessor);
             IsConnected = true;
             //TODO: Maybe some challenge-response authentication mechanism?
-            SendPacket(new HandshakeRequest(CryptoUtils.GetPublicKey(CryptoUtils.GetOrCreateUserCert())));
+            SendPacket(new HandshakeRequest(CryptoUtils.GetPublicKey(CryptoUtils.GetOrCreateUserCert()), GameMain.data.account.userName));
         }
 
         private void ClientSocket_OnClose(object sender, CloseEventArgs e)

--- a/NebulaHost/MultiplayerHostSession.cs
+++ b/NebulaHost/MultiplayerHostSession.cs
@@ -65,7 +65,7 @@ namespace NebulaHost
             LocalPlayer.IsMasterClient = true;
 
             // TODO: Load saved player info here
-            LocalPlayer.SetPlayerData(new PlayerData(PlayerManager.GetNextAvailablePlayerId(), GameMain.localPlanet?.id ?? -1, new Float3(1.0f, 0.6846404f, 0.243137181f)));
+            LocalPlayer.SetPlayerData(new PlayerData(PlayerManager.GetNextAvailablePlayerId(), GameMain.localPlanet?.id ?? -1, new Float3(1.0f, 0.6846404f, 0.243137181f), AccountData.me.userName));
         }
 
         private void StopServer()

--- a/NebulaHost/PacketProcessors/Session/HandshakeRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Session/HandshakeRequestProcessor.cs
@@ -59,6 +59,9 @@ namespace NebulaHost.PacketProcessors.Session
                 playerManager.SavedPlayerData.Add(clientCertHash, player.Data);
             }
 
+            // Add the username to the player data
+            player.Data.Username = packet.Username;
+
             // Make sure that each player that is currently in the game receives that a new player as join so they can create its RemotePlayerCharacter
             PlayerData pdata = player.Data.CreateCopyWithoutMechaData(); // Remove inventory from mecha data
             foreach (Player activePlayer in playerManager.GetConnectedPlayers())

--- a/NebulaModel/DataStructures/PlayerData.cs
+++ b/NebulaModel/DataStructures/PlayerData.cs
@@ -6,6 +6,7 @@ namespace NebulaModel.DataStructures
     [RegisterNestedType]
     public class PlayerData : INetSerializable
     {
+        public string Username { get; set; }
         public ushort PlayerId { get; set; }
         public int LocalPlanetId { get; set; }
         public Float3 Color { get; set; }
@@ -16,10 +17,11 @@ namespace NebulaModel.DataStructures
         public MechaData Mecha { get; set; }
 
         public PlayerData() { }
-        public PlayerData(ushort playerId, int localPlanetId, Float3 color, Float3 localPlanetPosition = new Float3(), Double3 position = new Double3(), Float3 rotation = new Float3(), Float3 bodyRotation = new Float3())
+        public PlayerData(ushort playerId, int localPlanetId, Float3 color, string username = null, Float3 localPlanetPosition = new Float3(), Double3 position = new Double3(), Float3 rotation = new Float3(), Float3 bodyRotation = new Float3())
         {
             PlayerId = playerId;
             LocalPlanetId = localPlanetId;
+            Username = username ?? $"Player {playerId}";
             LocalPlanetPosition = localPlanetPosition;
             Color = color;
             UPosition = position;
@@ -30,6 +32,7 @@ namespace NebulaModel.DataStructures
 
         public void Serialize(NetDataWriter writer)
         {
+            writer.Put(Username);
             writer.Put(PlayerId);
             writer.Put(LocalPlanetId);
             Color.Serialize(writer);
@@ -42,6 +45,7 @@ namespace NebulaModel.DataStructures
 
         public void Deserialize(NetDataReader reader)
         {
+            Username = reader.GetString();
             PlayerId = reader.GetUShort();
             LocalPlanetId = reader.GetInt();
             Color = reader.GetFloat3();
@@ -55,7 +59,7 @@ namespace NebulaModel.DataStructures
 
         public PlayerData CreateCopyWithoutMechaData()
         {
-            return new PlayerData(PlayerId, LocalPlanetId, Color, LocalPlanetPosition, UPosition, Rotation, BodyRotation);
+            return new PlayerData(PlayerId, LocalPlanetId, Color, Username, LocalPlanetPosition, UPosition, Rotation, BodyRotation);
         }
     }
 }

--- a/NebulaModel/Packets/Session/HandshakeRequest.cs
+++ b/NebulaModel/Packets/Session/HandshakeRequest.cs
@@ -2,14 +2,16 @@
 {
     public class HandshakeRequest
     {
+        public string Username { get; set; }
         public string ModVersion { get; set; }
         public int GameVersionSig { get; set; }
         public byte[] ClientCert { get; set; }
 
         public HandshakeRequest() { }
 
-        public HandshakeRequest(byte[] clientCert)
+        public HandshakeRequest(byte[] clientCert, string username)
         {
+            this.Username = username;
             this.ModVersion = Config.ModVersion.ToString();
             this.GameVersionSig = GameConfig.gameVersion.sig;
             this.ClientCert = clientCert;

--- a/NebulaWorld/RemotePlayerModel.cs
+++ b/NebulaWorld/RemotePlayerModel.cs
@@ -9,6 +9,7 @@ namespace NebulaWorld
     {
         const int PLAYER_PROTO_ID = 1;
 
+        public string Username { get; }
         public ushort PlayerId { get; }
         public Transform PlayerTransform { get; set; }
         public Transform PlayerModelTransform { get; set; }
@@ -22,7 +23,7 @@ namespace NebulaWorld
         public Player PlayerInstance { get; set; }
         public Mecha MechaInstance { get; set; }
 
-        public RemotePlayerModel(ushort playerId)
+        public RemotePlayerModel(ushort playerId, string username)
         {
             // Spawn remote player model by cloning the player prefab and replacing local player script by remote player ones.
             string playerPrefabPath = LDB.players.Select(PLAYER_PROTO_ID).PrefabPath;
@@ -53,6 +54,7 @@ namespace NebulaWorld
             MechaInstance.Init(PlayerInstance);
 
             PlayerId = playerId;
+            Username = username;
         }
 
         public void Destroy()

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -7,7 +7,6 @@ using NebulaModel.Packets.Trash;
 using NebulaWorld.Factory;
 using NebulaWorld.MonoBehaviours.Remote;
 using NebulaWorld.Trash;
-using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
@@ -80,7 +79,7 @@ namespace NebulaWorld
         {
             if (!remotePlayersModels.ContainsKey(playerData.PlayerId))
             {
-                RemotePlayerModel model = new RemotePlayerModel(playerData.PlayerId);
+                RemotePlayerModel model = new RemotePlayerModel(playerData.PlayerId, playerData.Username);
                 remotePlayersModels.Add(playerData.PlayerId, model);
             }
 
@@ -333,7 +332,7 @@ namespace NebulaWorld
                 {
                     // Make an instance of the "Icarus" text to represent the other player name
                     nameText = playerModel.StarmapNameText = GameObject.Instantiate(starmap_playerNameText, starmap_playerNameText.transform.parent);
-                    nameText.text = $"Player {playerModel.PlayerId}";
+                    nameText.text = $"{ playerModel.Username }{ playerModel.PlayerId }";
                     nameText.gameObject.SetActive(true);
 
                     // Make another copy of it, but just replace it with a point to represent their location
@@ -351,7 +350,7 @@ namespace NebulaWorld
                     adjustedVector = planet.uPosition;
 
                     // Add the local position of the player
-                    Vector3 localPlanetPosition = playerModel.Movement.GetLastPosition().LocalPlanetPosition.ToUnity();
+                    Vector3 localPlanetPosition = playerModel.Movement.GetLastPosition().LocalPlanetPosition.ToVector3();
                     adjustedVector += (VectorLF3)Maths.QRotate(planet.runtimeRotation, localPlanetPosition);
 
                     // Scale as required
@@ -423,7 +422,7 @@ namespace NebulaWorld
                     TextMesh textMesh = playerNameText.AddComponent<TextMesh>();
 
                     // Set the text to be their name
-                    textMesh.text = $"Player {playerModel.PlayerId}";
+                    textMesh.text = $"{ playerModel.Username }{ playerModel.PlayerId }";
                     // Align it to be centered below them
                     textMesh.anchor = TextAnchor.UpperCenter;
                     // Copy the font over from the sail indicator


### PR DESCRIPTION
For now it also appends the player ID to the username so that we can tell which sandboxie character is which - we probabyl need a more permanent solution for identical names.

This also renders the username properly below the characters and on the starmap