### PR TITLE
Add workflow yml for GitHub Actions/CI

### DIFF
--- a/.github/workflows/build-winx64.yml
+++ b/.github/workflows/build-winx64.yml
@@ -1,0 +1,56 @@
+name: Build - Win x64
+
+on:
+  push:
+    branches: [ master ]
+  pull_request_review:
+    types: [ submitted ]
+
+jobs:
+
+  build:
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+
+    # We *only* want to run this if a collaborator or owner of the repo approves a pull request, or if something is merged into the main branch
+    if: ${{ github.event.ref == 'refs/heads/master' || (github.event.review.state == 'approved' && (github.event.review.author_association == 'COLLABORATOR' || github.event.review.author_association == 'OWNER')) }}
+    runs-on: dsp-installed
+
+    env:
+      Solution_Name: Nebula.sln
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        
+    - name: Clear output directory in DSP files
+      # We use SilentlyContinue here because it errors out of the folder does not exist otherwise
+      run: rm -R -ErrorAction SilentlyContinue "C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\BepInEx\plugins\Nebula"
+
+    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    # Restore the application to populate the obj folder with RuntimeIdentifiers
+    - name: Restore the application
+      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
+      env:
+        Configuration: ${{ matrix.configuration }}
+        
+    # Build it
+    - name: Build the application
+      run: msbuild $env:Solution_Name /p:Configuration=$env:Configuration
+      env:
+        Configuration: ${{ matrix.configuration }}
+
+    # Upload it to the run results
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v2.2.3
+      with:
+        # Artifact name
+        name: build-artifacts
+        # A file, directory or wildcard pattern that describes what to upload
+        path: C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\BepInEx\plugins\Nebula

--- a/.github/workflows/build-winx64.yml
+++ b/.github/workflows/build-winx64.yml
@@ -34,15 +34,9 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
 
-    # Restore the application to populate the obj folder with RuntimeIdentifiers
-    - name: Restore the application
-      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
-      env:
-        Configuration: ${{ matrix.configuration }}
-        
     # Build it
     - name: Build the application
-      run: msbuild $env:Solution_Name /p:Configuration=$env:Configuration
+      run: msbuild $env:Solution_Name /restore /p:Configuration=$env:Configuration
       env:
         Configuration: ${{ matrix.configuration }}
 


### PR DESCRIPTION
This PR adds a workflow file to the repo, which in turn will run CI builds on pull requests and merges in the main branch.

This will only run if a collaborator or owner of the repo approves a pull request, or if something is merged into the main branch.

This means that code must first be approved of by a Collaborator or repo owner before it is built on the CI machine - this is in order to stop potential malicious code being merged in, or run on the CI VM.

Artifacts are uploaded under the "Actions" tab once this is live.

A worker has already been added to the repo that has the relevant label to execute the job.

Currently, the only thing it does it checks if it actually builds or not, as there are no tests (and there are unlikely to be any, as it's a mod, and the CI machine won't run DSP)