### PR TITLE
Player's drone sync + labor division

### DIFF
--- a/NebulaClient/MultiplayerClientSession.cs
+++ b/NebulaClient/MultiplayerClientSession.cs
@@ -81,6 +81,10 @@ namespace NebulaClient
         {
             serverConnection?.SendPacket(new StarBroadcastPacket(PacketProcessor.Write(packet), GameMain.data.localStar?.id ?? -1));
         }
+        public void SendPacketToLocalPlanet<T>(T packet) where T : class, new()
+        {
+            serverConnection?.SendPacket(new PlanetBroadcastPacket(PacketProcessor.Write(packet), GameMain.mainPlayer.planetId));
+        }
 
         public void Reconnect()
         {

--- a/NebulaClient/MultiplayerClientSession.cs
+++ b/NebulaClient/MultiplayerClientSession.cs
@@ -85,6 +85,11 @@ namespace NebulaClient
         {
             serverConnection?.SendPacket(new PlanetBroadcastPacket(PacketProcessor.Write(packet), GameMain.mainPlayer.planetId));
         }
+        public void SendPacketToPlanet<T>(T packet, int planetId) where T : class, new()
+        {
+            //Should send packet to particular planet
+            //Not needed at the moment, used only on the host side
+        }
 
         public void Reconnect()
         {

--- a/NebulaClient/MultiplayerClientSession.cs
+++ b/NebulaClient/MultiplayerClientSession.cs
@@ -6,6 +6,7 @@ using NebulaModel.Packets.Routers;
 using NebulaModel.Packets.Session;
 using NebulaModel.Utils;
 using NebulaWorld;
+using System;
 using System.Net;
 using UnityEngine;
 using WebSocketSharp;
@@ -89,6 +90,7 @@ namespace NebulaClient
         {
             //Should send packet to particular planet
             //Not needed at the moment, used only on the host side
+            throw new NotImplementedException();
         }
 
         public void Reconnect()

--- a/NebulaClient/NebulaClient.csproj
+++ b/NebulaClient/NebulaClient.csproj
@@ -83,6 +83,7 @@
     <Compile Include="PacketProcessors\Players\PlayerAnimationUpdateProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerColorChangeProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerMovementProcessor.cs" />
+    <Compile Include="PacketProcessors\Players\RemoveDroneOrdersProcessor.cs" />
     <Compile Include="PacketProcessors\Session\HandshakeResponseProcessor.cs" />
     <Compile Include="PacketProcessors\Session\PlayerDisconnectedProcessor.cs" />
     <Compile Include="PacketProcessors\Session\PlayerJoiningProcessor.cs" />

--- a/NebulaClient/NebulaClient.csproj
+++ b/NebulaClient/NebulaClient.csproj
@@ -79,6 +79,7 @@
     <Compile Include="PacketProcessors\Planet\FactoryDataProcessor.cs" />
     <Compile Include="PacketProcessors\Planet\PlanetDataResponseProcessor.cs" />
     <Compile Include="PacketProcessors\Planet\VegetationMinedProcessor.cs" />
+    <Compile Include="PacketProcessors\Players\NewDroneOrderProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerAnimationUpdateProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerColorChangeProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerMovementProcessor.cs" />

--- a/NebulaClient/PacketProcessors/Players/NewDroneOrderProcessor.cs
+++ b/NebulaClient/PacketProcessors/Players/NewDroneOrderProcessor.cs
@@ -1,0 +1,17 @@
+﻿using NebulaModel.Attributes;
+using NebulaModel.Networking;
+using NebulaModel.Packets.Players;
+using NebulaModel.Packets.Processors;
+using NebulaWorld;
+
+namespace NebulaClient.PacketProcessors.Players
+{
+    [RegisterPacketProcessor]
+    class NewDroneOrderProcessor : IPacketProcessor<NewDroneOrderPacket>
+    {
+        public void ProcessPacket(NewDroneOrderPacket packet, NebulaConnection conn)
+        {
+            SimulatedWorld.UpdateRemotePlayerDrone(packet);
+        }
+    }
+}

--- a/NebulaClient/PacketProcessors/Players/RemoveDroneOrdersProcessor.cs
+++ b/NebulaClient/PacketProcessors/Players/RemoveDroneOrdersProcessor.cs
@@ -1,0 +1,20 @@
+﻿using NebulaModel.Networking;
+using NebulaHost.PacketProcessors.Players;
+using NebulaModel.Packets.Processors;
+
+namespace NebulaClient.PacketProcessors.Players
+{
+    class RemoveDroneOrdersProcessor : IPacketProcessor<RemoveDroneOrdersPacket>
+    {
+        public void ProcessPacket(RemoveDroneOrdersPacket packet, NebulaConnection conn)
+        {
+            if (packet.QueuedEntityIds != null)
+            {
+                for (int i = 0; i < packet.QueuedEntityIds.Length; i++)
+                {
+                    GameMain.mainPlayer.mecha.droneLogic.serving.Remove(packet.QueuedEntityIds[i]);
+                }
+            }
+        }
+    }
+}

--- a/NebulaHost/MultiplayerHostSession.cs
+++ b/NebulaHost/MultiplayerHostSession.cs
@@ -89,6 +89,11 @@ namespace NebulaHost
             PlayerManager.SendPacketToLocalStar(packet);
         }
 
+        public void SendPacketToLocalPlanet<T>(T packet) where T : class, new()
+        {
+            PlayerManager.SendPacketToLocalPlanet(packet);
+        }
+
         private void Update()
         {
             gameStateUpdateTimer += Time.deltaTime;

--- a/NebulaHost/MultiplayerHostSession.cs
+++ b/NebulaHost/MultiplayerHostSession.cs
@@ -94,6 +94,11 @@ namespace NebulaHost
             PlayerManager.SendPacketToLocalPlanet(packet);
         }
 
+        public void SendPacketToPlanet<T>(T packet, int planetId) where T : class, new()
+        {
+            PlayerManager.SendPacketToPlanet(packet, planetId);
+        }
+
         private void Update()
         {
             gameStateUpdateTimer += Time.deltaTime;

--- a/NebulaHost/NebulaHost.csproj
+++ b/NebulaHost/NebulaHost.csproj
@@ -77,6 +77,7 @@
     <Compile Include="PacketProcessors\GameHistory\GameHistoryResearchContributionProcessor.cs" />
     <Compile Include="PacketProcessors\Planet\FactoryLoadRequestProcessor.cs" />
     <Compile Include="PacketProcessors\Planet\PlanetDataRequestProcessor.cs" />
+    <Compile Include="PacketProcessors\Players\NewDroneOrderProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerAnimationUpdateProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerColorChangedProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerMechaDataProcessor.cs" />

--- a/NebulaHost/NebulaHost.csproj
+++ b/NebulaHost/NebulaHost.csproj
@@ -82,6 +82,7 @@
     <Compile Include="PacketProcessors\Players\PlayerMechaDataProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerMovementProcessor.cs" />
     <Compile Include="PacketProcessors\Planet\VegetationMinedProcessor.cs" />
+    <Compile Include="PacketProcessors\Routers\PlanetBroadcastProcessor.cs" />
     <Compile Include="PacketProcessors\Routers\StarBroadcastProcessor.cs" />
     <Compile Include="PacketProcessors\Session\HandshakeRequestProcessor.cs" />
     <Compile Include="PacketProcessors\Session\SyncCompleteProcessor.cs" />

--- a/NebulaHost/PacketProcessors/Players/NewDroneOrderProcessor.cs
+++ b/NebulaHost/PacketProcessors/Players/NewDroneOrderProcessor.cs
@@ -1,0 +1,17 @@
+﻿using NebulaModel.Attributes;
+using NebulaModel.Networking;
+using NebulaModel.Packets.Players;
+using NebulaModel.Packets.Processors;
+using NebulaWorld;
+
+namespace NebulaHost.PacketProcessors.Players
+{
+    [RegisterPacketProcessor]
+    class NewDroneOrderProcessor : IPacketProcessor<NewDroneOrderPacket>
+    {
+        public void ProcessPacket(NewDroneOrderPacket packet, NebulaConnection conn)
+        {
+            SimulatedWorld.UpdateRemotePlayerDrone(packet);
+        }
+    }
+}

--- a/NebulaHost/PacketProcessors/Players/NewDroneOrderProcessor.cs
+++ b/NebulaHost/PacketProcessors/Players/NewDroneOrderProcessor.cs
@@ -3,15 +3,37 @@ using NebulaModel.Networking;
 using NebulaModel.Packets.Players;
 using NebulaModel.Packets.Processors;
 using NebulaWorld;
+using NebulaWorld.Player;
 
 namespace NebulaHost.PacketProcessors.Players
 {
     [RegisterPacketProcessor]
     class NewDroneOrderProcessor : IPacketProcessor<NewDroneOrderPacket>
     {
+        private PlayerManager playerManager;
+
+        public NewDroneOrderProcessor()
+        {
+            playerManager = MultiplayerHostSession.Instance.PlayerManager;
+        }
+
         public void ProcessPacket(NewDroneOrderPacket packet, NebulaConnection conn)
         {
-            SimulatedWorld.UpdateRemotePlayerDrone(packet);
+            Player player = playerManager.GetPlayer(conn);
+
+            if (player != null)
+            {
+                if (packet.Stage == 1 || packet.Stage == 2)
+                {
+                    DroneManager.AddPlayerDronePlan(player.Id, packet.EntityId);
+                }
+                else if (packet.Stage == 3)
+                {
+                    DroneManager.RemovePlayerDronePlan(player.Id, packet.EntityId);
+                }
+
+                SimulatedWorld.UpdateRemotePlayerDrone(packet);
+            }
         }
     }
 }

--- a/NebulaHost/PacketProcessors/Players/NewDroneOrderProcessor.cs
+++ b/NebulaHost/PacketProcessors/Players/NewDroneOrderProcessor.cs
@@ -19,6 +19,12 @@ namespace NebulaHost.PacketProcessors.Players
 
         public void ProcessPacket(NewDroneOrderPacket packet, NebulaConnection conn)
         {
+            //Host does not need to know about flying drones of other players if he is not on the same planet
+            if (GameMain.mainPlayer.planetId != packet.PlanetId)
+            {
+                return;
+            }
+
             Player player = playerManager.GetPlayer(conn);
 
             if (player != null)

--- a/NebulaHost/PacketProcessors/Routers/PlanetBroadcastProcessor.cs
+++ b/NebulaHost/PacketProcessors/Routers/PlanetBroadcastProcessor.cs
@@ -20,12 +20,8 @@ namespace NebulaHost.PacketProcessors.Routers
             {
                 //Forward packet to other users
                 playerManager.SendRawPacketToPlanet(packet.PacketObject, packet.PlanetId, conn);
-
-                //Host probably does not need to know about flying drones of other players if he is not on the same planet
-                if (GameMain.mainPlayer.planetId == packet.PlanetId)
-                {
-                    MultiplayerHostSession.Instance.PacketProcessor.EnqueuePacketForProcessing(packet.PacketObject, conn);
-                }
+                //Forward packet to the host
+                MultiplayerHostSession.Instance.PacketProcessor.EnqueuePacketForProcessing(packet.PacketObject, conn);
             }
         }
     }

--- a/NebulaHost/PacketProcessors/Routers/PlanetBroadcastProcessor.cs
+++ b/NebulaHost/PacketProcessors/Routers/PlanetBroadcastProcessor.cs
@@ -1,0 +1,33 @@
+﻿using NebulaModel.Attributes;
+using NebulaModel.Networking;
+using NebulaModel.Packets.Processors;
+using NebulaModel.Packets.Routers;
+using NebulaWorld;
+
+namespace NebulaHost.PacketProcessors.Routers
+{
+    [RegisterPacketProcessor]
+    class PlanetBroadcastProcessor : IPacketProcessor<PlanetBroadcastPacket>
+    {
+        private PlayerManager playerManager;
+        public PlanetBroadcastProcessor()
+        {
+            playerManager = MultiplayerHostSession.Instance.PlayerManager;
+        }
+        public void ProcessPacket(PlanetBroadcastPacket packet, NebulaConnection conn)
+        {
+            Player player = playerManager.GetPlayer(conn);
+            if (player != null)
+            {
+                //Forward packet to other users
+                playerManager.SendRawPacketToPlanet(packet.PacketObject, packet.PlanetId, conn);
+
+                //Host probably does not need to know about flying drones of other players if he is not on the same planet
+                if (LocalPlayer.Data.LocalPlanetId == packet.PlanetId)
+                {
+                    MultiplayerHostSession.Instance.PacketProcessor.EnqueuePacketForProcessing(packet.PacketObject, conn);
+                }
+            }
+        }
+    }
+}

--- a/NebulaHost/PacketProcessors/Routers/PlanetBroadcastProcessor.cs
+++ b/NebulaHost/PacketProcessors/Routers/PlanetBroadcastProcessor.cs
@@ -2,7 +2,6 @@
 using NebulaModel.Networking;
 using NebulaModel.Packets.Processors;
 using NebulaModel.Packets.Routers;
-using NebulaWorld;
 
 namespace NebulaHost.PacketProcessors.Routers
 {
@@ -23,7 +22,7 @@ namespace NebulaHost.PacketProcessors.Routers
                 playerManager.SendRawPacketToPlanet(packet.PacketObject, packet.PlanetId, conn);
 
                 //Host probably does not need to know about flying drones of other players if he is not on the same planet
-                if (LocalPlayer.Data.LocalPlanetId == packet.PlanetId)
+                if (GameMain.mainPlayer.planetId == packet.PlanetId)
                 {
                     MultiplayerHostSession.Instance.PacketProcessor.EnqueuePacketForProcessing(packet.PacketObject, conn);
                 }

--- a/NebulaHost/PlayerManager.cs
+++ b/NebulaHost/PlayerManager.cs
@@ -81,11 +81,33 @@ namespace NebulaHost
             }
         }
 
+        public void SendPacketToLocalPlanet<T>(T packet) where T : class, new()
+        {
+            foreach (Player player in GetConnectedPlayers())
+            {
+                if (player.Data.LocalPlanetId == GameMain.data.mainPlayer.planetId)
+                {
+                    player.SendPacket(packet);
+                }
+            }
+        }
+
         public void SendRawPacketToStar(byte[] rawPacket, int starId, NebulaConnection sender)
         {
             foreach (Player player in GetConnectedPlayers())
             {
                 if (GameMain.galaxy.PlanetById(player.Data.LocalPlanetId)?.star.id == starId && player.Connection != sender)
+                {
+                    player.SendRawPacket(rawPacket);
+                }
+            }
+        }
+
+        public void SendRawPacketToPlanet(byte[] rawPacket, int planetId, NebulaConnection sender)
+        {
+            foreach (Player player in GetConnectedPlayers())
+            {
+                if (player.Data.LocalPlanetId == planetId && player.Connection != sender)
                 {
                     player.SendRawPacket(rawPacket);
                 }

--- a/NebulaModel/NebulaModel.csproj
+++ b/NebulaModel/NebulaModel.csproj
@@ -105,12 +105,14 @@
     <Compile Include="Packets\Planet\FactoryLoadRequest.cs" />
     <Compile Include="Packets\Planet\PlanetDataRequest.cs" />
     <Compile Include="Packets\Planet\PlanetDataResponse.cs" />
+    <Compile Include="Packets\Players\NewDroneOrderPacket.cs" />
     <Compile Include="Packets\Players\PlayerAnimationUpdate.cs" />
     <Compile Include="Packets\Players\PlayerMechaData.cs" />
     <Compile Include="Packets\Players\PlayerMovement.cs" />
     <Compile Include="Packets\Players\PlayerColorChanged.cs" />
     <Compile Include="Packets\Players\PlayerTechBonuses.cs" />
     <Compile Include="Packets\Processors\IPacketProcessor.cs" />
+    <Compile Include="Packets\Routers\PlanetBroadcastPacket.cs" />
     <Compile Include="Packets\Routers\StarBroadcastPacket.cs" />
     <Compile Include="Packets\Session\HandshakeRequest.cs" />
     <Compile Include="Packets\Session\HandshakeResponse.cs" />

--- a/NebulaModel/NebulaModel.csproj
+++ b/NebulaModel/NebulaModel.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Packets\Players\PlayerMovement.cs" />
     <Compile Include="Packets\Players\PlayerColorChanged.cs" />
     <Compile Include="Packets\Players\PlayerTechBonuses.cs" />
+    <Compile Include="Packets\Players\RemoveDroneOrdersPacket.cs" />
     <Compile Include="Packets\Processors\IPacketProcessor.cs" />
     <Compile Include="Packets\Routers\PlanetBroadcastPacket.cs" />
     <Compile Include="Packets\Routers\StarBroadcastPacket.cs" />

--- a/NebulaModel/Packets/Players/NewDroneOrderPacket.cs
+++ b/NebulaModel/Packets/Players/NewDroneOrderPacket.cs
@@ -1,0 +1,18 @@
+﻿namespace NebulaModel.Packets.Players
+{
+    public class NewDroneOrderPacket
+    {
+        public int PlanetId { get; set; }
+        public int DroneId { get; set; }
+        public int EntityId { get; set; }
+        public int PlayerId { get; set; }
+        public NewDroneOrderPacket() { }
+        public NewDroneOrderPacket(int planetId, int droneId, int entityId, int playerId)
+        {
+            PlanetId = planetId;
+            DroneId = droneId;
+            EntityId = entityId;
+            PlayerId = playerId;
+        }
+    }
+}

--- a/NebulaModel/Packets/Players/NewDroneOrderPacket.cs
+++ b/NebulaModel/Packets/Players/NewDroneOrderPacket.cs
@@ -5,14 +5,19 @@
         public int PlanetId { get; set; }
         public int DroneId { get; set; }
         public int EntityId { get; set; }
-        public int PlayerId { get; set; }
+        public ushort PlayerId { get; set; }
+        public int Stage { get; set; }
+        public int Priority { get; set; }
+        
         public NewDroneOrderPacket() { }
-        public NewDroneOrderPacket(int planetId, int droneId, int entityId, int playerId)
+        public NewDroneOrderPacket(int planetId, int droneId, int entityId, ushort playerId, int stage, int priority)
         {
             PlanetId = planetId;
             DroneId = droneId;
             EntityId = entityId;
             PlayerId = playerId;
+            Stage = stage;
+            Priority = priority;
         }
     }
 }

--- a/NebulaModel/Packets/Players/RemoveDroneOrdersPacket.cs
+++ b/NebulaModel/Packets/Players/RemoveDroneOrdersPacket.cs
@@ -1,0 +1,14 @@
+﻿namespace NebulaHost.PacketProcessors.Players
+{
+    public class RemoveDroneOrdersPacket
+    {
+        public int[] QueuedEntityIds { get; set; }
+
+        public RemoveDroneOrdersPacket() { }
+
+        public RemoveDroneOrdersPacket(int[] queuedEntityIds)
+        {
+            QueuedEntityIds = queuedEntityIds;
+        }
+    }
+}

--- a/NebulaModel/Packets/Routers/PlanetBroadcastPacket.cs
+++ b/NebulaModel/Packets/Routers/PlanetBroadcastPacket.cs
@@ -1,0 +1,15 @@
+﻿namespace NebulaModel.Packets.Routers
+{
+    public class PlanetBroadcastPacket
+    {
+        public byte[] PacketObject { get; set; }
+        public int PlanetId { get; set; }
+
+        public PlanetBroadcastPacket() { }
+        public PlanetBroadcastPacket(byte[] packetObject, int planetId)
+        {
+            PacketObject = packetObject;
+            PlanetId = planetId;
+        }
+    }
+}

--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Patches\Dynamic\GameSave_Patch.cs" />
     <Compile Include="Patches\Dynamic\GameScenarioLogic_Patch.cs" />
     <Compile Include="Patches\Dynamic\GameStatData_Patch.cs" />
+    <Compile Include="Patches\Dynamic\Mecha_Patch.cs" />
     <Compile Include="Patches\Dynamic\PlanetFactory_Patch.cs" />
     <Compile Include="Patches\Dynamic\Debugging.cs" />
     <Compile Include="Patches\Dynamic\ArriveLeavePlanet_Patch.cs" />

--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Patches\Dynamic\UIStorageWindow_Patch.cs" />
     <Compile Include="Patches\Dynamic\UITankWindow_Patch.cs" />
     <Compile Include="Patches\Dynamic\VFInput_Patch.cs" />
+    <Compile Include="Patches\Transpilers\MechaDroneLogic_Patch.cs" />
     <Compile Include="Patches\Transpilers\PlayerAction_Build_Patch.cs" />
     <Compile Include="Patches\Transpilers\PlayerAction_Mine_Patch.cs" />
     <Compile Include="Patches\Dynamic\UIEscMenu_Patch.cs" />

--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -146,9 +146,9 @@ namespace NebulaPatcher.Patches.Dynamic
             gameData.mainPlayer.controller.velocityOnLanding = Vector3.zero;
         }
 
-        [HarmonyPrefix]
+        [HarmonyPostfix]
         [HarmonyPatch("OnDraw")]
-        public static void OnDraw_Prefix()
+        public static void OnDraw_Postfix()
         {
             if (SimulatedWorld.Initialized)
             {

--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -186,5 +186,16 @@ namespace NebulaPatcher.Patches.Dynamic
                 }
             }
         }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("LeavePlanet")]
+        public static void LeavePlanet_Prefix(GameData __instance)
+        {
+            //Players should clear the list of drone orders of other players when they leave the planet
+            if (SimulatedWorld.Initialized)
+            {
+                GameMain.mainPlayer.mecha.droneLogic.serving.Clear();
+            }
+        }
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/Mecha_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/Mecha_Patch.cs
@@ -1,0 +1,19 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(Mecha))]
+    class Mecha_Patch
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch("GameTick")]
+        public static void GameTick_Postfix(long time, float dt)
+        {
+            if (SimulatedWorld.Initialized)
+            {
+                SimulatedWorld.OnDronesGameTick(time, dt);
+            }
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Transpilers/MechaDroneLogic_Patch.cs
+++ b/NebulaPatcher/Patches/Transpilers/MechaDroneLogic_Patch.cs
@@ -9,7 +9,7 @@ namespace NebulaPatcher.Patches.Transpiler
     class MechaDroneLogic_Patch
     {
         /*
-         * Call DroneManager.BroadcastDroneOrder(int droneId, int entityId) when drone gets new order
+         * Call DroneManager.BroadcastDroneOrder(int droneId, int entityId, int stage) when drone gets new order
          */
         [HarmonyTranspiler]
         [HarmonyPatch("UpdateTargets")]
@@ -26,7 +26,58 @@ namespace NebulaPatcher.Patches.Transpiler
                     codes.InsertRange(i + 1, new CodeInstruction[] {
                         new CodeInstruction(OpCodes.Ldloc_S, 11),
                         new CodeInstruction(OpCodes.Ldloc_3),
-                        new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(DroneManager), "BroadcastDroneOrder", new System.Type[] { typeof(int), typeof(int) }))
+                        new CodeInstruction(OpCodes.Ldc_I4_1),
+                        new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(DroneManager), "BroadcastDroneOrder", new System.Type[] { typeof(int), typeof(int), typeof(int) }))
+                        });
+                    break;
+                }
+            }
+            return codes;
+        }
+
+        /*
+         * Call DroneManager.BroadcastDroneOrder(int droneId, int entityId, int stage) when drone's stage changes
+         */
+        [HarmonyTranspiler]
+        [HarmonyPatch("UpdateDrones")]
+        static IEnumerable<CodeInstruction> UpdateDrones_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var codes = new List<CodeInstruction>(instructions);
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (codes[i].opcode == OpCodes.Brfalse &&
+                    codes[i - 1].opcode == OpCodes.Call &&
+                    codes[i + 2].opcode == OpCodes.Ldloc_S &&
+                    codes[i + 1].opcode == OpCodes.Ldloc_0 &&
+                    codes[i - 2].opcode == OpCodes.Ldloca_S)
+                {
+                    codes.InsertRange(i + 1, new CodeInstruction[] {
+                        new CodeInstruction(OpCodes.Ldloc_S, 4),
+                        new CodeInstruction(OpCodes.Ldloc_S, 7),
+                        new CodeInstruction(OpCodes.Ldc_I4_2),
+                        new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(DroneManager), "BroadcastDroneOrder", new System.Type[] { typeof(int), typeof(int), typeof(int) }))
+                        });
+                    break;
+                }
+            }
+
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (codes[i].opcode == OpCodes.Br &&
+                    codes[i - 1].opcode == OpCodes.Pop &&
+                    codes[i + 2].opcode == OpCodes.Ldloc_S &&
+                    codes[i + 1].opcode == OpCodes.Ldloc_0 &&
+                    codes[i - 2].opcode == OpCodes.Callvirt &&
+                    codes[i - 3].opcode == OpCodes.Ldloc_S)
+                {
+                    codes.InsertRange(i + 5, new CodeInstruction[] {
+                        new CodeInstruction(OpCodes.Ldloc_S, 4),
+                        new CodeInstruction(OpCodes.Ldloc_0),
+                        new CodeInstruction(OpCodes.Ldloc_S, 4),
+                        new CodeInstruction(OpCodes.Ldelema, typeof(MechaDrone)),
+                        new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(MechaDrone), "targetObject")),
+                        new CodeInstruction(OpCodes.Ldc_I4_3),
+                        new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(DroneManager), "BroadcastDroneOrder", new System.Type[] { typeof(int), typeof(int), typeof(int) }))
                         });
                     break;
                 }

--- a/NebulaPatcher/Patches/Transpilers/MechaDroneLogic_Patch.cs
+++ b/NebulaPatcher/Patches/Transpilers/MechaDroneLogic_Patch.cs
@@ -1,0 +1,37 @@
+﻿using HarmonyLib;
+using NebulaWorld.Player;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+
+namespace NebulaPatcher.Patches.Transpiler
+{
+    [HarmonyPatch(typeof(MechaDroneLogic))]
+    class MechaDroneLogic_Patch
+    {
+        /*
+         * Call DroneManager.BroadcastDroneOrder(int droneId, int entityId) when drone gets new order
+         */
+        [HarmonyTranspiler]
+        [HarmonyPatch("UpdateTargets")]
+        static IEnumerable<CodeInstruction> UpdateTargets_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var codes = new List<CodeInstruction>(instructions);
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (codes[i].opcode == OpCodes.Pop &&
+                    codes[i - 1].opcode == OpCodes.Callvirt &&
+                    codes[i + 1].opcode == OpCodes.Ldarg_0 &&
+                    codes[i - 2].opcode == OpCodes.Ldloc_3)
+                {
+                    codes.InsertRange(i + 1, new CodeInstruction[] {
+                        new CodeInstruction(OpCodes.Ldloc_S, 11),
+                        new CodeInstruction(OpCodes.Ldloc_3),
+                        new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(DroneManager), "BroadcastDroneOrder", new System.Type[] { typeof(int), typeof(int) }))
+                        });
+                    break;
+                }
+            }
+            return codes;
+        }
+    }
+}

--- a/NebulaWorld/INetworkProvider.cs
+++ b/NebulaWorld/INetworkProvider.cs
@@ -8,6 +8,8 @@
 
         void SendPacketToLocalPlanet<T>(T packet) where T : class, new();
 
+        void SendPacketToPlanet<T>(T packet, int planetId) where T : class, new();
+
         void DestroySession();
     }
 }

--- a/NebulaWorld/INetworkProvider.cs
+++ b/NebulaWorld/INetworkProvider.cs
@@ -7,6 +7,7 @@
         void SendPacketToLocalStar<T>(T packet) where T : class, new();
 
         void SendPacketToLocalPlanet<T>(T packet) where T : class, new();
+
         void DestroySession();
     }
 }

--- a/NebulaWorld/INetworkProvider.cs
+++ b/NebulaWorld/INetworkProvider.cs
@@ -6,6 +6,7 @@
 
         void SendPacketToLocalStar<T>(T packet) where T : class, new();
 
+        void SendPacketToLocalPlanet<T>(T packet) where T : class, new();
         void DestroySession();
     }
 }

--- a/NebulaWorld/LocalPlayer.cs
+++ b/NebulaWorld/LocalPlayer.cs
@@ -31,6 +31,11 @@ namespace NebulaWorld
             networkProvider?.SendPacketToLocalStar(packet);
         }
 
+        public static void SendPacketToLocalPlanet<T>(T packet) where T : class, new()
+        {
+            networkProvider?.SendPacketToLocalPlanet(packet);
+        }
+
         public static void SetReady()
         {
             if (!IsMasterClient)

--- a/NebulaWorld/LocalPlayer.cs
+++ b/NebulaWorld/LocalPlayer.cs
@@ -36,6 +36,11 @@ namespace NebulaWorld
             networkProvider?.SendPacketToLocalPlanet(packet);
         }
 
+        public static void SendPacketToPlanet<T>(T packet, int planetId) where T : class, new()
+        {
+            networkProvider?.SendPacketToPlanet(packet, planetId);
+        }
+
         public static void SetReady()
         {
             if (!IsMasterClient)

--- a/NebulaWorld/NebulaWorld.csproj
+++ b/NebulaWorld/NebulaWorld.csproj
@@ -51,6 +51,7 @@
     <Compile Include="MonoBehaviours\Remote\RemotePlayerAnimation.cs" />
     <Compile Include="MonoBehaviours\Remote\RemotePlayerEffects.cs" />
     <Compile Include="MonoBehaviours\Remote\RemotePlayerMovement.cs" />
+    <Compile Include="Player\DroneManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RemotePlayerModel.cs" />
     <Compile Include="SimulatedWorld.cs" />

--- a/NebulaWorld/Player/DroneManager.cs
+++ b/NebulaWorld/Player/DroneManager.cs
@@ -1,0 +1,17 @@
+﻿using NebulaModel.Packets.Players;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NebulaWorld.Player
+{
+    public static class DroneManager
+    {
+        public static void BroadcastDroneOrder(int droneId, int entityId)
+        {
+            UnityEngine.Debug.Log($"Drone {droneId} is going to {entityId}");
+            LocalPlayer.SendPacketToLocalPlanet(new NewDroneOrderPacket());
+        }
+    }
+}

--- a/NebulaWorld/Player/DroneManager.cs
+++ b/NebulaWorld/Player/DroneManager.cs
@@ -1,17 +1,22 @@
 ﻿using NebulaModel.Packets.Players;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace NebulaWorld.Player
 {
     public static class DroneManager
     {
-        public static void BroadcastDroneOrder(int droneId, int entityId)
+        public static int[] DronePriorities = new int[255];
+        public static Random rnd = new Random();
+
+        public static void BroadcastDroneOrder(int droneId, int entityId, int stage)
         {
-            UnityEngine.Debug.Log($"Drone {droneId} is going to {entityId}");
-            LocalPlayer.SendPacketToLocalPlanet(new NewDroneOrderPacket());
-        }
+            int priority = 0;
+            if (stage == 1 || stage == 2)
+            {
+                priority = rnd.Next();
+                DronePriorities[droneId] = priority;
+            }
+            LocalPlayer.SendPacketToLocalPlanet(new NewDroneOrderPacket(GameMain.mainPlayer.planetId, droneId, entityId, LocalPlayer.PlayerId, stage, priority));
+        }    
     }
 }

--- a/NebulaWorld/Player/DroneManager.cs
+++ b/NebulaWorld/Player/DroneManager.cs
@@ -1,5 +1,6 @@
 ﻿using NebulaModel.Packets.Players;
 using System;
+using System.Collections.Generic;
 
 namespace NebulaWorld.Player
 {
@@ -7,6 +8,7 @@ namespace NebulaWorld.Player
     {
         public static int[] DronePriorities = new int[255];
         public static Random rnd = new Random();
+        public static Dictionary<ushort, List<int>> PlayerDroneBuildingPlans = new Dictionary<ushort, List<int>>();
 
         public static void BroadcastDroneOrder(int droneId, int entityId, int stage)
         {
@@ -17,6 +19,32 @@ namespace NebulaWorld.Player
                 DronePriorities[droneId] = priority;
             }
             LocalPlayer.SendPacketToLocalPlanet(new NewDroneOrderPacket(GameMain.mainPlayer.planetId, droneId, entityId, LocalPlayer.PlayerId, stage, priority));
-        }    
+        }
+
+        public static void AddPlayerDronePlan(ushort playerId, int entityId)
+        {
+            if (!PlayerDroneBuildingPlans.ContainsKey(playerId))
+            {
+                PlayerDroneBuildingPlans.Add(playerId, new List<int>());
+            }
+            PlayerDroneBuildingPlans[playerId].Add(entityId);
+        }
+
+        public static void RemovePlayerDronePlan(ushort playerId, int entityId)
+        {
+            if (PlayerDroneBuildingPlans.ContainsKey(playerId))
+            {
+                PlayerDroneBuildingPlans[playerId].Remove(entityId);
+            }
+        }
+
+        public static int[] GetPlayerDronePlans(ushort playerId)
+        {
+            if (PlayerDroneBuildingPlans.ContainsKey(playerId))
+            {
+                return PlayerDroneBuildingPlans[playerId].ToArray();
+            }
+            return null;
+        }
     }
 }

--- a/NebulaWorld/RemotePlayerModel.cs
+++ b/NebulaWorld/RemotePlayerModel.cs
@@ -14,7 +14,7 @@ namespace NebulaWorld
         public RemotePlayerAnimation Animator { get; set; }
         public RemotePlayerEffects Effects { get; set; }
 
-        public Player PlayerInstance { get; set; }
+        public global::Player PlayerInstance { get; set; }
         public Mecha MechaInstance { get; set; }
 
         public RemotePlayerModel(ushort playerId)
@@ -42,9 +42,9 @@ namespace NebulaWorld
 
             PlayerTransform.gameObject.name = $"Remote Player ({playerId})";
 
-            PlayerInstance = new Player();
+            PlayerInstance = new global::Player();
             MechaInstance = new Mecha();
-            AccessTools.Property(typeof(Player), "mecha").SetValue(PlayerInstance, MechaInstance, null);
+            AccessTools.Property(typeof(global::Player), "mecha").SetValue(PlayerInstance, MechaInstance, null);
             MechaInstance.Init(PlayerInstance);
         }
 

--- a/NebulaWorld/RemotePlayerModel.cs
+++ b/NebulaWorld/RemotePlayerModel.cs
@@ -46,6 +46,11 @@ namespace NebulaWorld
             MechaInstance = new Mecha();
             AccessTools.Property(typeof(global::Player), "mecha").SetValue(PlayerInstance, MechaInstance, null);
             MechaInstance.Init(PlayerInstance);
+
+            //Fix MechaDroneRenderers
+            AccessTools.Field(typeof(MechaDroneRenderer), "mat_0").SetValue(MechaInstance.droneRenderer, new Material(Configs.builtin.mechaDroneMat.shader));
+            Material mat = (Material)AccessTools.Field(typeof(MechaDroneRenderer), "mat_0").GetValue(MechaInstance.droneRenderer);
+            MethodInvoker.GetHandler(AccessTools.Method(typeof(Material), "CopyPropertiesFromMaterial", new System.Type[] { typeof(Material) })).Invoke(mat, Configs.builtin.mechaDroneMat);
         }
 
         public void Destroy()

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -126,7 +126,7 @@ namespace NebulaWorld
                 drone.movement = droneLogic.player.mecha.droneMovement;
                 if (packet.Stage == 1)
                 {
-                    drone.position = player.Movement.GetLastPosition().LocalPlanetPosition.ToUnity();
+                    drone.position = player.Movement.GetLastPosition().LocalPlanetPosition.ToVector3();
                 }
                 drone.target = (Vector3)MethodInvoker.GetHandler(AccessTools.Method(typeof(MechaDroneLogic), "_obj_hpos", new System.Type[] { typeof(int) })).Invoke(GameMain.mainPlayer.mecha.droneLogic, packet.EntityId);
                 drone.initialVector = drone.position + drone.position.normalized * 4.5f + ((drone.target - drone.position).normalized + UnityEngine.Random.insideUnitSphere) * 1.5f;
@@ -375,7 +375,7 @@ namespace NebulaWorld
                     //Update only moving drones of players on the same planet
                     if (drones[i].stage != 0 && GameMain.mainPlayer.planetId == remoteModel.Value.Movement.localPlanetId)
                     {
-                        drones[i].Update(GameMain.localPlanet.factory.prebuildPool, remoteModel.Value.Movement.GetLastPosition().LocalPlanetPosition.ToUnity(), dt, ref tmp, ref tmp2, 0);
+                        drones[i].Update(GameMain.localPlanet.factory.prebuildPool, remoteModel.Value.Movement.GetLastPosition().LocalPlanetPosition.ToVector3(), dt, ref tmp, ref tmp2, 0);
                     }
                 }
                 remoteModel.Value.MechaInstance.droneRenderer.Update();

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -252,7 +252,7 @@ namespace NebulaWorld
                 GameMain.mainPlayer.uRotation = Quaternion.Euler(LocalPlayer.Data.Rotation.ToUnity());
 
                 //Load player's saved data from the last session.
-                AccessTools.Property(typeof(Player), "package").SetValue(GameMain.mainPlayer, LocalPlayer.Data.Mecha.Inventory, null);
+                AccessTools.Property(typeof(global::Player), "package").SetValue(GameMain.mainPlayer, LocalPlayer.Data.Mecha.Inventory, null);
                 GameMain.mainPlayer.mecha.forge = LocalPlayer.Data.Mecha.Forge;
                 GameMain.mainPlayer.mecha.coreEnergy = LocalPlayer.Data.Mecha.CoreEnergy;
                 GameMain.mainPlayer.mecha.reactorEnergy = LocalPlayer.Data.Mecha.ReactorEnergy;

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -6,6 +6,7 @@ using NebulaModel.Packets.Players;
 using NebulaModel.Packets.Trash;
 using NebulaWorld.Factory;
 using NebulaWorld.MonoBehaviours.Remote;
+using NebulaWorld.Player;
 using NebulaWorld.Trash;
 using System.Collections.Generic;
 using UnityEngine;
@@ -108,6 +109,72 @@ namespace NebulaWorld
             {
                 player.Animator.UpdateState(packet);
                 player.Effects.UpdateState(packet);
+            }
+        }
+
+        public static void UpdateRemotePlayerDrone(NewDroneOrderPacket packet)
+        {
+            if (remotePlayersModels.TryGetValue(packet.PlayerId, out RemotePlayerModel player))
+            {
+                //Setup drone of remote player based on the drone data
+                ref MechaDrone drone = ref player.PlayerInstance.mecha.drones[packet.DroneId];
+                MechaDroneLogic droneLogic = player.PlayerInstance.mecha.droneLogic;
+
+                drone.stage = packet.Stage;
+                drone.targetObject = packet.Stage < 3 ? packet.EntityId : 0;
+                drone.movement = droneLogic.player.mecha.droneMovement;
+                if (packet.Stage == 1)
+                {
+                    drone.position = player.Movement.GetLastPosition().LocalPlanetPosition.ToUnity();
+                }
+                drone.target = (Vector3)MethodInvoker.GetHandler(AccessTools.Method(typeof(MechaDroneLogic), "_obj_hpos", new System.Type[] { typeof(int) })).Invoke(GameMain.mainPlayer.mecha.droneLogic, packet.EntityId);
+                drone.initialVector = drone.position + drone.position.normalized * 4.5f + ((drone.target - drone.position).normalized + UnityEngine.Random.insideUnitSphere) * 1.5f;
+                drone.forward = drone.initialVector;
+                drone.progress = 0f;
+                player.MechaInstance.droneCount = GameMain.mainPlayer.mecha.droneCount;
+                player.MechaInstance.droneSpeed = GameMain.mainPlayer.mecha.droneSpeed;
+                Mecha myMecha = GameMain.mainPlayer.mecha;
+                if (packet.Stage == 3)
+                {
+                    myMecha.droneLogic.serving.Remove(packet.EntityId);
+                }
+
+                if (drone.stage == 1 || drone.stage == 2) {
+                    //Check if my drone is already going there
+                    if (!myMecha.droneLogic.serving.Contains(packet.EntityId))
+                    {
+                        myMecha.droneLogic.serving.Add(packet.EntityId);
+                    } else
+                    {
+                        //resolve conflict (two drones are going to the same building)
+                        //find my drone that is going there
+                        int priority = 0;
+                        int droneId = 0;
+                        for (int i = 0; i < myMecha.droneCount; i++)
+                        {
+                            if (myMecha.drones[i].stage > 0 && myMecha.drones[i].targetObject == drone.targetObject)
+                            {
+                                priority = DroneManager.DronePriorities[i];
+                                droneId = i;
+                                break;
+                            }
+                        }
+                        //compare, who's drone has higher priority
+                        if (packet.Priority > priority)
+                        {
+                            //their drone won, my drone has to return
+                            ref MechaDrone myDrone = ref myMecha.drones[droneId];
+                            myDrone.stage = 3;
+                            myDrone.targetObject = 0;
+                        } else
+                        {
+                            //my drone won, their has to return
+                            drone.stage = 3;
+                            drone.targetObject = 0;
+                        }
+                    }
+                }
+                
             }
         }
 
@@ -277,25 +344,28 @@ namespace NebulaWorld
         {
             foreach(KeyValuePair<ushort, RemotePlayerModel> remoteModel in remotePlayersModels)
             {
-                remoteModel.Value.MechaInstance.droneRenderer.Draw();
+                //Render drones of players only on the local planet
+                if (GameMain.mainPlayer.planetId == remoteModel.Value.Movement.localPlanetId)
+                {
+                    remoteModel.Value.MechaInstance.droneRenderer.Draw();
+                }
             }
         }
 
         public static void OnDronesGameTick(long time, float dt)
         {
-            double tmp = 0;
-            double tmp2 = 0;
+            double tmp = 1e10; //fake energy of remote player, needed to do the Update()
+            double tmp2 = 1;
             //Update drones positions based on their targets
             foreach (KeyValuePair<ushort, RemotePlayerModel> remoteModel in remotePlayersModels)
             {
                 MechaDrone[] drones = remoteModel.Value.PlayerInstance.mecha.drones;
-                int droneCount = remoteModel.Value.PlayerInstance.mecha.droneCount;
+                int droneCount = GameMain.mainPlayer.mecha.droneCount;
                 for (int i = 0; i < droneCount; i++)
                 {
-                    if (drones[i].stage != 0)
+                    //Update only moving drones of players on the same planet
+                    if (drones[i].stage != 0 && GameMain.mainPlayer.planetId == remoteModel.Value.Movement.localPlanetId)
                     {
-                        //To-do: fix the correct factory here
-                        //To-do: Optimize getting local position of player
                         drones[i].Update(GameMain.localPlanet.factory.prebuildPool, remoteModel.Value.Movement.GetLastPosition().LocalPlanetPosition.ToUnity(), dt, ref tmp, ref tmp2, 0);
                     }
                 }


### PR DESCRIPTION
This is the implementation of #126 

I am basically sending 3 events using transpilers:

- Drone went to build something
- Drone is going back to mecha
- Drone changed build target

The labor division (each drone will build something else) is achieved by leveraging the original approach of marking which prebuild is under build from the drone. In case of collision (client and host will send drone at the same time), a random number is generated as a priority for the drone order. 

For example:
1. Host will sent packet: my drone is going to build that with the random number `178361`.
2. Client will sent packet: my drone is going to build that with the random number `2781`.

In this case, the Client lost and his drone has to go back to mecha. In the case of more players, the higher number will always win. 

In the GIF below, I have build 8 buildings and each player has only 3 drones. That is why the first 6 buildings are built quickly and the last two later.

![output](https://user-images.githubusercontent.com/79051050/114853600-3e676580-9de4-11eb-8bb5-8d8bf7dbe081.gif)
