### PR TITLE
Bug Fix: Tooltips that are triggered remotely are not shown

### DIFF
--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Patches\Dynamic\UIPowerGeneratorWindow_Patch.cs" />
     <Compile Include="Patches\Dynamic\UIProductionStatWindow_Patch.cs" />
     <Compile Include="Patches\Dynamic\UIPowerGizmo_OnUpdate_Patch.cs" />
+    <Compile Include="Patches\Dynamic\UIRealtimeTip_Patch.cs" />
     <Compile Include="Patches\Dynamic\UISiloWindow_Patch.cs" />
     <Compile Include="Patches\Dynamic\UISplitterWindow_Patch.cs" />
     <Compile Include="Patches\Dynamic\UIStorageWindow_Patch.cs" />

--- a/NebulaPatcher/Patches/Dynamic/UIRealtimeTip_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIRealtimeTip_Patch.cs
@@ -1,0 +1,36 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+using NebulaWorld.Factory;
+using System;
+using UnityEngine;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(UIRealtimeTip))]
+    class UIRealtimeTip_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch("Popup", new Type[] { typeof(string), typeof(bool), typeof(int) })]
+        public static bool Popup_Prefix()
+        {
+            //Do not show popups if they are triggered remotely
+            return !SimulatedWorld.Initialized || (!FactoryManager.EventFromServer && !FactoryManager.EventFromClient);
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("Popup", new Type[] { typeof(string), typeof(Vector2), typeof(int) })]
+        public static bool Popup_Prefix2()
+        {
+            //Do not show popups if they are triggered remotely
+            return !SimulatedWorld.Initialized || (!FactoryManager.EventFromServer && !FactoryManager.EventFromClient);
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("Popup", new Type[] { typeof(string), typeof(Vector3), typeof(bool), typeof(int) })]
+        public static bool Popup_Prefix3()
+        {
+            //Do not show popups if they are triggered remotely
+            return !SimulatedWorld.Initialized || (!FactoryManager.EventFromServer && !FactoryManager.EventFromClient);
+        }
+    }
+}


### PR DESCRIPTION
This is a bug fix for #204 .

