### PR TITLE
Null check for updating colliders

### DIFF
--- a/NebulaPatcher/Patches/Dynamic/ArriveLeavePlanet_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/ArriveLeavePlanet_Patch.cs
@@ -74,14 +74,16 @@ namespace NebulaPatcher.Patches.Dynamic
             if (SimulatedWorld.Initialized && RefreshMissingMeshes && __instance.localPlanet != null)
             {
                 PlanetData planetData = __instance.localPlanet;
-                for (int i = 0; i < planetData.meshColliders.Length; i++)
-                {
-                    if (planetData.meshColliders[i].sharedMesh == null)
+                if (planetData.meshColliders != null) {
+                    for (int i = 0; i < planetData.meshColliders.Length; i++)
                     {
-                        planetData.meshColliders[i].sharedMesh = planetData.meshes[i];
+                        if (planetData.meshColliders[i].sharedMesh == null)
+                        {
+                            planetData.meshColliders[i].sharedMesh = planetData.meshes[i];
+                        }
                     }
+                    RefreshMissingMeshes = false;
                 }
-                RefreshMissingMeshes = false;
             }
         }
 


### PR DESCRIPTION
This is a fix for the #160 

![image](https://user-images.githubusercontent.com/79051050/115106768-d8571b80-9f66-11eb-99de-df31b516df82.png)

I am not sure why, but this is caused by a race condition when ArrivePlanet and GameTick are called before the planet is loaded.

Added null check that will delay the refresh.