### PR TITLE
Bug fix for items being granted to all players when belt was destroyed

### DIFF
--- a/NebulaClient/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
@@ -35,6 +35,7 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                     }
                 }
                 planet.factory.DestructFinally(GameMain.mainPlayer, packet.ObjId, ref protoId);
+                FactoryManager.DoNotAddItemsFromBuildingOnDestruct = false;
                 FactoryManager.EventFromServer = false;
             }
         }

--- a/NebulaPatcher/Patches/Transpilers/CargoTraffic_Patch.cs
+++ b/NebulaPatcher/Patches/Transpilers/CargoTraffic_Patch.cs
@@ -82,11 +82,6 @@ namespace NebulaPatcher.Patches.Transpiler
                                     new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(FactoryManager), "get_DoNotAddItemsFromBuildingOnDestruct")),
                                     new CodeInstruction(OpCodes.Brtrue_S, codes[i-1].operand),
                                     });
-                    UnityEngine.Debug.Log("FOUND!");
-                    for(int j = 0; j < 10; j++)
-                    {
-                        UnityEngine.Debug.Log($"{codes[i-7+j].opcode} - {codes[i - 7 + j].operand}");
-                    }
                     break;
                 }
             }

--- a/NebulaPatcher/Patches/Transpilers/CargoTraffic_Patch.cs
+++ b/NebulaPatcher/Patches/Transpilers/CargoTraffic_Patch.cs
@@ -47,5 +47,50 @@ namespace NebulaPatcher.Patches.Transpiler
             }
             return codes;
         }
+
+        /* Change:
+                if (num27 > 0)
+					{
+						int upCount = GameMain.mainPlayer.TryAddItemToPackage(num27, 1, true, this.beltPool[beltId].entityId);
+						UIItemup.Up(num27, upCount);
+					}
+
+         * To:
+            if (num27 > 0 && !FactoryManager.DoNotAddItemsFromBuildingOnDestruct)
+					{
+						int upCount = GameMain.mainPlayer.TryAddItemToPackage(num27, 1, true, this.beltPool[beltId].entityId);
+						UIItemup.Up(num27, upCount);
+					}
+         */
+        [HarmonyTranspiler]
+        [HarmonyPatch("AlterBeltConnections")]
+        static IEnumerable<CodeInstruction> AlterBeltConnections_Transpiler(ILGenerator gen, IEnumerable<CodeInstruction> instructions)
+        {
+            var codes = new List<CodeInstruction>(instructions);
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (codes[i].opcode == OpCodes.Call && codes[i].operand?.ToString() == "Player get_mainPlayer()" &&
+                    codes[i - 1].opcode == OpCodes.Ble &&
+                    codes[i - 2].opcode == OpCodes.Ldc_I4_0 &&
+                    codes[i - 3].opcode == OpCodes.Ldloc_S &&
+                    codes[i - 4].opcode == OpCodes.Stloc_S &&
+                    codes[i - 5].opcode == OpCodes.Ldelem_I4 &&
+                    codes[i - 6].opcode == OpCodes.Ldloc_S &&
+                    codes[i - 7].opcode == OpCodes.Ldfld)
+                {
+                    codes.InsertRange(i, new CodeInstruction[] {
+                                    new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(FactoryManager), "get_DoNotAddItemsFromBuildingOnDestruct")),
+                                    new CodeInstruction(OpCodes.Brtrue_S, codes[i-1].operand),
+                                    });
+                    UnityEngine.Debug.Log("FOUND!");
+                    for(int j = 0; j < 10; j++)
+                    {
+                        UnityEngine.Debug.Log($"{codes[i-7+j].opcode} - {codes[i - 7 + j].operand}");
+                    }
+                    break;
+                }
+            }
+            return codes;
+        }
     }
 }


### PR DESCRIPTION
This is a fix for the #173 

When someone destroyed a belt with the item on it, that item would be granted to every player.

I have added very small transpiler to bypass it :)