### PR TITLE
Bug Fix: Prebuild indexes are now taken from the game logic

### DIFF
--- a/NebulaClient/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
@@ -34,14 +34,10 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                         planet.audio.Init();
                     }
 
-                //Remove building from drone queue
-                GameMain.mainPlayer.mecha.droneLogic.serving.Remove(-packet.PrebuildId);
-                planet.factory.BuildFinally(GameMain.mainPlayer, packet.PrebuildId);
-                if (!DroneManager.RemoveBuildRequest(-packet.PrebuildId))
-                {
-                    Log.Warn($"Build Request was not succesfully removed.");
-                }
+                    //Remove building from drone queue
+                    GameMain.mainPlayer.mecha.droneLogic.serving.Remove(-packet.PrebuildId);
                     planet.factory.BuildFinally(GameMain.mainPlayer, packet.PrebuildId);
+                    DroneManager.RemoveBuildRequest(-packet.PrebuildId);
 
                     // Make sure to free the physics once the FlattenTerrain is done
                     if (packet.PlanetId != GameMain.localPlanet?.id)

--- a/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
@@ -13,21 +13,19 @@ namespace NebulaPatcher.Patches.Dynamic
     [HarmonyPatch(typeof(PlanetFactory))]
     class BuildFinally_patch
     {
-        [HarmonyPrefix]
-        [HarmonyPatch("AddPrebuildDataWithComponents")]
-        public static bool AddPrebuildDataWithComponents_Prefix(PlanetFactory __instance, PrebuildData prebuild)
+        [HarmonyPostfix]
+        [HarmonyPatch("AddPrebuildData")]
+        public static void AddPrebuildData_Prefix(PlanetFactory __instance, PrebuildData prebuild, ref int __result)
         {
             if (!SimulatedWorld.Initialized)
-                return true;
+                return;
 
             // If the host game called the method, we need to compute the PrebuildId ourself
             if (LocalPlayer.IsMasterClient && !FactoryManager.EventFromClient)
             {
-                int nextPrebuildId = FactoryManager.GetNextPrebuildId(__instance);
-                FactoryManager.SetPrebuildRequest(__instance.planetId, nextPrebuildId, LocalPlayer.PlayerId);
+               
+                FactoryManager.SetPrebuildRequest(__instance.planetId, __result, LocalPlayer.PlayerId);
             }
-
-            return true;
         }
 
         [HarmonyPrefix]
@@ -56,7 +54,7 @@ namespace NebulaPatcher.Patches.Dynamic
                 LocalPlayer.SendPacket(new BuildEntityRequest(__instance.planetId, prebuildId, FactoryManager.PacketAuthor == -1 ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor));
             }
 
-            if (!LocalPlayer.IsMasterClient && !FactoryManager.EventFromServer)
+            if (!LocalPlayer.IsMasterClient && !FactoryManager.EventFromServer && !DroneManager.IsPendingBuildRequest(-prebuildId))
             {
                 DroneManager.AddBuildRequestSent(-prebuildId);
             }

--- a/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
@@ -15,7 +15,7 @@ namespace NebulaPatcher.Patches.Dynamic
     {
         [HarmonyPostfix]
         [HarmonyPatch("AddPrebuildData")]
-        public static void AddPrebuildData_Prefix(PlanetFactory __instance, PrebuildData prebuild, ref int __result)
+        public static void AddPrebuildData_Postfix(PlanetFactory __instance, PrebuildData prebuild, ref int __result)
         {
             if (!SimulatedWorld.Initialized)
                 return;

--- a/NebulaWorld/Player/DroneManager.cs
+++ b/NebulaWorld/Player/DroneManager.cs
@@ -13,6 +13,14 @@ namespace NebulaWorld.Player
         public static List<int> PendingBuildRequests = new List<int>();
         public static Dictionary<ushort, Vector3> CachedPositions = new Dictionary<ushort, Vector3>();
 
+        public static void Initialize()
+        {
+            DronePriorities = new int[255];
+            PlayerDroneBuildingPlans = new Dictionary<ushort, List<int>>();
+            PendingBuildRequests = new List<int>();
+            CachedPositions = new Dictionary<ushort, Vector3>();
+        }
+
         public static void BroadcastDroneOrder(int droneId, int entityId, int stage)
         {
             if (!SimulatedWorld.Initialized)

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -11,6 +11,7 @@ using NebulaWorld.Trash;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using NebulaWorld.Player;
 
 namespace NebulaWorld
 {
@@ -37,6 +38,7 @@ namespace NebulaWorld
 
         public static void Initialize()
         {
+            DroneManager.Initialize();
             FactoryManager.Initialize();
             PlanetManager.Initialize();
             Initialized = true;


### PR DESCRIPTION
I found another issue when drone research is unlocked, client for some reason starts sending "BuildFinally()" packet twice, even after reconnecting.

After 10 minutes of testing, no issue observed

Following changes were applied:

- Prebuild ID is not calculated anymore, but it is taken from the game logic after prebuild is actually created.
- Some static fields were not reseted in the `DroneManager` so I have added `Initialize()` method to reset all static fields.
- Added check, so the second "BuildFinally()" call will not do anything, it will just produce a warning on the host. (I will check in the future why this is happening).

