### PR TITLE
Drone Target System Refactored

### DIFF
--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Patches\Dynamic\GameSave_Patch.cs" />
     <Compile Include="Patches\Dynamic\GameScenarioLogic_Patch.cs" />
     <Compile Include="Patches\Dynamic\GameStatData_Patch.cs" />
+    <Compile Include="Patches\Dynamic\MechaDroneLogic_Patch.cs" />
     <Compile Include="Patches\Dynamic\PlanetData_Patch.cs" />
     <Compile Include="Patches\Dynamic\Mecha_Patch.cs" />
     <Compile Include="Patches\Dynamic\PlanetFactory_Patch.cs" />

--- a/NebulaPatcher/Patches/Dynamic/MechaDroneLogic_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/MechaDroneLogic_Patch.cs
@@ -1,0 +1,20 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+using NebulaWorld.Player;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(MechaDroneLogic))]
+    class MechaDroneLogic_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch("UpdateTargets")]
+        public static void UpdateTargets_Prefix()
+        {
+            if (SimulatedWorld.Initialized)
+            {
+                DroneManager.ClearCachedPositions();
+            }
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Transpilers/MechaDroneLogic_Patch.cs
+++ b/NebulaPatcher/Patches/Transpilers/MechaDroneLogic_Patch.cs
@@ -2,6 +2,7 @@
 using NebulaWorld.Player;
 using System.Collections.Generic;
 using System.Reflection.Emit;
+using UnityEngine;
 
 namespace NebulaPatcher.Patches.Transpiler
 {
@@ -39,7 +40,7 @@ namespace NebulaPatcher.Patches.Transpiler
                  if (a.sqrMagnitude > this.sqrMinBuildAlt && sqrMagnitude <= num2 && !this.serving.Contains(num4))
              * 
              * To:
-                 if (a.sqrMagnitude > this.sqrMinBuildAlt && sqrMagnitude <= num2 && !this.serving.Contains(num4) && !DroneManager.IsPendingBuildRequest(num4))
+                 if (a.sqrMagnitude > this.sqrMinBuildAlt && sqrMagnitude <= num2 && !this.serving.Contains(num4) && !DroneManager.IsPendingBuildRequest(num4) && DroneManager.AmIClosestPlayer(sqrMagnitude, ref a))
              */
             for (int i = 0; i < codes.Count; i++)
             {
@@ -53,6 +54,9 @@ namespace NebulaPatcher.Patches.Transpiler
                         new CodeInstruction(OpCodes.Ldloc_S, 6),
                         new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(DroneManager), nameof(DroneManager.IsPendingBuildRequest), new System.Type[] { typeof(int) })),
                         new CodeInstruction(OpCodes.Brtrue_S, codes[i].operand),
+                        new CodeInstruction(OpCodes.Ldloca_S, 7),
+                        new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(DroneManager), nameof(DroneManager.AmIClosestPlayer), new System.Type[] { typeof(Vector3).MakeByRefType() })),
+                        new CodeInstruction(OpCodes.Brfalse_S, codes[i].operand),
                         });
                     break;
                 }

--- a/NebulaWorld/Player/DroneManager.cs
+++ b/NebulaWorld/Player/DroneManager.cs
@@ -1,15 +1,17 @@
-﻿using NebulaModel.Packets.Players;
-using System;
+﻿using NebulaModel.DataStructures;
+using NebulaModel.Packets.Players;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace NebulaWorld.Player
 {
     public static class DroneManager
     {
         public static int[] DronePriorities = new int[255];
-        public static Random rnd = new Random();
+        public static System.Random rnd = new System.Random();
         public static Dictionary<ushort, List<int>> PlayerDroneBuildingPlans = new Dictionary<ushort, List<int>>();
         public static List<int> PendingBuildRequests = new List<int>();
+        public static Dictionary<ushort, Vector3> CachedPositions = new Dictionary<ushort, Vector3>();
 
         public static void BroadcastDroneOrder(int droneId, int entityId, int stage)
         {
@@ -70,6 +72,43 @@ namespace NebulaWorld.Player
         public static bool RemoveBuildRequest(int entityId)
         {
             return PendingBuildRequests.Remove(entityId);
+        }
+
+        public static void ClearCachedPositions()
+        {
+            CachedPositions.Clear();
+        }
+
+        public static bool AmIClosestPlayer(ref Vector3 entityPos)
+        {
+            if (!SimulatedWorld.Initialized)
+            {
+                return true;
+            }
+            float myDistance = (GameMain.mainPlayer.position - entityPos).sqrMagnitude;
+            using (SimulatedWorld.GetRemotePlayersModels(out var remotePlayersModels))
+            {
+                foreach (var model in remotePlayersModels.Values)
+                {
+                    //Check only players on the same planet
+                    if (model.Movement.GetLastPosition().LocalPlanetId != GameMain.mainPlayer.planetId)
+                    {
+                        continue;
+                    }
+                    //Cache players positions for this looking for traget session
+                    if (!CachedPositions.ContainsKey(model.PlayerId))
+                    {
+                        CachedPositions.Add(model.PlayerId, model.Movement.GetLastPosition().LocalPlanetPosition.ToVector3());
+                    }
+                    //If remote player is closer, ignore the entity
+                    if (myDistance > (CachedPositions[model.PlayerId] - entityPos).sqrMagnitude)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -7,7 +7,6 @@ using NebulaModel.Packets.Trash;
 using NebulaWorld.Factory;
 using NebulaWorld.MonoBehaviours.Remote;
 using NebulaWorld.Planet;
-using NebulaWorld.Player;
 using NebulaWorld.Trash;
 using System.Collections.Generic;
 using UnityEngine;
@@ -168,64 +167,9 @@ namespace NebulaWorld
                     drone.progress = 0f;
                     player.MechaInstance.droneCount = GameMain.mainPlayer.mecha.droneCount;
                     player.MechaInstance.droneSpeed = GameMain.mainPlayer.mecha.droneSpeed;
-                    Mecha myMecha = GameMain.mainPlayer.mecha;
                     if (packet.Stage == 3)
                     {
-                        myMecha.droneLogic.serving.Remove(packet.EntityId);
-                    }
-
-                    if (drone.stage == 1 || drone.stage == 2)
-                    {
-                        //Check if target entity exists as Prebuild
-                        if (GameMain.data.localPlanet.factory.prebuildPool.Length <= -packet.EntityId || GameMain.data.localPlanet.factory.prebuildPool[-packet.EntityId].id == 0)
-                        {
-                            return;
-                        }
-
-                        //Check target prebuild if it is same prebuild that I have. Sometimes it is same ID, but different prebuild
-                        ref PrebuildData prebuildData = ref GameMain.data.localPlanet.factory.prebuildPool[-packet.EntityId];
-                        if (prebuildData.pos.x != packet.EntityPos.x || prebuildData.pos.y != packet.EntityPos.y || prebuildData.pos.z != packet.EntityPos.z)
-                        {
-                            return;
-                        }
-
-                        //Check if my drone is already going there
-                        if (!myMecha.droneLogic.serving.Contains(packet.EntityId))
-                        {
-                            myMecha.droneLogic.serving.Add(packet.EntityId);
-                        }
-                        else
-                        {
-                            //resolve conflict (two drones are going to the same building)
-                            //find my drone that is going there
-                            int priority = 0;
-                            int droneId = 0;
-                            for (int i = 0; i < myMecha.droneCount; i++)
-                            {
-                                if (myMecha.drones[i].stage > 0 && myMecha.drones[i].targetObject == drone.targetObject)
-                                {
-                                    priority = DroneManager.DronePriorities[i];
-                                    droneId = i;
-                                    break;
-                                }
-                            }
-
-                            ref MechaDrone myDrone = ref myMecha.drones[droneId];
-                            //for size comparison sqrMagnitude is fine, since sqrMagnitude, magnitude and the actual distance along the curve are all strictly monotonically increasing
-                            float diff = (myDrone.position - myDrone.target).sqrMagnitude - (drone.position - drone.target).sqrMagnitude;
-                            if (diff > 0 || (diff == 0 && packet.Priority > priority))
-                            {
-                                //my drone is further away (myMagnitude > otherMagnitude = difference positive) and has to return
-                                myDrone.stage = 3;
-                                myDrone.targetObject = 0;
-                            }
-                            else
-                            {
-                                //their drone is further away (otherMagnitude > myMagnitude = difference negative) and has to return
-                                drone.stage = 3;
-                                drone.targetObject = 0;
-                            }
-                        }
+                        GameMain.mainPlayer.mecha.droneLogic.serving.Remove(packet.EntityId);
                     }
                 }
             }


### PR DESCRIPTION
I have changed the targeting system for the drone to completely eliminate the deadlocks by having no locks :D

Changes:
- Removing sync of locking prebuilds
- Added condition for choosing a new target (select prebuild only if I am the closest player)

This is how it works. [Youtube video](https://www.youtube.com/watch?v=ErIhp9BBEdo)