### PR TITLE
Building on Remote Star system + unloading factories when client leaves star system

### DIFF
--- a/NebulaHost/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
@@ -1,4 +1,5 @@
-﻿using NebulaModel.Attributes;
+﻿using HarmonyLib;
+using NebulaModel.Attributes;
 using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets.Factory;
@@ -31,6 +32,11 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
 
                 planet.audio = new PlanetAudio(planet);
                 planet.audio.Init();
+
+                if (AccessTools.Field(typeof(CargoTraffic), "beltRenderingBatch").GetValue(planet.factory.cargoTraffic) == null)
+                {
+                    planet.factory.cargoTraffic.CreateRenderingBatches();
+                }
             }
 
             planet.factory.BuildFinally(GameMain.mainPlayer, packet.PrebuildId);

--- a/NebulaHost/PacketProcessors/Planet/PlanetDataRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Planet/PlanetDataRequestProcessor.cs
@@ -1,4 +1,5 @@
-﻿using NebulaModel.Attributes;
+﻿using HarmonyLib;
+using NebulaModel.Attributes;
 using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets.Planet;
@@ -33,6 +34,11 @@ namespace NebulaHost.PacketProcessors.Planet
                     planet.aux = new PlanetAuxData(planet);
                     planetAlgorithm.GenerateTerrain(planet.mod_x, planet.mod_y);
                     planetAlgorithm.CalcWaterPercent();
+
+                    //Load planet meshes and register callback to unload unneccessary stuff
+                    planet.wanted = true;
+                    planet.onLoaded += OnActivePlanetLoaded;
+                    PlanetModelingManager.modPlanetReqList.Enqueue(planet);
                 }
 
                 if (planet.factory == null)
@@ -52,6 +58,12 @@ namespace NebulaHost.PacketProcessors.Planet
             }
 
             conn.SendPacket(new PlanetDataResponse(planetDataToReturn));
+        }
+
+        public void OnActivePlanetLoaded(PlanetData planet)
+        {
+            planet.Unload();
+            planet.onLoaded -= OnActivePlanetLoaded;
         }
     }
 }

--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Patches\Dynamic\GameSave_Patch.cs" />
     <Compile Include="Patches\Dynamic\GameScenarioLogic_Patch.cs" />
     <Compile Include="Patches\Dynamic\GameStatData_Patch.cs" />
+    <Compile Include="Patches\Dynamic\PlanetData_Patch.cs" />
     <Compile Include="Patches\Dynamic\PlanetFactory_Patch.cs" />
     <Compile Include="Patches\Dynamic\Debugging.cs" />
     <Compile Include="Patches\Dynamic\ArriveLeavePlanet_Patch.cs" />

--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -165,5 +165,26 @@ namespace NebulaPatcher.Patches.Dynamic
                 SimulatedWorld.OnDronesDraw();
             }
         }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("LeaveStar")]
+        public static void LeaveStar_Prefix(GameData __instance)
+        {
+            //Client should unload all factories once they leave the star system
+            if (SimulatedWorld.Initialized && !LocalPlayer.IsMasterClient)
+            {
+                for (int i = 0; i < __instance.localStar.planetCount; i++)
+                {
+                    if (__instance.localStar.planets != null && __instance.localStar.planets[i] != null)
+                    {
+                        if (__instance.localStar.planets[i].factory != null)
+                        {
+                            __instance.localStar.planets[i].factory.Free();
+                            __instance.localStar.planets[i].factory = null;
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/PlanetData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetData_Patch.cs
@@ -1,0 +1,76 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(PlanetData))]
+    class PlanetData_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch("UnloadMeshes")]
+        public static bool UnloadMeshes_Prefix(PlanetData __instance)
+        {
+            //Host should not unload planet meshes, since he need to permorm all terrain operations
+            if (SimulatedWorld.Initialized && LocalPlayer.IsMasterClient)
+            {
+                //Do not unload meshes, just hide them so it is not visible
+                UnloadVisuals(__instance);
+                return false;
+            }
+
+            return true;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("UnloadData")]
+        public static bool UnloadData_Prefix()
+        {
+            //TODO: FIX: This causes that atmosphere dissapear
+            //Host should not unload planet data, since he need to permorm all operations from users
+            if (SimulatedWorld.Initialized && LocalPlayer.IsMasterClient)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public static void UnloadVisuals(PlanetData __instance)
+        {
+            if (__instance.gameObject != null)
+            {
+                __instance.gameObject.SetActive(false);
+            }
+            if (__instance.terrainMaterial != null)
+            {
+                UnityEngine.Object.Destroy(__instance.terrainMaterial);
+                __instance.terrainMaterial = null;
+            }
+            if (__instance.oceanMaterial != null)
+            {
+                UnityEngine.Object.Destroy(__instance.oceanMaterial);
+                __instance.oceanMaterial = null;
+            }
+            if (__instance.atmosMaterial != null)
+            {
+                UnityEngine.Object.Destroy(__instance.atmosMaterial);
+                __instance.atmosMaterial = null;
+            }
+            if (__instance.minimapMaterial != null)
+            {
+                UnityEngine.Object.Destroy(__instance.minimapMaterial);
+                __instance.minimapMaterial = null;
+            }
+            if (__instance.reformMaterial0 != null)
+            {
+                UnityEngine.Object.Destroy(__instance.reformMaterial0);
+                __instance.reformMaterial0 = null;
+            }
+            if (__instance.reformMaterial1 != null)
+            {
+                UnityEngine.Object.Destroy(__instance.reformMaterial1);
+                __instance.reformMaterial1 = null;
+            }
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/PlanetData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetData_Patch.cs
@@ -25,7 +25,6 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPatch("UnloadData")]
         public static bool UnloadData_Prefix()
         {
-            //TODO: FIX: This causes that atmosphere dissapear
             //Host should not unload planet data, since he need to permorm all operations from users
             if (SimulatedWorld.Initialized && LocalPlayer.IsMasterClient)
             {

--- a/NebulaPatcher/Patches/Transpilers/PlayerAction_Build_Patch.cs
+++ b/NebulaPatcher/Patches/Transpilers/PlayerAction_Build_Patch.cs
@@ -73,6 +73,27 @@ namespace NebulaPatcher.Patches.Transpiler
                 }
             }
 
+            //Apply Ignoring if inserter match the planet grid check
+            for (i = 5; i < codes.Count - 2; i++)
+            {
+                if (codes[i].opcode == OpCodes.Brfalse &&
+                    codes[i + 1].opcode == OpCodes.Ldloca_S &&
+                    codes[i - 1].opcode == OpCodes.Ldloc_S &&
+                    codes[i - 2].opcode == OpCodes.Stfld &&
+                    codes[i - 3].opcode == OpCodes.Call &&
+                    codes[i - 4].opcode == OpCodes.Ldfld &&
+                    codes[i - 5].opcode == OpCodes.Ldloc_3 &&
+                    codes[i + 2].opcode == OpCodes.Ldloc_3)
+                {
+                    Label targetLabel = (Label)codes[i].operand;
+                    codes.InsertRange(i+1, new CodeInstruction[] {
+                                    new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(FactoryManager), "get_IgnoreBasicBuildConditionChecks")),
+                                    new CodeInstruction(OpCodes.Brtrue_S, targetLabel),
+                                    });
+                    break;
+                }
+            }
+
             //Apply ignoring of 3 ground checks
             for (i = 9; i < codes.Count - 4; i++)
             {


### PR DESCRIPTION
This PR should cover the following:
- #141 (Loading planet meshes and preventing unloading them on the host)
- #69 (Factories are never unloaded)

The following approach was implemented:

1. When the host leaves the star system, everything is unloaded except planet's meshes
2. When a client enters a new star system, the host will also generate meshes for the planets and keeps them.
3. When a client leaves a star system, all factories and their logic is unloaded.