### PR TITLE
Adding soil to the correct player

### DIFF
--- a/NebulaClient/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
@@ -19,6 +19,7 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
             {
                 FactoryManager.EventFromServer = true;
                 FactoryManager.EventFactory = planet.factory;
+                FactoryManager.PacketAuthor = packet.AuthorId;
 
                 // Physics could be null, if the host is not on the requested planet
                 if (packet.PlanetId != GameMain.localPlanet?.id)
@@ -42,6 +43,7 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                     planet.audio = null;
                 }
 
+                FactoryManager.PacketAuthor = -1;
                 FactoryManager.EventFromServer = false;
                 FactoryManager.EventFactory = null;
             }

--- a/NebulaHost/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
@@ -22,6 +22,7 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
             FactoryManager.EventFromClient = true;
             PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
             FactoryManager.EventFactory = planet.factory;
+            FactoryManager.PacketAuthor = packet.AuthorId;
 
             // Physics could be null, if the host is not on the requested planet
             // Make sure to init all the planet data required to perform the BuildFinally of the distant planet
@@ -51,6 +52,7 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                 planet.audio = null;
             }
 
+            FactoryManager.PacketAuthor = -1;
             FactoryManager.EventFromClient = false;
             FactoryManager.EventFactory = null;
         }

--- a/NebulaModel/Packets/Factory/BuildEntityRequest.cs
+++ b/NebulaModel/Packets/Factory/BuildEntityRequest.cs
@@ -4,12 +4,14 @@
     {
         public int PlanetId { get; set; }
         public int PrebuildId { get; set; }
+        public int AuthorId { get; set; }
 
         public BuildEntityRequest() { }
-        public BuildEntityRequest(int planetId, int prebuildId)
+        public BuildEntityRequest(int planetId, int prebuildId, int authorId)
         {
             PlanetId = planetId;
             PrebuildId = prebuildId;
+            AuthorId = authorId;
         }
     }
 }

--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Patches\Dynamic\PlanetModelingManager_Patch.cs" />
     <Compile Include="Patches\Dynamic\PlanetPhysics_Patch.cs" />
     <Compile Include="Patches\Dynamic\PlayerAction_Build_Patch.cs" />
+    <Compile Include="Patches\Dynamic\Player_Patch.cs" />
     <Compile Include="Patches\Dynamic\ProductionStatistics_Patch.cs" />
     <Compile Include="Patches\Dynamic\SplitterComponent_Patch.cs" />
     <Compile Include="Patches\Dynamic\TrashContainer_Patch.cs" />

--- a/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
@@ -52,7 +52,7 @@ namespace NebulaPatcher.Patches.Dynamic
 
             if (LocalPlayer.IsMasterClient || !FactoryManager.EventFromServer)
             {
-                LocalPlayer.SendPacket(new BuildEntityRequest(__instance.planetId, prebuildId));
+                LocalPlayer.SendPacket(new BuildEntityRequest(__instance.planetId, prebuildId, FactoryManager.PacketAuthor == -1 ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor));
             }
 
             return LocalPlayer.IsMasterClient || FactoryManager.EventFromServer;

--- a/NebulaPatcher/Patches/Dynamic/Player_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/Player_Patch.cs
@@ -15,7 +15,7 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPatch("SetSandCount")]
         public static bool RemoveLayer_Prefix()
         {
-            //Soil should be given in singleplayer or to he player who is author of the "Build" request, or to the host if there is no author.
+            //Soil should be given in singleplayer or to the player who is author of the "Build" request, or to the host if there is no author.
             return !SimulatedWorld.Initialized || FactoryManager.PacketAuthor == LocalPlayer.PlayerId || FactoryManager.PacketAuthor == -1;
         }
     }

--- a/NebulaPatcher/Patches/Dynamic/Player_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/Player_Patch.cs
@@ -1,0 +1,22 @@
+﻿using HarmonyLib;
+using NebulaModel.Packets.Universe;
+using NebulaWorld;
+using NebulaWorld.Universe;
+using System;
+using UnityEngine;
+using NebulaWorld.Factory;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(Player))]
+    class Player_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch("SetSandCount")]
+        public static bool RemoveLayer_Prefix()
+        {
+            //Soil should be given in singleplayer or to he player who is author of the "Build" request, or to the host if there is no author.
+            return !SimulatedWorld.Initialized || FactoryManager.PacketAuthor == LocalPlayer.PlayerId || FactoryManager.PacketAuthor == -1;
+        }
+    }
+}

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -392,6 +392,7 @@ namespace NebulaWorld
                 GameMain.mainPlayer.mecha.reactorEnergy = LocalPlayer.Data.Mecha.ReactorEnergy;
                 GameMain.mainPlayer.mecha.reactorStorage = LocalPlayer.Data.Mecha.ReactorStorage;
                 GameMain.mainPlayer.mecha.warpStorage = LocalPlayer.Data.Mecha.WarpStorage;
+                AccessTools.Property(typeof(global::Player), "sandCount").SetValue(GameMain.mainPlayer, LocalPlayer.Data.Mecha.SandCount, null);
 
                 //Fix references that brokes during import
                 AccessTools.Property(typeof(MechaForge), "mecha").SetValue(GameMain.mainPlayer.mecha.forge, GameMain.mainPlayer.mecha, null);

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -392,7 +392,7 @@ namespace NebulaWorld
                 GameMain.mainPlayer.mecha.reactorEnergy = LocalPlayer.Data.Mecha.ReactorEnergy;
                 GameMain.mainPlayer.mecha.reactorStorage = LocalPlayer.Data.Mecha.ReactorStorage;
                 GameMain.mainPlayer.mecha.warpStorage = LocalPlayer.Data.Mecha.WarpStorage;
-                AccessTools.Property(typeof(global::Player), "sandCount").SetValue(GameMain.mainPlayer, LocalPlayer.Data.Mecha.SandCount, null);
+                GameMain.mainPlayer.SetSandCount(LocalPlayer.Data.Mecha.SandCount);
 
                 //Fix references that brokes during import
                 AccessTools.Property(typeof(MechaForge), "mecha").SetValue(GameMain.mainPlayer.mecha.forge, GameMain.mainPlayer.mecha, null);


### PR DESCRIPTION
This is a fix for the #174 where the soil is added to all players when the building is placed.

When the host sends the `EntityBuilt` packet to the clients, it also includes the `id` of the author who builds it, and this author will receive the soil. I add a check, that prevents adding soil if the client is not the author of the build.

![output](https://user-images.githubusercontent.com/79051050/115143769-8b984100-a049-11eb-93c1-7ec3fa16d3aa.gif)
