### PR TITLE
Added validation if any connected building was destroyed.

### DIFF
--- a/NebulaHost/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
@@ -79,6 +79,7 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                 GameMain.mainPlayer.mecha.buildArea = float.MaxValue;
                 FactoryManager.IgnoreBasicBuildConditionChecks = true;
                 bool canBuild = pab.CheckBuildConditions();
+                canBuild &= CheckBuildingConnections(pab.buildPreviews, planet.factory);
                 FactoryManager.IgnoreBasicBuildConditionChecks = false;
 
                 if (canBuild)
@@ -104,9 +105,39 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                 FactoryManager.EventFactory = null;
                 pab.buildPreviews = tmpList;
                 pab.waitConfirm = tmpConfirm;
-                pab.previewPose.position = tmpPos;
+                pab.previewPose.position = tmpPos; 
                 pab.previewPose.rotation = tmpRot;
             }
+        }
+
+        public bool CheckBuildingConnections(List<BuildPreview> buildPreviews, PlanetFactory factory)
+        {
+            //Check if some entity that is suppose to be connected to this building is missing
+            for(int i = 0; i < buildPreviews.Count; i++)
+            {
+                bool isInputOk = true;
+                if (buildPreviews[i].inputObjId > 0)
+                {
+                    isInputOk = factory.entityPool.Length >= buildPreviews[i].inputObjId && factory.entityPool[buildPreviews[i].inputObjId].id != 0;
+                } else if (buildPreviews[i].inputObjId < 0)
+                {
+                    isInputOk = factory.prebuildPool.Length >= -buildPreviews[i].inputObjId && factory.prebuildPool[-buildPreviews[i].inputObjId].id != 0;
+                }
+                bool isOutputOk = true;
+                if (buildPreviews[i].outputObjId > 0)
+                {
+                    isInputOk = factory.entityPool.Length >= buildPreviews[i].outputObjId && factory.entityPool[buildPreviews[i].outputObjId].id != 0;
+                }
+                else if (buildPreviews[i].outputObjId < 0)
+                {
+                    isInputOk = factory.prebuildPool.Length >= -buildPreviews[i].outputObjId && factory.prebuildPool[-buildPreviews[i].outputObjId].id != 0;
+                }
+                if (!isInputOk || !isOutputOk)
+                {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 }


### PR DESCRIPTION
This is a fix for the "floating storage issue" #171 

This issue can also cause #158 and #150 if some building connections are mismatched.

The issue can happen like this:
1. Client will send a request to build 2nd level of storage
2. At the same time host will delete the 1st level of storage
3. Host will receive the request to build the 2nd level and accept that request since there is no validation for this situation.

![output](https://user-images.githubusercontent.com/79051050/115116892-4ec24080-9f9c-11eb-9104-40b9e3ba0d2d.gif)

This issue affects other stuff that relates to the building connected to other buildings.

I have added validation on the host, to check all expected connections to other buildings and if some building does not exist, it will deny a request to build.