### PR TITLE
Fix save game loading issues

### DIFF
--- a/NebulaPatcher/Patches/Dynamic/GameSave_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameSave_Patch.cs
@@ -21,13 +21,6 @@ namespace NebulaPatcher.Patches.Dynamic
         }
 
         [HarmonyPrefix]
-        [HarmonyPatch("LoadCurrentGame")]
-        public static void LoadCurrentGame_Prefix(string saveName)
-        {
-            SaveManager.SetLastSave(saveName);
-        }
-
-        [HarmonyPrefix]
         [HarmonyPatch("AutoSave")]
         public static bool AutoSave_Prefix()
         {
@@ -39,8 +32,8 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPatch("SaveAsLastExit")]
         public static bool SaveAsLastExit_Prefix()
         {
-            // Only save if in single player or if you are the host
-            return (!SimulatedWorld.Initialized && !SimulatedWorld.ExitingMultiplayerSession) || LocalPlayer.IsMasterClient;
+            // Only save if in single player, since multiplayer requires to load from the Load Save Window
+            return (!SimulatedWorld.Initialized && !SimulatedWorld.ExitingMultiplayerSession);
         }
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/UIEscMenu_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIEscMenu_Patch.cs
@@ -1,10 +1,6 @@
 ﻿using HarmonyLib;
-using NebulaModel;
-using NebulaModel.Logger;
-using NebulaPatcher.MonoBehaviours;
 using NebulaWorld;
 using UnityEngine;
-using UnityEngine.Events;
 using UnityEngine.UI;
 
 namespace NebulaPatcher.Patches.Dynamic
@@ -12,8 +8,6 @@ namespace NebulaPatcher.Patches.Dynamic
     [HarmonyPatch(typeof(UIEscMenu))]
     class UIEscMenu_Patch
     {
-        private static RectTransform hostGameButton;
-
         [HarmonyPrefix]
         [HarmonyPatch("_OnOpen")]
         public static void _OnOpen_Prefix(UIEscMenu __instance)
@@ -25,29 +19,6 @@ namespace NebulaPatcher.Patches.Dynamic
             // Disable load game button if in a multiplayer session
             Button loadGameWindowButton = AccessTools.Field(typeof(UIEscMenu), "button3").GetValue(__instance) as Button;
             SetButtonEnableState(loadGameWindowButton, !SimulatedWorld.Initialized);
-
-            // If we are in a multiplayer game already make sure to hide the host game button
-            if (SimulatedWorld.Initialized)
-            {
-                hostGameButton?.gameObject.SetActive(false);
-                return;
-            }
-
-            if (hostGameButton != null)
-            {
-                hostGameButton.gameObject.SetActive(true);
-                hostGameButton.GetComponentInChildren<Text>().text = "Host Game";
-                return;
-            }
-
-            RectTransform buttonTemplate = GameObject.Find("Esc Menu/button (6)").GetComponent<RectTransform>();
-            hostGameButton = Object.Instantiate(buttonTemplate, buttonTemplate.parent, false);
-            hostGameButton.name = "button-host-game";
-            hostGameButton.anchoredPosition = new Vector2(buttonTemplate.anchoredPosition.x, buttonTemplate.anchoredPosition.y - buttonTemplate.sizeDelta.y * 2);
-            hostGameButton.GetComponentInChildren<Text>().text = "Host Game";
-
-            hostGameButton.GetComponent<Button>().onClick.RemoveAllListeners();
-            hostGameButton.GetComponent<Button>().onClick.AddListener(new UnityAction(OnHostCurrentGameClick));
         }
 
         [HarmonyPrefix]
@@ -59,23 +30,6 @@ namespace NebulaPatcher.Patches.Dynamic
             {
                 LocalPlayer.LeaveGame();
             }
-        }
-
-        private static void OnHostCurrentGameClick()
-        {
-            // Make sure to save the game before enabling the multiplayer mod
-            GameSave.AutoSave();
-
-            int port = Config.DefaultPort;
-
-            Log.Info($"Listening server on port {port}");
-            var session = NebulaBootstrapper.Instance.CreateMultiplayerHostSession();
-            session.StartServer(port, true);
-
-            // Manually call the OnGameLoadCompleted manually since we are already in a game.
-            SimulatedWorld.OnGameLoadCompleted();
-
-            GameMain.Resume();
         }
 
         private static void SetButtonEnableState(Button button, bool enable)

--- a/NebulaPatcher/Patches/Dynamic/UILoadGameWindow_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UILoadGameWindow_Patch.cs
@@ -8,15 +8,15 @@ namespace NebulaPatcher.Patches.Dynamic
     [HarmonyPatch(typeof(UILoadGameWindow))]
     class UILoadGameWindow_Patch
     {
-        [HarmonyPrefix]
+        [HarmonyPostfix]
         [HarmonyPatch("DoLoadSelectedGame")]
-        public static void DoLoadSelectedGame_Prefix()
+        public static void DoLoadSelectedGame_Postfix()
         {
             if (MainMenuManager.IsInMultiplayerMenu)
             {
                 Log.Info($"Listening server on port {Config.DefaultPort}");
                 var session = NebulaBootstrapper.Instance.CreateMultiplayerHostSession();
-                session.StartServer(Config.DefaultPort);
+                session.StartServer(Config.DefaultPort, true);
             }
         }
     }


### PR DESCRIPTION
This PR fixes #242 and #243, which are the issues that we had where reconnecting players was sometimes joining as new players or on another planet.

We had 2 main issues:
1. We were not loading the server save file when we were hosting a game from the Load Game Window which was causing all the players to join with no player data. (This was not occurring if the host stayed in game while the clients reconnected)
2. The other issue with the players that were spawning on another planet was caused by the fact that we were not handling the save game loading of AutoSaves properly. So we were always reloading the last autosave instead of the actually loading the game that the host had chosen in the Load Game Window.

This PR also fixes the AutoSave rotation that was not handled previously and I also removed the Host button from the Esc menu.
