### PR TITLE
Bug fix: nullcheck for planet data

### DIFF
--- a/NebulaPatcher/Patches/Dynamic/CargoTraffic_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/CargoTraffic_Patch.cs
@@ -22,7 +22,7 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPatch("PickupBeltItems")]
         public static void PickupBeltItems_Postfix()
         {
-            if (SimulatedWorld.Initialized)
+            if (SimulatedWorld.Initialized && GameMain.data.localPlanet != null)
             {
                 BeltManager.BeltPickupEnded();
             }


### PR DESCRIPTION
During the test, this exception was raised:

```
Exception hit 4 times: NullReferenceException: Object reference not set to an instance of an object
NebulaWorld.Factory.BeltManager.BeltPickupEnded () <IL 0x00015, 0x000bb>
NebulaPatcher.Patches.Dynamic.CargoTraffic_Patch.PickupBeltItems_Postfix () <IL 0x0000b, 0x000d2>
(wrapper dynamic-method) CargoTraffic.DMD<CargoTraffic..PickupBeltItems> (CargoTraffic,Player,int,bool) <IL 0x00140, 0x00581>
PlanetFactory.TakeBackItemsInEntity (Player,int) <IL 0x00029, 0x0025c>
```

this is just null check to prevent this.