### PR TITLE
Added seperate IP and URL address handling

### DIFF
--- a/NebulaClient/MultiplayerClientSession.cs
+++ b/NebulaClient/MultiplayerClientSession.cs
@@ -18,7 +18,7 @@ namespace NebulaClient
         public static MultiplayerClientSession Instance { get; protected set; }
 
         private WebSocket clientSocket;
-        private IPEndPoint serverEndpoint;
+        private EndPoint serverEndpoint;
         private NebulaConnection serverConnection;
         private float mechaSynchonizationTimer = 0f;
 
@@ -26,22 +26,33 @@ namespace NebulaClient
         public bool IsConnected { get; protected set; }
 
         private const int MECHA_SYNCHONIZATION_INTERVAL = 5;
-
-        private string serverIp;
-        private int serverPort;
+        private string socketAddress;
 
         private void Awake()
         {
             Instance = this;
         }
 
-        public void Connect(string ip, int port)
+        public void ConnectToIp(IPAddress ip, int port)
         {
-            serverIp = ip;
-            serverPort = port;
-            serverEndpoint = new IPEndPoint(IPAddress.Parse(serverIp), port);
+            serverEndpoint = new IPEndPoint(ip, port);
+            socketAddress = $"ws://{ip}:{port}/socket";
+            Log.Info($"Connect to IP: {socketAddress}");
+            ConnectInternal();
+        }
 
-            clientSocket = new WebSocket($"ws://{ip}:{port}/socket");
+        public void ConnectToUrl(string url, int port)
+        {
+            IPHostEntry host = Dns.GetHostEntry(url);
+            serverEndpoint = new IPEndPoint(host.AddressList[0], port);
+            socketAddress = $"ws://{url}:{port}/socket";
+            Log.Info($"Connect to URL: {socketAddress}");
+            ConnectInternal();
+        }
+
+        private void ConnectInternal()
+        {
+            clientSocket = new WebSocket(socketAddress);
             clientSocket.OnOpen += ClientSocket_OnOpen;
             clientSocket.OnClose += ClientSocket_OnClose;
             clientSocket.OnMessage += ClientSocket_OnMessage;
@@ -97,7 +108,7 @@ namespace NebulaClient
         {
             SimulatedWorld.Clear();
             Disconnect();
-            Connect(serverIp, serverPort);
+            ConnectInternal();
         }
 
         private void ClientSocket_OnMessage(object sender, MessageEventArgs e)
@@ -149,7 +160,7 @@ namespace NebulaClient
                 {
                     InGamePopup.ShowWarning(
                         "Connection Lost",
-                        $"You have been disconnect of the server.\n{e.Reason}",
+                        $"You have been disconnected from the server.\n{e.Reason}",
                         "Quit", "Reconnect",
                         () => { LocalPlayer.LeaveGame(); },
                         () => { Reconnect(); });

--- a/NebulaModel/Networking/NebulaConnection.cs
+++ b/NebulaModel/Networking/NebulaConnection.cs
@@ -7,13 +7,13 @@ namespace NebulaModel.Networking
 {
     public class NebulaConnection
     {
-        private readonly IPEndPoint peerEndpoint;
+        private readonly EndPoint peerEndpoint;
         private readonly WebSocket peerSocket;
         private readonly NetPacketProcessor packetProcessor;
 
         public bool IsAlive => peerSocket?.IsAlive ?? false;
 
-        public NebulaConnection(WebSocket peerSocket, IPEndPoint peerEndpoint, NetPacketProcessor packetProcessor)
+        public NebulaConnection(WebSocket peerSocket, EndPoint peerEndpoint, NetPacketProcessor packetProcessor)
         {
             this.peerEndpoint = peerEndpoint;
             this.peerSocket = peerSocket;

--- a/NebulaPatcher/Patches/Dynamic/UIMainMenu_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIMainMenu_Patch.cs
@@ -155,7 +155,9 @@ namespace NebulaPatcher.Patches.Dynamic
             hostIPAdressInput = hostIpField.GetComponentInChildren<InputField>();
             hostIPAdressInput.onEndEdit.RemoveAllListeners();
             hostIPAdressInput.onValueChanged.RemoveAllListeners();
-            hostIPAdressInput.characterLimit = 255;     //note: arbitarily chosen, should be enough for most dns services
+            //note: connectToUrl uses Dns.getHostEntry, which can only use up to 255 chars.
+            //256 will trigger an argument out of range exception
+            hostIPAdressInput.characterLimit = 255;    
             hostIPAdressInput.text = "127.0.0.1";
 
             OverrideButton(multiplayerMenu.Find("start-button").GetComponent<RectTransform>(), "Join Game", OnJoinGameButtonClick);

--- a/NebulaPatcher/Patches/Dynamic/UIMainMenu_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIMainMenu_Patch.cs
@@ -155,7 +155,7 @@ namespace NebulaPatcher.Patches.Dynamic
             hostIPAdressInput = hostIpField.GetComponentInChildren<InputField>();
             hostIPAdressInput.onEndEdit.RemoveAllListeners();
             hostIPAdressInput.onValueChanged.RemoveAllListeners();
-            hostIPAdressInput.characterLimit = 30;
+            hostIPAdressInput.characterLimit = 255;     //note: arbitarily chosen, should be enough for most dns services
             hostIPAdressInput.text = "127.0.0.1";
 
             OverrideButton(multiplayerMenu.Find("start-button").GetComponent<RectTransform>(), "Join Game", OnJoinGameButtonClick);
@@ -185,15 +185,49 @@ namespace NebulaPatcher.Patches.Dynamic
             multiplayerMenu.gameObject.SetActive(false);
 
             Log.Info($"Connecting to server... {ip}:{port}");
-
-            var session = NebulaBootstrapper.Instance.CreateMultiplayerClientSession();
-            session.Connect(ip, port);
+            if(!ConnectToServer(ip, port))
+            {
+                //re-enabling the menu again after failed connect attempt
+                Log.Warn($"Was not able to connect to {hostIPAdressInput.text}");
+                InGamePopup.ShowWarning("Connect failed", $"Was not able to connect to {hostIPAdressInput.text}", "OK");
+                multiplayerMenu.gameObject.SetActive(true);
+            }
         }
 
         private static void OnJoinGameBackButtonClick()
         {
             multiplayerMenu.gameObject.SetActive(false);
             UIRoot.instance.OpenMainMenuUI();
+        }
+
+        private static bool ConnectToServer(string connectionString, int serverPort)
+        {
+            NebulaClient.MultiplayerClientSession session; 
+
+            //trying as ipAddress first
+            bool isValidIp = System.Net.IPAddress.TryParse(connectionString, out var serverIp);
+            if (isValidIp)
+            {
+                switch (serverIp.AddressFamily)
+                {
+                    case System.Net.Sockets.AddressFamily.InterNetwork:
+                    case System.Net.Sockets.AddressFamily.InterNetworkV6:
+                        session = NebulaBootstrapper.Instance.CreateMultiplayerClientSession();
+                        session.ConnectToIp(serverIp, serverPort);
+                        return true;
+                    default:
+                        break;
+                }
+            }
+
+            //trying to resolve as uri
+            if (System.Uri.TryCreate(connectionString, System.UriKind.RelativeOrAbsolute, out var serverUri))
+            {
+                session = NebulaBootstrapper.Instance.CreateMultiplayerClientSession();
+                session.ConnectToUrl(connectionString, serverPort);
+                return true;
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
-Extended Stringbox length for the longer addresses (open for different sizes)
-Naive deduction about connection type: check is IP, if not, try as URL, else stop
-Connecting is internally handled in different methods for URL/IPs

"Tests":
-Connected to Server with their fritzbox-URL
-After playing for a while, pulling my LAN-cable and later reconnected with the ingame dialog