### PR TITLE
Destroying vegetables on remote planets sync, preventing double vege generation + bug fix

### DIFF
--- a/NebulaClient/NebulaClient.csproj
+++ b/NebulaClient/NebulaClient.csproj
@@ -79,6 +79,7 @@
     <Compile Include="PacketProcessors\GameStates\GameStateUpdateProcessor.cs" />
     <Compile Include="PacketProcessors\Planet\FactoryDataProcessor.cs" />
     <Compile Include="PacketProcessors\Planet\PlanetDataResponseProcessor.cs" />
+    <Compile Include="PacketProcessors\Planet\RemoveVegetableProcessor.cs" />
     <Compile Include="PacketProcessors\Planet\VegetationMinedProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerAnimationUpdateProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerColorChangeProcessor.cs" />

--- a/NebulaClient/PacketProcessors/Planet/RemoveVegetableProcessor.cs
+++ b/NebulaClient/PacketProcessors/Planet/RemoveVegetableProcessor.cs
@@ -2,7 +2,7 @@
 using NebulaModel.Networking;
 using NebulaModel.Packets.Planet;
 using NebulaModel.Packets.Processors;
-using NebulaWorld.Factory;
+using NebulaWorld.Planet;
 
 namespace NebulaClient.PacketProcessors.Planet
 {
@@ -11,11 +11,11 @@ namespace NebulaClient.PacketProcessors.Planet
     {
         public void ProcessPacket(RemoveVegetablePacket packet, NebulaConnection conn)
         {
-            if (GameMain.data.factories[packet.FactorytId] != null)
+            if (GameMain.data.factories[packet.FactorytIndex] != null)
             {
-                FactoryManager.EventFromServer = true;
-                GameMain.data.factories[packet.FactorytId].RemoveVegeWithComponents(packet.VegeId);
-                FactoryManager.EventFromServer = false;
+                PlanetManager.EventFromServer = true;
+                GameMain.data.factories[packet.FactorytIndex].RemoveVegeWithComponents(packet.VegeId);
+                PlanetManager.EventFromServer = false;
             }
         }
     }

--- a/NebulaClient/PacketProcessors/Planet/RemoveVegetableProcessor.cs
+++ b/NebulaClient/PacketProcessors/Planet/RemoveVegetableProcessor.cs
@@ -1,0 +1,22 @@
+﻿using NebulaModel.Attributes;
+using NebulaModel.Networking;
+using NebulaModel.Packets.Planet;
+using NebulaModel.Packets.Processors;
+using NebulaWorld.Factory;
+
+namespace NebulaClient.PacketProcessors.Planet
+{
+    [RegisterPacketProcessor]
+    class RemoveVegetableProcessor : IPacketProcessor<RemoveVegetablePacket>
+    {
+        public void ProcessPacket(RemoveVegetablePacket packet, NebulaConnection conn)
+        {
+            if (GameMain.data.factories[packet.FactorytId] != null)
+            {
+                FactoryManager.EventFromServer = true;
+                GameMain.data.factories[packet.FactorytId].RemoveVegeWithComponents(packet.VegeId);
+                FactoryManager.EventFromServer = false;
+            }
+        }
+    }
+}

--- a/NebulaHost/NebulaHost.csproj
+++ b/NebulaHost/NebulaHost.csproj
@@ -78,6 +78,7 @@
     <Compile Include="PacketProcessors\GameHistory\GameHistoryResearchContributionProcessor.cs" />
     <Compile Include="PacketProcessors\Planet\FactoryLoadRequestProcessor.cs" />
     <Compile Include="PacketProcessors\Planet\PlanetDataRequestProcessor.cs" />
+    <Compile Include="PacketProcessors\Planet\RemoveVegetableProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerAnimationUpdateProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerColorChangedProcessor.cs" />
     <Compile Include="PacketProcessors\Players\PlayerMechaDataProcessor.cs" />

--- a/NebulaHost/PacketProcessors/Planet/PlanetDataRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Planet/PlanetDataRequestProcessor.cs
@@ -39,10 +39,7 @@ namespace NebulaHost.PacketProcessors.Planet
                     planet.wanted = true;
                     planet.onLoaded += OnActivePlanetLoaded;
                     PlanetModelingManager.modPlanetReqList.Enqueue(planet);
-                }
 
-                if (planet.factory == null)
-                {
                     if (planet.type != EPlanetType.Gas)
                     {
                         planetAlgorithm.GenerateVegetables();

--- a/NebulaHost/PacketProcessors/Planet/RemoveVegetableProcessor.cs
+++ b/NebulaHost/PacketProcessors/Planet/RemoveVegetableProcessor.cs
@@ -1,0 +1,22 @@
+﻿using NebulaModel.Attributes;
+using NebulaModel.Networking;
+using NebulaModel.Packets.Planet;
+using NebulaModel.Packets.Processors;
+using NebulaWorld.Factory;
+
+namespace NebulaHost.PacketProcessors.Planet
+{
+    [RegisterPacketProcessor]
+    class RemoveVegetableProcessor : IPacketProcessor<RemoveVegetablePacket>
+    {
+        public void ProcessPacket(RemoveVegetablePacket packet, NebulaConnection conn)
+        {
+            if (GameMain.data.factories[packet.FactorytId] != null)
+            {
+                FactoryManager.EventFromClient = true;
+                GameMain.data.factories[packet.FactorytId].RemoveVegeWithComponents(packet.VegeId);
+                FactoryManager.EventFromClient = false;
+            }
+        }
+    }
+}

--- a/NebulaHost/PacketProcessors/Planet/RemoveVegetableProcessor.cs
+++ b/NebulaHost/PacketProcessors/Planet/RemoveVegetableProcessor.cs
@@ -2,7 +2,7 @@
 using NebulaModel.Networking;
 using NebulaModel.Packets.Planet;
 using NebulaModel.Packets.Processors;
-using NebulaWorld.Factory;
+using NebulaWorld.Planet;
 
 namespace NebulaHost.PacketProcessors.Planet
 {
@@ -11,11 +11,11 @@ namespace NebulaHost.PacketProcessors.Planet
     {
         public void ProcessPacket(RemoveVegetablePacket packet, NebulaConnection conn)
         {
-            if (GameMain.data.factories[packet.FactorytId] != null)
+            if (GameMain.data.factories[packet.FactorytIndex] != null)
             {
-                FactoryManager.EventFromClient = true;
-                GameMain.data.factories[packet.FactorytId].RemoveVegeWithComponents(packet.VegeId);
-                FactoryManager.EventFromClient = false;
+                PlanetManager.EventFromClient = true;
+                GameMain.data.factories[packet.FactorytIndex].RemoveVegeWithComponents(packet.VegeId);
+                PlanetManager.EventFromClient = false;
             }
         }
     }

--- a/NebulaModel/NebulaModel.csproj
+++ b/NebulaModel/NebulaModel.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Packets\Planet\FactoryLoadRequest.cs" />
     <Compile Include="Packets\Planet\PlanetDataRequest.cs" />
     <Compile Include="Packets\Planet\PlanetDataResponse.cs" />
+    <Compile Include="Packets\Planet\RemoveVegetablePacket.cs" />
     <Compile Include="Packets\Players\PlayerAnimationUpdate.cs" />
     <Compile Include="Packets\Players\PlayerMechaData.cs" />
     <Compile Include="Packets\Players\PlayerMovement.cs" />

--- a/NebulaModel/Packets/Planet/RemoveVegetablePacket.cs
+++ b/NebulaModel/Packets/Planet/RemoveVegetablePacket.cs
@@ -2,14 +2,14 @@
 {
     public class RemoveVegetablePacket
     {
-        public int FactorytId { get; set; }
+        public int FactorytIndex { get; set; }
         public int VegeId { get; set; }
 
         public RemoveVegetablePacket() { }
 
         public RemoveVegetablePacket(int factoryId, int vegeId)
         {
-            FactorytId = factoryId;
+            FactorytIndex = factoryId;
             VegeId = vegeId;
         }
     }

--- a/NebulaModel/Packets/Planet/RemoveVegetablePacket.cs
+++ b/NebulaModel/Packets/Planet/RemoveVegetablePacket.cs
@@ -1,0 +1,16 @@
+﻿namespace NebulaModel.Packets.Planet
+{
+    public class RemoveVegetablePacket
+    {
+        public int FactorytId { get; set; }
+        public int VegeId { get; set; }
+
+        public RemoveVegetablePacket() { }
+
+        public RemoveVegetablePacket(int factoryId, int vegeId)
+        {
+            FactorytId = factoryId;
+            VegeId = vegeId;
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
@@ -5,6 +5,7 @@ using NebulaModel.Packets.Planet;
 using NebulaWorld;
 using NebulaWorld.Factory;
 using UnityEngine;
+using NebulaWorld.Planet;
 
 namespace NebulaPatcher.Patches.Dynamic
 {
@@ -141,7 +142,7 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPatch("RemoveVegeWithComponents")]
         public static void RemoveVegeWithComponents_Prefix(PlanetFactory __instance, int id)
         {
-            if (SimulatedWorld.Initialized && !FactoryManager.EventFromClient && !FactoryManager.EventFromServer)
+            if (SimulatedWorld.Initialized && !PlanetManager.EventFromClient && !PlanetManager.EventFromServer)
             {
                 LocalPlayer.SendPacketToLocalStar(new RemoveVegetablePacket(GameMain.localPlanet?.factoryIndex ?? -1, id));
             }

--- a/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using NebulaModel.Logger;
 using NebulaModel.Packets.Factory;
+using NebulaModel.Packets.Planet;
 using NebulaWorld;
 using NebulaWorld.Factory;
 using UnityEngine;
@@ -133,6 +134,16 @@ namespace NebulaPatcher.Patches.Dynamic
             if (SimulatedWorld.Initialized && !FactoryManager.EventFromClient && !FactoryManager.EventFromServer)
             {
                 LocalPlayer.SendPacketToLocalStar(new FoundationBuildUpdatePacket(radius, reformSize, veinBuried, fade0));
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("RemoveVegeWithComponents")]
+        public static void RemoveVegeWithComponents_Prefix(PlanetFactory __instance, int id)
+        {
+            if (SimulatedWorld.Initialized && !FactoryManager.EventFromClient && !FactoryManager.EventFromServer)
+            {
+                LocalPlayer.SendPacketToLocalStar(new RemoveVegetablePacket(GameMain.localPlanet?.factoryIndex ?? -1, id));
             }
         }
     }

--- a/NebulaWorld/NebulaWorld.csproj
+++ b/NebulaWorld/NebulaWorld.csproj
@@ -51,6 +51,7 @@
     <Compile Include="MonoBehaviours\Remote\RemotePlayerAnimation.cs" />
     <Compile Include="MonoBehaviours\Remote\RemotePlayerEffects.cs" />
     <Compile Include="MonoBehaviours\Remote\RemotePlayerMovement.cs" />
+    <Compile Include="Planet\PlanetManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RemotePlayerModel.cs" />
     <Compile Include="SimulatedWorld.cs" />

--- a/NebulaWorld/Planet/PlanetManager.cs
+++ b/NebulaWorld/Planet/PlanetManager.cs
@@ -1,0 +1,14 @@
+﻿namespace NebulaWorld.Planet
+{
+    public static class PlanetManager
+    {
+        public static bool EventFromServer { get; set; }
+        public static bool EventFromClient { get; set; }
+
+        public static void Initialize()
+        {
+            EventFromServer = false;
+            EventFromClient = false;
+        }
+    }
+}

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -6,6 +6,7 @@ using NebulaModel.Packets.Players;
 using NebulaModel.Packets.Trash;
 using NebulaWorld.Factory;
 using NebulaWorld.MonoBehaviours.Remote;
+using NebulaWorld.Planet;
 using NebulaWorld.Trash;
 using System.Collections.Generic;
 using UnityEngine;
@@ -29,6 +30,7 @@ namespace NebulaWorld
         public static void Initialize()
         {
             FactoryManager.Initialize();
+            PlanetManager.Initialize();
             remotePlayersModels = new Dictionary<ushort, RemotePlayerModel>();
             Initialized = true;
             ExitingMultiplayerSession = false;
@@ -158,30 +160,31 @@ namespace NebulaWorld
                 Debug.Log("FAILED TO SYNC VEGE DATA");
             }
             PlanetData planet = GameMain.galaxy?.PlanetById(pModel.Movement.localPlanetId);
-            if (planet == null)
+            PlanetFactory factory = planet?.factory;
+            if (planet == null || factory == null)
                 return;
 
             if (packet.isVegetable) // Trees, rocks, leaves, etc
             {
-                VegeData vData = (VegeData)planet.factory?.GetVegeData(packet.MiningID);
+                VegeData vData = (VegeData)factory.GetVegeData(packet.MiningID);
                 VegeProto vProto = LDB.veges.Select((int)vData.protoId);
                 if (vProto != null && planet.id == GameMain.localPlanet?.id)
                 {
                     VFEffectEmitter.Emit(vProto.MiningEffect, vData.pos, vData.rot);
                     VFAudio.Create(vProto.MiningAudio, null, vData.pos, true);
                 }
-                planet.factory?.RemoveVegeWithComponents(vData.id);
+                factory.RemoveVegeWithComponents(vData.id);
             }
             else // veins
             {
-                VeinData vData = (VeinData)planet.factory?.GetVeinData(packet.MiningID);
+                VeinData vData = (VeinData)factory.GetVeinData(packet.MiningID);
                 VeinProto vProto = LDB.veins.Select((int)vData.type);
                 if (vProto != null)
                 {
-                    if (planet.factory?.veinPool[packet.MiningID].amount > 0)
+                    if (factory.veinPool[packet.MiningID].amount > 0)
                     {
-                        VeinData[] vPool = planet.factory?.veinPool;
-                        PlanetData.VeinGroup[] vGroups = planet.factory?.planet.veinGroups;
+                        VeinData[] vPool = factory.veinPool;
+                        PlanetData.VeinGroup[] vGroups = factory.planet.veinGroups;
                         long[] vAmounts = planet.veinAmounts;
                         vPool[packet.MiningID].amount -= 1;
                         vGroups[(int)vData.groupIndex].amount -= 1;
@@ -195,7 +198,7 @@ namespace NebulaWorld
                     }
                     else
                     {
-                        PlanetData.VeinGroup[] vGroups = planet.factory?.planet.veinGroups;
+                        PlanetData.VeinGroup[] vGroups = factory.planet.veinGroups;
                         vGroups[vData.groupIndex].count -= 1;
 
                         if (planet.id == GameMain.localPlanet?.id)
@@ -204,7 +207,7 @@ namespace NebulaWorld
                             VFAudio.Create(vProto.MiningAudio, null, vData.pos, true);
                         }
 
-                        planet.factory?.RemoveVeinWithComponents(vData.id);
+                        factory.RemoveVeinWithComponents(vData.id);
                     }
                 }
             }


### PR DESCRIPTION
Following PR solves three issues:

1. #164 - Vegetables were generated twice for the remote planets.
2. #165 - Fix for the exception that was raised on the client-side when host mines on a remote planet.
3. #139 - Vegetables were not destroyed if the player was not on the planet and did not have loaded colliders (for example by calling "FlattenTerrain", that function needs colliders to detect which vegetables need to be destroyed)


