### PR TITLE
PR comments addressed + Bug fix

### DIFF
--- a/NebulaClient/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
@@ -49,7 +49,7 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                         planet.physics = new PlanetPhysics(planet);
                         planet.physics.Init();
                     }
-                    if (AccessTools.Field(typeof(CargoTraffic), "beltRenderingBatch").GetValue(planet.factory.cargoTraffic) == null)
+                    if (BeltManager.GetCargoTraffic(planet.factory.cargoTraffic) == null)
                     {
                         planet.factory.cargoTraffic.CreateRenderingBatches();
                     }

--- a/NebulaClient/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
@@ -36,7 +36,17 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                             }
                         }
                     }
+                    if (packet.PlanetId != GameMain.mainPlayer.planetId)
+                    {
+                        //Creating rendering batches is required to properly handle DestructFinally for the belts, since model needs to be changed.
+                        //ToDo: Optimize it somehow, since creating and destroying rendering batches is not optimal.
+                        planet.factory.cargoTraffic.CreateRenderingBatches();
+                    }
                     planet.factory.DestructFinally(GameMain.mainPlayer, packet.ObjId, ref protoId);
+                    if (packet.PlanetId != GameMain.mainPlayer.planetId)
+                    {
+                        planet.factory.cargoTraffic.DestroyRenderingBatches();
+                    }
                 }
             }
         }

--- a/NebulaClient/PacketProcessors/Factory/Foundation/FoundationBuildUpdateProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Foundation/FoundationBuildUpdateProcessor.cs
@@ -11,6 +11,8 @@ namespace NebulaClient.PacketProcessors.Factory.Foundation
     [RegisterPacketProcessor]
     class FoundationBuildUpdateProcessor : IPacketProcessor<FoundationBuildUpdatePacket>
     {
+        Vector3[] reformPoints = new Vector3[100];
+
         public void ProcessPacket(FoundationBuildUpdatePacket packet, NebulaConnection conn)
         {
             //Check if client has loaded planet
@@ -18,8 +20,11 @@ namespace NebulaClient.PacketProcessors.Factory.Foundation
             PlanetFactory factory = planet?.factory;
             if (factory != null)
             {
-                Vector3[] reformPoints = new Vector3[100];
                 Vector3 reformCenterPoint = new Vector3();
+                for (int i = 0; i < reformPoints.Length; i++)
+                {
+                    reformPoints[i] = Vector3.zero;
+                }
                 if (factory.platformSystem.reformData == null)
                 {
                     factory.platformSystem.InitReformData();

--- a/NebulaHost/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
@@ -61,7 +61,7 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                         planet.physics = new PlanetPhysics(planet);
                         planet.physics.Init();
                     }
-                    if (AccessTools.Field(typeof(CargoTraffic), "beltRenderingBatch").GetValue(planet.factory.cargoTraffic) == null)
+                    if (BeltManager.GetCargoTraffic(planet.factory.cargoTraffic) == null)
                     {
                         planet.factory.cargoTraffic.CreateRenderingBatches();
                     }

--- a/NebulaHost/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
@@ -18,7 +18,17 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                 using (FactoryManager.DoNotAddItemsFromBuildingOnDestruct.On())
                 {
                     FactoryManager.PacketAuthor = packet.AuthorId;
+                    if (packet.PlanetId != GameMain.mainPlayer.planetId)
+                    {
+                        //Creating rendering batches is required to properly handle DestructFinally for the belts, since model needs to be changed.
+                        //ToDo: Optimize it somehow, since creating and destroying rendering batches is not optimal.
+                        planet.factory.cargoTraffic.CreateRenderingBatches();
+                    }
                     planet.factory.DestructFinally(GameMain.mainPlayer, packet.ObjId, ref protoId);
+                    if (packet.PlanetId != GameMain.mainPlayer.planetId)
+                    {
+                        planet.factory.cargoTraffic.DestroyRenderingBatches();
+                    }
                     FactoryManager.PacketAuthor = -1;
                 }
             }

--- a/NebulaHost/PacketProcessors/Factory/Foundation/FoundationBuildUpdateProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Foundation/FoundationBuildUpdateProcessor.cs
@@ -11,12 +11,17 @@ namespace NebulaHost.PacketProcessors.Factory.Foundation
     [RegisterPacketProcessor]
     class FoundationBuildUpdateProcessor : IPacketProcessor<FoundationBuildUpdatePacket>
     {
+        Vector3[] reformPoints = new Vector3[100];
+
         public void ProcessPacket(FoundationBuildUpdatePacket packet, NebulaConnection conn)
         {
             PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
             PlanetFactory factory = GameMain.data.GetOrCreateFactory(planet);
-            Vector3[] reformPoints = new Vector3[100];
             Vector3 reformCenterPoint = new Vector3();
+            for(int i = 0; i < reformPoints.Length; i++)
+            {
+                reformPoints[i] = Vector3.zero;
+            }
 
             //Check if some mandatory variables are missing
             if (factory.platformSystem.reformData == null)

--- a/NebulaWorld/Factory/BeltManager.cs
+++ b/NebulaWorld/Factory/BeltManager.cs
@@ -8,8 +8,8 @@ namespace NebulaWorld.Factory
     {
         public static List<BeltUpdate> BeltUpdates = new List<BeltUpdate>();
 
-        public static readonly AccessTools.FieldRef<object, CargoTraffic> GetCargoTraffic =
-            AccessTools.FieldRefAccess<CargoTraffic>(typeof(CargoTraffic), "beltRenderingBatch");
+        public static readonly AccessTools.FieldRef<object, BeltRenderingBatch[]> GetCargoTraffic =
+            AccessTools.FieldRefAccess<BeltRenderingBatch[]>(typeof(CargoTraffic), "beltRenderingBatch");
 
         public static void BeltPickupStarted()
         {

--- a/NebulaWorld/Factory/BeltManager.cs
+++ b/NebulaWorld/Factory/BeltManager.cs
@@ -1,4 +1,5 @@
-﻿using NebulaModel.Packets.Belt;
+﻿using HarmonyLib;
+using NebulaModel.Packets.Belt;
 using System.Collections.Generic;
 
 namespace NebulaWorld.Factory
@@ -6,6 +7,10 @@ namespace NebulaWorld.Factory
     public static class BeltManager
     {
         public static List<BeltUpdate> BeltUpdates = new List<BeltUpdate>();
+
+        public static readonly AccessTools.FieldRef<object, CargoTraffic> GetCargoTraffic =
+            AccessTools.FieldRefAccess<CargoTraffic>(typeof(CargoTraffic), "beltRenderingBatch");
+
         public static void BeltPickupStarted()
         {
             BeltUpdates.Clear();


### PR DESCRIPTION
I have addressed two comments from @Therzok:

- Cache array of vectors: https://github.com/hubastard/nebula/pull/149#discussion_r615412386

- Avoiding allocation: https://github.com/hubastard/nebula/pull/124#discussion_r615393843

- Bugfix for missing renderer for belts. When someone deletes a belt and the host is not on the planet, the belt renderer is required to successfully perform `DestructFinally`. I put ToDo that this can be optimized in the future, right now, it just prevents error messages.