### PR TITLE
Bug fix: Loading mecha upgrades for new player

### DIFF
--- a/NebulaClient/PacketProcessors/Factory/Belt/BeltUpdatePickupItemsProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Belt/BeltUpdatePickupItemsProcessor.cs
@@ -12,12 +12,16 @@ namespace NebulaClient.PacketProcessors.Factory.Belt
         {
             if (GameMain.data.factories[packet.FactoryIndex]?.cargoTraffic != null)
             {
+                CargoTraffic traffic = GameMain.data.factories[packet.FactoryIndex].cargoTraffic;
                 //Iterate though belt updates and remove target items
                 for (int i = 0; i < packet.BeltUpdates.Length; i++)
                 {
-                    CargoTraffic traffic = GameMain.data.factories[packet.FactoryIndex].cargoTraffic;
                     CargoPath cargoPath = traffic.GetCargoPath(traffic.beltPool[packet.BeltUpdates[i].BeltId].segPathId);
-                    cargoPath.TryPickItem(packet.BeltUpdates[i].SegId - 4 - 1, 12);
+                    //Check if belt exists
+                    if (cargoPath != null)
+                    {
+                        cargoPath.TryPickItem(packet.BeltUpdates[i].SegId - 4 - 1, 12);
+                    }
                 }
             }
         }

--- a/NebulaHost/PacketProcessors/Factory/Belt/BeltUpdatePickupItemsProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Belt/BeltUpdatePickupItemsProcessor.cs
@@ -10,12 +10,16 @@ namespace NebulaHost.PacketProcessors.Factory.Belt
     {
         public void ProcessPacket(BeltUpdatePickupItemsPacket packet, NebulaConnection conn)
         {
+            CargoTraffic traffic = GameMain.data.factories[packet.FactoryIndex].cargoTraffic;
             //Iterate though belt updates and remove target items
             for (int i = 0; i < packet.BeltUpdates.Length; i++)
             {
-                CargoTraffic traffic = GameMain.data.factories[packet.FactoryIndex].cargoTraffic;
                 CargoPath cargoPath = traffic.GetCargoPath(traffic.beltPool[packet.BeltUpdates[i].BeltId].segPathId);
-                cargoPath.TryPickItem(packet.BeltUpdates[i].SegId - 4 - 1, 12);
+                //Check if belt exists
+                if (cargoPath != null)
+                {
+                    cargoPath.TryPickItem(packet.BeltUpdates[i].SegId - 4 - 1, 12);
+                }
             }
         }
     }

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -341,8 +341,10 @@ namespace NebulaWorld
                 AccessTools.Property(typeof(MechaForge), "mecha").SetValue(GameMain.mainPlayer.mecha.forge, GameMain.mainPlayer.mecha, null);
                 AccessTools.Property(typeof(MechaForge), "player").SetValue(GameMain.mainPlayer.mecha.forge, GameMain.mainPlayer, null);
                 GameMain.mainPlayer.mecha.forge.gameHistory = GameMain.data.history;
+            }
 
-                //Update player's Mecha tech bonuses
+            //Update player's Mecha tech bonuses
+            if (!LocalPlayer.IsMasterClient) {
                 LocalPlayer.Data.Mecha.TechBonuses.UpdateMech(GameMain.mainPlayer.mecha);
             }
 


### PR DESCRIPTION
I had a small issue that mecha upgrades were loaded only for the players whose save state already exists but it did not work for new players.

This will fix issue #169 