### PR TITLE
Change the source of the username from GameMain to AccountData

### DIFF
--- a/NebulaClient/MultiplayerClientSession.cs
+++ b/NebulaClient/MultiplayerClientSession.cs
@@ -111,7 +111,7 @@ namespace NebulaClient
             serverConnection = new NebulaConnection(clientSocket, serverEndpoint, PacketProcessor);
             IsConnected = true;
             //TODO: Maybe some challenge-response authentication mechanism?
-            SendPacket(new HandshakeRequest(CryptoUtils.GetPublicKey(CryptoUtils.GetOrCreateUserCert()), GameMain.data.account.userName));
+            SendPacket(new HandshakeRequest(CryptoUtils.GetPublicKey(CryptoUtils.GetOrCreateUserCert()), AccountData.me.userName));
         }
 
         private void ClientSocket_OnClose(object sender, CloseEventArgs e)


### PR DESCRIPTION
This stops usernames being empty sometimes, as the details may not have yet been populated in GameMain when the username is sent from the client.