### PR TITLE
Fixed an issue where gas planets throws a null ref exception because …

### DIFF
--- a/NebulaPatcher/Patches/Dynamic/ArriveLeavePlanet_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/ArriveLeavePlanet_Patch.cs
@@ -74,10 +74,11 @@ namespace NebulaPatcher.Patches.Dynamic
             if (SimulatedWorld.Initialized && RefreshMissingMeshes && __instance.localPlanet != null)
             {
                 PlanetData planetData = __instance.localPlanet;
+                
                 if (planetData.meshColliders != null) {
                     for (int i = 0; i < planetData.meshColliders.Length; i++)
                     {
-                        if (planetData.meshColliders[i].sharedMesh == null)
+                        if (planetData.meshColliders[i] != null && planetData.meshColliders[i].sharedMesh == null)
                         {
                             planetData.meshColliders[i].sharedMesh = planetData.meshes[i];
                         }


### PR DESCRIPTION
…of a missing meshcollider at index 16. I assume this is because it has no actual terrain, but don't know for certain why.