### PR TITLE
Bug Fixes: Remote building and upgrading

### DIFF
--- a/NebulaClient/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
@@ -22,6 +22,7 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                 using (FactoryManager.EventFromServer.On())
                 {
                     FactoryManager.EventFactory = planet.factory;
+                    FactoryManager.TargetPlanet = packet.PlanetId;
                     FactoryManager.PacketAuthor = packet.AuthorId;
 
                     // Physics could be null, if the host is not on the requested planet
@@ -50,6 +51,7 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                     }
                     FactoryManager.PacketAuthor = -1;
                     FactoryManager.EventFactory = null;
+                    FactoryManager.TargetPlanet = -2;
                 }
             }
         }

--- a/NebulaClient/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
@@ -25,6 +25,8 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
             PlayerAction_Build pab = GameMain.mainPlayer.controller?.actionBuild;
             if (pab != null)
             {
+                FactoryManager.TargetPlanet = packet.PlanetId;
+
                 //Make backup of values that are overwritten
                 List<BuildPreview> tmpList = pab.buildPreviews;
                 bool tmpConfirm = pab.waitConfirm;
@@ -49,7 +51,6 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                         planet.physics = new PlanetPhysics(planet);
                         planet.physics.Init();
                     }
-                    planet.factory.cargoTraffic.GetOrCreateBeltRenderingBatches();
 
                     //Take item from the inventory if player is author of the build
                     if (packet.AuthorId == LocalPlayer.PlayerId)
@@ -86,6 +87,8 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                 pab.waitConfirm = tmpConfirm;
                 pab.previewPose.position = tmpPos;
                 pab.previewPose.rotation = tmpRot;
+
+                FactoryManager.TargetPlanet = -2;
             }
         }
     }

--- a/NebulaClient/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
@@ -36,17 +36,9 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                             }
                         }
                     }
-                    if (packet.PlanetId != GameMain.mainPlayer.planetId)
-                    {
-                        //Creating rendering batches is required to properly handle DestructFinally for the belts, since model needs to be changed.
-                        //ToDo: Optimize it somehow, since creating and destroying rendering batches is not optimal.
-                        planet.factory.cargoTraffic.CreateRenderingBatches();
-                    }
+                    FactoryManager.TargetPlanet = packet.PlanetId;
                     planet.factory.DestructFinally(GameMain.mainPlayer, packet.ObjId, ref protoId);
-                    if (packet.PlanetId != GameMain.mainPlayer.planetId)
-                    {
-                        planet.factory.cargoTraffic.DestroyRenderingBatches();
-                    }
+                    FactoryManager.TargetPlanet = -2;
                 }
             }
         }

--- a/NebulaClient/PacketProcessors/Factory/Entity/UpgradeEntityRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/UpgradeEntityRequestProcessor.cs
@@ -19,8 +19,26 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
             {
                 using (FactoryManager.EventFromServer.On())
                 {
+                    if (packet.PlanetId != GameMain.localPlanet?.id)
+                    {
+                        planet.physics = new PlanetPhysics(planet);
+                        planet.physics.Init();
+                        planet.audio = new PlanetAudio(planet);
+                        planet.audio.Init();
+                    }
+
                     ItemProto itemProto = LDB.items.Select(packet.UpgradeProtoId);
+                    FactoryManager.TargetPlanet = packet.PlanetId;
                     planet.factory.UpgradeFinally(GameMain.mainPlayer, packet.ObjId, itemProto);
+                    FactoryManager.TargetPlanet = -2;
+
+                    if (packet.PlanetId != GameMain.localPlanet?.id)
+                    {
+                        planet.physics.Free();
+                        planet.physics = null;
+                        planet.audio.Free();
+                        planet.audio = null;
+                    }
                 }
             }
         }

--- a/NebulaClient/PacketProcessors/Planet/RemoveVegetableProcessor.cs
+++ b/NebulaClient/PacketProcessors/Planet/RemoveVegetableProcessor.cs
@@ -11,7 +11,7 @@ namespace NebulaClient.PacketProcessors.Planet
     {
         public void ProcessPacket(RemoveVegetablePacket packet, NebulaConnection conn)
         {
-            if (GameMain.data.factories[packet.FactorytIndex] != null)
+            if (packet.FactorytIndex >= 0 && GameMain.data.factories[packet.FactorytIndex] != null)
             {
                 using (PlanetManager.EventFromServer.On())
                 {

--- a/NebulaHost/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
@@ -24,6 +24,7 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                 PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
                 FactoryManager.EventFactory = planet.factory;
                 FactoryManager.PacketAuthor = packet.AuthorId;
+                FactoryManager.TargetPlanet = packet.PlanetId;
 
                 // Physics could be null, if the host is not on the requested planet
                 // Make sure to init all the planet data required to perform the BuildFinally of the distant planet
@@ -34,8 +35,6 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
 
                     planet.audio = new PlanetAudio(planet);
                     planet.audio.Init();
-
-                    planet.factory.cargoTraffic.GetOrCreateBeltRenderingBatches();
                 }
 
                 //Remove building from drone queue
@@ -53,6 +52,7 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                 }
                 FactoryManager.EventFactory = null;
                 FactoryManager.PacketAuthor = -1;
+                FactoryManager.TargetPlanet = -2;
             }
         }
     }

--- a/NebulaHost/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
@@ -24,6 +24,8 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
             PlayerAction_Build pab = GameMain.mainPlayer.controller?.actionBuild;
             if (pab != null)
             {
+                FactoryManager.TargetPlanet = packet.PlanetId;
+
                 //Make backup of values that are overwritten
                 List<BuildPreview> tmpList = pab.buildPreviews;
                 bool tmpConfirm = pab.waitConfirm;
@@ -61,7 +63,6 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                         planet.physics = new PlanetPhysics(planet);
                         planet.physics.Init();
                     }
-                    planet.factory.cargoTraffic.GetOrCreateBeltRenderingBatches();
                     if (planet.aux == null)
                     {
                         planet.aux = new PlanetAuxData(planet);
@@ -81,6 +82,8 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                         canBuild = pab.CheckBuildConditions();
                         canBuild &= CheckBuildingConnections(pab.buildPreviews, planet.factory.entityPool, planet.factory.prebuildPool);
                     }
+
+                    UnityEngine.Debug.Log(pab.buildPreviews[0].condition);
 
                     if (canBuild)
                     {
@@ -108,6 +111,8 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                 pab.waitConfirm = tmpConfirm;
                 pab.previewPose.position = tmpPos; 
                 pab.previewPose.rotation = tmpRot;
+
+                FactoryManager.TargetPlanet = -2;
             }
         }
 

--- a/NebulaHost/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
@@ -18,6 +18,7 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                 using (FactoryManager.DoNotAddItemsFromBuildingOnDestruct.On())
                 {
                     FactoryManager.PacketAuthor = packet.AuthorId;
+                    FactoryManager.TargetPlanet = packet.PlanetId;
                     if (packet.PlanetId != GameMain.mainPlayer.planetId)
                     {
                         //Creating rendering batches is required to properly handle DestructFinally for the belts, since model needs to be changed.
@@ -30,6 +31,7 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                         planet.factory.cargoTraffic.DestroyRenderingBatches();
                     }
                     FactoryManager.PacketAuthor = -1;
+                    FactoryManager.TargetPlanet = -2;
                 }
             }
         }

--- a/NebulaHost/PacketProcessors/Factory/Entity/UpgradeEntityRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/UpgradeEntityRequestProcessor.cs
@@ -15,8 +15,27 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
             {
                 PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
 
+                // Physics could be null, if the host is not on the requested planet
+                if (packet.PlanetId != GameMain.localPlanet?.id)
+                {
+                    planet.physics = new PlanetPhysics(planet);
+                    planet.physics.Init();
+                    planet.audio = new PlanetAudio(planet);
+                    planet.audio.Init();
+                }
+
                 ItemProto itemProto = LDB.items.Select(packet.UpgradeProtoId);
+                FactoryManager.TargetPlanet = packet.PlanetId;
                 planet.factory.UpgradeFinally(GameMain.mainPlayer, packet.ObjId, itemProto);
+                FactoryManager.TargetPlanet = -2;
+
+                if (packet.PlanetId != GameMain.localPlanet?.id)
+                {
+                    planet.physics.Free();
+                    planet.physics = null;
+                    planet.audio.Free();
+                    planet.audio = null;
+                }
             }
         }
     }

--- a/NebulaHost/PacketProcessors/Planet/RemoveVegetableProcessor.cs
+++ b/NebulaHost/PacketProcessors/Planet/RemoveVegetableProcessor.cs
@@ -11,7 +11,7 @@ namespace NebulaHost.PacketProcessors.Planet
     {
         public void ProcessPacket(RemoveVegetablePacket packet, NebulaConnection conn)
         {
-            if (GameMain.data.factories[packet.FactorytIndex] != null)
+            if (packet.FactorytIndex >= 0 && GameMain.data.factories[packet.FactorytIndex] != null)
             {
                 using (PlanetManager.EventFromClient.On())
                 {

--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -48,6 +48,9 @@
     <Compile Include="Patches\Dynamic\GameSave_Patch.cs" />
     <Compile Include="Patches\Dynamic\GameScenarioLogic_Patch.cs" />
     <Compile Include="Patches\Dynamic\GameStatData_Patch.cs" />
+    <Compile Include="Patches\Dynamic\InserterRenderer_Patch.cs" />
+    <Compile Include="Patches\Dynamic\LabRenderer_Patch.cs" />
+    <Compile Include="Patches\Dynamic\ObjectRenderer_Patch.cs" />
     <Compile Include="Patches\Dynamic\MechaDroneLogic_Patch.cs" />
     <Compile Include="Patches\Dynamic\PlanetData_Patch.cs" />
     <Compile Include="Patches\Dynamic\Mecha_Patch.cs" />

--- a/NebulaPatcher/Patches/Dynamic/CargoTraffic_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/CargoTraffic_Patch.cs
@@ -37,5 +37,45 @@ namespace NebulaPatcher.Patches.Dynamic
               LocalPlayer.SendPacketToLocalStar(new BeltUpdatePutItemOnPacket(beltId, itemId, GameMain.data.localPlanet.factoryIndex));
             }
         }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("AlterBeltRenderer")]
+        public static bool AlterBeltRenderer_Prefix()
+        {
+            //Do not call renderer, if user is not on the planet as the request
+            return !SimulatedWorld.Initialized || FactoryManager.TargetPlanet == -2 || GameMain.mainPlayer.planetId == FactoryManager.TargetPlanet;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("RemoveBeltRenderer")]
+        public static bool RemoveBeltRenderer_Prefix()
+        {
+            //Do not call renderer, if user is not on the planet as the request
+            return !SimulatedWorld.Initialized || FactoryManager.TargetPlanet == -2 || GameMain.mainPlayer.planetId == FactoryManager.TargetPlanet;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("AlterPathRenderer")]
+        public static bool AlterPathRenderer_Prefix()
+        {
+            //Do not call renderer, if user is not on the planet as the request
+            return !SimulatedWorld.Initialized || FactoryManager.TargetPlanet == -2 || GameMain.mainPlayer.planetId == FactoryManager.TargetPlanet;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("RemovePathRenderer")]
+        public static bool RemovePathRenderer_Prefix()
+        {
+            //Do not call renderer, if user is not on the planet as the request
+            return !SimulatedWorld.Initialized || FactoryManager.TargetPlanet == -2 || GameMain.mainPlayer.planetId == FactoryManager.TargetPlanet;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("RefreshPathUV")]
+        public static bool RefreshPathUV_Prefix()
+        {
+            //Do not call renderer, if user is not on the planet as the request
+            return !SimulatedWorld.Initialized || FactoryManager.TargetPlanet == -2 || GameMain.mainPlayer.planetId == FactoryManager.TargetPlanet;
+        }
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/InserterRenderer_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/InserterRenderer_Patch.cs
@@ -1,0 +1,36 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+using NebulaWorld.Factory;
+using System;
+using UnityEngine;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(InserterRenderer))]
+    class InserterRenderer_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch("AddInst")]
+        public static bool AddInst_Prefix()
+        {
+            //Do not call renderer, if user is not on the planet as the request
+            return !SimulatedWorld.Initialized || FactoryManager.TargetPlanet == -2 || GameMain.mainPlayer.planetId == FactoryManager.TargetPlanet;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("AlterInst", new Type[] { typeof(int), typeof(int), typeof(Vector3), typeof(Quaternion), typeof(bool) })]
+        public static bool AlterInst_Prefix()
+        {
+            //Do not call renderer, if user is not on the planet as the request
+            return !SimulatedWorld.Initialized || FactoryManager.TargetPlanet == -2 || GameMain.mainPlayer.planetId == FactoryManager.TargetPlanet;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("RemoveInst")]
+        public static bool RemoveInst_Prefix()
+        {
+            //Do not call renderer, if user is not on the planet as the request
+            return !SimulatedWorld.Initialized || FactoryManager.TargetPlanet == -2 || GameMain.mainPlayer.planetId == FactoryManager.TargetPlanet;
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/LabRenderer_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/LabRenderer_Patch.cs
@@ -1,0 +1,36 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+using NebulaWorld.Factory;
+using System;
+using UnityEngine;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(LabRenderer))]
+    class LabRenderer_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch("AddInst")]
+        public static bool AddInst_Prefix()
+        {
+            //Do not call renderer, if user is not on the planet as the request
+            return !SimulatedWorld.Initialized || FactoryManager.TargetPlanet == -2 || GameMain.mainPlayer.planetId == FactoryManager.TargetPlanet;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("AlterInst", new Type[] { typeof(int), typeof(int), typeof(Vector3), typeof(Quaternion), typeof(bool) })]
+        public static bool AlterInst_Prefix()
+        {
+            //Do not call renderer, if user is not on the planet as the request
+            return !SimulatedWorld.Initialized || FactoryManager.TargetPlanet == -2 || GameMain.mainPlayer.planetId == FactoryManager.TargetPlanet;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("RemoveInst")]
+        public static bool RemoveInst_Prefix()
+        {
+            //Do not call renderer, if user is not on the planet as the request
+            return !SimulatedWorld.Initialized || FactoryManager.TargetPlanet == -2 || GameMain.mainPlayer.planetId == FactoryManager.TargetPlanet;
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/ObjectRenderer_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/ObjectRenderer_Patch.cs
@@ -1,0 +1,43 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+using NebulaWorld.Factory;
+using System;
+using UnityEngine;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(ObjectRenderer))]
+    class ObjectRenderer_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch("AddInst")]
+        public static bool AddInst_Prefix()
+        {
+            //Do not call renderer, if user is not on the planet as the request
+            return !SimulatedWorld.Initialized || FactoryManager.TargetPlanet == -2 || GameMain.mainPlayer.planetId == FactoryManager.TargetPlanet;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("AlterInst", new Type[] { typeof(int), typeof(int), typeof(Vector3), typeof(Quaternion), typeof(bool) })]
+        public static bool AlterInst_Prefix()
+        {
+            //Do not call renderer, if user is not on the planet as the request
+            return !SimulatedWorld.Initialized || FactoryManager.TargetPlanet == -2 || GameMain.mainPlayer.planetId == FactoryManager.TargetPlanet;
+        }
+        [HarmonyPrefix]
+        [HarmonyPatch("AlterInst", new Type[] { typeof(int), typeof(int), typeof(Vector3), typeof(bool) })]
+        public static bool AlterInst_Prefix2()
+        {
+            //Do not call renderer, if user is not on the planet as the request
+            return !SimulatedWorld.Initialized || FactoryManager.TargetPlanet == -2 || GameMain.mainPlayer.planetId == FactoryManager.TargetPlanet;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("RemoveInst")]
+        public static bool RemoveInst_Prefix()
+        {
+            //Do not call renderer, if user is not on the planet as the request
+            return !SimulatedWorld.Initialized || FactoryManager.TargetPlanet == -2 || GameMain.mainPlayer.planetId == FactoryManager.TargetPlanet;
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/PlayerAction_Build_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlayerAction_Build_Patch.cs
@@ -76,7 +76,7 @@ namespace NebulaPatcher.Patches.Dynamic
                 return true;
 
             //Clients needs to send destruction packet here
-            if (!LocalPlayer.IsMasterClient)
+            if (!LocalPlayer.IsMasterClient && !FactoryManager.EventFromServer && !FactoryManager.EventFromClient)
             {
                 LocalPlayer.SendPacket(new DestructEntityRequest(__instance.player.planetId, objId, LocalPlayer.PlayerId));
             }

--- a/NebulaWorld/Factory/BeltManager.cs
+++ b/NebulaWorld/Factory/BeltManager.cs
@@ -8,20 +8,6 @@ namespace NebulaWorld.Factory
     {
         public static List<BeltUpdate> BeltUpdates = new List<BeltUpdate>();
 
-        static readonly AccessTools.FieldRef<CargoTraffic, BeltRenderingBatch[]> GetBeltRenderingBatches =
-            AccessTools.FieldRefAccess<CargoTraffic, BeltRenderingBatch[]>("beltRenderingBatch");
-
-        public static BeltRenderingBatch[] GetOrCreateBeltRenderingBatches(this CargoTraffic cargoTraffic)
-        {
-            var batches = GetBeltRenderingBatches(cargoTraffic);
-            if (batches == null)
-            {
-                cargoTraffic.CreateRenderingBatches();
-                batches = GetBeltRenderingBatches(cargoTraffic);
-            }
-
-            return batches;
-        }
         public static void BeltPickupStarted()
         {
             BeltUpdates.Clear();
@@ -35,7 +21,10 @@ namespace NebulaWorld.Factory
         }
         public static void BeltPickupEnded()
         {
-            LocalPlayer.SendPacketToLocalStar(new BeltUpdatePickupItemsPacket(BeltUpdates.ToArray(), GameMain.data.localPlanet.factoryIndex));
+            if (GameMain.data.localPlanet != null)
+            {
+                LocalPlayer.SendPacketToLocalStar(new BeltUpdatePickupItemsPacket(BeltUpdates.ToArray(), GameMain.data.localPlanet.factoryIndex));
+            }
             BeltUpdates.Clear();
         }
     }

--- a/NebulaWorld/Factory/FactoryManager.cs
+++ b/NebulaWorld/Factory/FactoryManager.cs
@@ -21,11 +21,14 @@ namespace NebulaWorld.Factory
         public static PlanetFactory EventFactory { get; set; }
         public static readonly ToggleSwitch IgnoreBasicBuildConditionChecks = new ToggleSwitch();
         public static readonly ToggleSwitch DoNotAddItemsFromBuildingOnDestruct = new ToggleSwitch();
+
         public static int PacketAuthor { get; set; }
+        public static int TargetPlanet { get; set; }
 
         public static void Initialize()
         {
             PacketAuthor = -1;
+            TargetPlanet = -2; //-2, because "player.planetId" can return -1
         }
 
         public static void SetPrebuildRequest(int planetId, int prebuildId, ushort playerId)


### PR DESCRIPTION
I have noticed that when someone builds or upgrades a building on different planet it created 3D object and it was rendered in the distance. So I have added patches to ignore `ObjectRenderer` actions when a player is not on the same planet.

I have also fixed plenty of bugs that were reported on Discord:
# Bug 1
1. Error below fixed by adding a check to the `BeltPickupEnded()`
```
[Error  : Unity Log] NullReferenceException: Object reference not set to an instance of an object
NebulaWorld.Factory.BeltManager.BeltPickupEnded () <0x0004e>
NebulaPatcher.Patches.Dynamic.CargoTraffic_Patch.PickupBeltItems_Postfix () <0x00025>
(wrapper dynamic-method) CargoTraffic.DMD<CargoTraffic..PickupBeltItems> (CargoTraffic,Player,int,bool) <0x002be>
PlanetFactory.TakeBackItemsInEntity (Player,int) <0x000e2>
(wrapper dynamic-method) PlanetFactory.DMD<PlanetFactory..DestructFinally> (PlanetFactory,Player,int,int&) <0x00118>
(wrapper dynamic-method) PlayerAction_Build.DMD<PlayerAction_Build..DoDestructObject> (PlayerAction_Build,int) <0x00352>
(wrapper dynamic-method) PlayerAction_Build.DMD<PlayerAction_Build..CreatePrebuilds> (PlayerAction_Build) <0x0154e>
NebulaClient.PacketProcessors.Factory.Entity.CreatePrebuildsRequestProcessor.ProcessPacket (NebulaModel.Packets.Factory.CreatePrebuildsRequest,NebulaModel.Networking.NebulaConnection) <0x009af>
NebulaModel.Networking.Serialization.NetPacketProcessor/<>c__DisplayClass34_0`2<NebulaModel.Packets.Factory.CreatePrebuildsRequest, NebulaModel.Networking.NebulaConnection>.<SubscribeReusable>b__0 (NebulaModel.Networking.Serialization.NetDataReader,object) <0x000d9>
NebulaModel.Networking.Serialization.NetPacketProcessor.ReadPacket (NebulaModel.Networking.Serialization.NetDataReader,object) <0x00039>
NebulaModel.Networking.Serialization.NetPacketProcessor.ProcessPacketQueue () <0x000e8>
NebulaClient.MultiplayerClientSession.Update () <0x00026>
```
# Bug 2
2. Added check for the factoryIndex (need to be >= 0) (also created issue for future improvement #237 )
```
[Error  : Unity Log] IndexOutOfRangeException: Array index is out of range.
Stack trace:
NebulaHost.PacketProcessors.Planet.RemoveVegetableProcessor.ProcessPacket (NebulaModel.Packets.Planet.RemoveVegetablePacket packet, NebulaModel.Networking.NebulaConnection conn)
NebulaModel.Networking.Serialization.NetPacketProcessor+<>c__DisplayClass34_0`2[NebulaModel.Packets.Planet.RemoveVegetablePacket,NebulaModel.Networking.NebulaConnection].<SubscribeReusable>b__0 (NebulaModel.Networking.Serialization.NetDataReader reader, System.Object userData)
NebulaModel.Networking.Serialization.NetPacketProcessor.ReadPacket (NebulaModel.Networking.Serialization.NetDataReader reader, System.Object userData)
NebulaModel.Networking.Serialization.NetPacketProcessor.ProcessPacketQueue ()
NebulaHost.MultiplayerHostSession.Update ()
```

# Bug 3
3. Added `(!FactoryManager.EventFromServer && !FactoryManager.EventFromClient)` check to the `[HarmonyPatch("DoDestructObject")]`
```
[Error  : Unity Log] NullReferenceException: Object reference not set to an instance of an object
Stack trace:
NebulaHost.PacketProcessors.Factory.Entity.DestructEntityRequestProcessor.ProcessPacket (NebulaModel.Packets.Factory.DestructEntityRequest packet, NebulaModel.Networking.NebulaConnection conn)
NebulaModel.Networking.Serialization.NetPacketProcessor+<>c__DisplayClass34_0`2[NebulaModel.Packets.Factory.DestructEntityRequest,NebulaModel.Networking.NebulaConnection].<SubscribeReusable>b__0 (NebulaModel.Networking.Serialization.NetDataReader reader, System.Object userData)
NebulaModel.Networking.Serialization.NetPacketProcessor.ReadPacket (NebulaModel.Networking.Serialization.NetDataReader reader, System.Object userData)
NebulaModel.Networking.Serialization.NetPacketProcessor.ProcessPacketQueue ()
NebulaHost.MultiplayerHostSession.Update ()
```
# Bug 4
4. Added loading physics and audio when a building is upgraded since colliders need to be updated
```
[Error  : Unity Log] NullReferenceException: Object reference not set to an instance of an object
Stack trace:
PlanetFactory.CreateEntityDisplayComponents (int,PrefabDesc,int16) <0x00a18>
PlanetFactory.UpgradeEntityWithComponents (int,ItemProto) <0x0077c>
(wrapper dynamic-method) PlanetFactory.DMD<PlanetFactory..UpgradeFinally> (PlanetFactory,Player,int,ItemProto) <0x000ff>
NebulaHost.PacketProcessors.Factory.Entity.UpgradeEntityRequestProcessor.ProcessPacket (NebulaModel.Packets.Factory.UpgradeEntityRequest,NebulaModel.Networking.NebulaConnection) <0x0012b>
NebulaModel.Networking.Serialization.NetPacketProcessor/<>c__DisplayClass34_0`2<NebulaModel.Packets.Factory.UpgradeEntityRequest, NebulaModel.Networking.NebulaConnection>.<SubscribeReusable>b__0 (NebulaModel.Networking.Serialization.NetDataReader,object) <0x000d9>
NebulaModel.Networking.Serialization.NetPacketProcessor.ReadPacket (NebulaModel.Networking.Serialization.NetDataReader,object) <0x00039>
NebulaModel.Networking.Serialization.NetPacketProcessor.ProcessPacketQueue () <0x000e8>
NebulaHost.MultiplayerHostSession.Update () <0x003e9>
```
