### PR TITLE
Add GitVersioning support

### DIFF
--- a/.github/workflows/build-winx64.yml
+++ b/.github/workflows/build-winx64.yml
@@ -25,6 +25,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
+        fetch-depth: 0 # can't shallowly clone due to git versioning
         
     - name: Clear output directory in DSP files
       # We use SilentlyContinue here because it errors out if the folder does not exist otherwise

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
+  <PropertyGroup Label="NuGet Versions">
     <NuGetVersionNerdbankGitVersioning>3.4.194</NuGetVersionNerdbankGitVersioning>
     <NuGetVersionlz4net>1.0.15.93</NuGetVersionlz4net>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <NuGetVersionNerdbankGitVersioning>3.4.194</NuGetVersionNerdbankGitVersioning>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,5 +2,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <NuGetVersionNerdbankGitVersioning>3.4.194</NuGetVersionNerdbankGitVersioning>
+    <NuGetVersionlz4net>1.0.15.93</NuGetVersionlz4net>
   </PropertyGroup>
 </Project>

--- a/Nebula.sln
+++ b/Nebula.sln
@@ -12,9 +12,11 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{08DB0E29-5C9B-41F3-A130-4CB9CAFAED70}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		PluginImports.targets = PluginImports.targets
 		SharedConfig.targets = SharedConfig.targets
+		version.json = version.json
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NebulaHost", "NebulaHost\NebulaHost.csproj", "{1927F7FF-230B-4B1B-B7ED-34B58730AFBE}"

--- a/NebulaClient/NebulaClient.csproj
+++ b/NebulaClient/NebulaClient.csproj
@@ -131,9 +131,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="$(NuGetVersionNerdbankGitVersioning)" PrivateAssets="all" />
-    <PackageReference Include="lz4net">
-      <Version>1.0.15.93</Version>
-    </PackageReference>
+    <PackageReference Include="lz4net" Version="$(NuGetVersionlz4net)" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/NebulaClient/NebulaClient.csproj
+++ b/NebulaClient/NebulaClient.csproj
@@ -130,6 +130,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="$(NuGetVersionNerdbankGitVersioning)" PrivateAssets="all" />
     <PackageReference Include="lz4net">
       <Version>1.0.15.93</Version>
     </PackageReference>

--- a/NebulaClient/Properties/AssemblyInfo.cs
+++ b/NebulaClient/Properties/AssemblyInfo.cs
@@ -20,16 +20,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("5be9c74b-7832-4ef1-a53d-bf461bbdb0be")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NebulaHost/NebulaHost.csproj
+++ b/NebulaHost/NebulaHost.csproj
@@ -131,6 +131,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="$(NuGetVersionNerdbankGitVersioning)" PrivateAssets="all" />
     <PackageReference Include="lz4net">
       <Version>1.0.15.93</Version>
     </PackageReference>

--- a/NebulaHost/NebulaHost.csproj
+++ b/NebulaHost/NebulaHost.csproj
@@ -133,7 +133,6 @@
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="$(NuGetVersionNerdbankGitVersioning)" PrivateAssets="all" />
     <PackageReference Include="lz4net" Version="$(NuGetVersionlz4net)" />
-
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(PluginImports)" />

--- a/NebulaHost/NebulaHost.csproj
+++ b/NebulaHost/NebulaHost.csproj
@@ -132,9 +132,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="$(NuGetVersionNerdbankGitVersioning)" PrivateAssets="all" />
-    <PackageReference Include="lz4net">
-      <Version>1.0.15.93</Version>
-    </PackageReference>
+    <PackageReference Include="lz4net" Version="$(NuGetVersionlz4net)" />
+
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(PluginImports)" />

--- a/NebulaHost/Properties/AssemblyInfo.cs
+++ b/NebulaHost/Properties/AssemblyInfo.cs
@@ -20,16 +20,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1927f7ff-230b-4b1b-b7ed-34b58730afbe")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NebulaModel/NebulaModel.csproj
+++ b/NebulaModel/NebulaModel.csproj
@@ -174,6 +174,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="$(NuGetVersionNerdbankGitVersioning)" PrivateAssets="all" />
     <PackageReference Include="lz4net">
       <Version>1.0.15.93</Version>
     </PackageReference>

--- a/NebulaModel/NebulaModel.csproj
+++ b/NebulaModel/NebulaModel.csproj
@@ -175,9 +175,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="$(NuGetVersionNerdbankGitVersioning)" PrivateAssets="all" />
-    <PackageReference Include="lz4net">
-      <Version>1.0.15.93</Version>
-    </PackageReference>
+    <PackageReference Include="lz4net" Version="$(NuGetVersionlz4net)" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(PluginImports)" />

--- a/NebulaModel/Properties/AssemblyInfo.cs
+++ b/NebulaModel/Properties/AssemblyInfo.cs
@@ -20,16 +20,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("c6237195-f77c-40c0-b06a-4ad51cad314d")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -126,6 +126,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="$(NuGetVersionNerdbankGitVersioning)" PrivateAssets="all" />
     <PackageReference Include="lz4net">
       <Version>1.0.15.93</Version>
     </PackageReference>

--- a/NebulaPatcher/NebulaPatcher.csproj
+++ b/NebulaPatcher/NebulaPatcher.csproj
@@ -127,9 +127,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="$(NuGetVersionNerdbankGitVersioning)" PrivateAssets="all" />
-    <PackageReference Include="lz4net">
-      <Version>1.0.15.93</Version>
-    </PackageReference>
+    <PackageReference Include="lz4net" Version="$(NuGetVersionlz4net)" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(PluginImports)" />

--- a/NebulaPatcher/Properties/AssemblyInfo.cs
+++ b/NebulaPatcher/Properties/AssemblyInfo.cs
@@ -20,16 +20,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("28b0716c-3926-4865-ab43-6c4431d022d6")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NebulaWorld/Properties/AssemblyInfo.cs
+++ b/NebulaWorld/Properties/AssemblyInfo.cs
@@ -20,16 +20,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("28aea139-fb22-4672-af51-28b728cf2978")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/version.json
+++ b/version.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+
+  "version": "0.1",
+
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$"
+  ]
+} 


### PR DESCRIPTION
Autogenerated assembly metadata, which is also exposed as constants in the dll. It follows semver $(Major).$(Minor).$(Patch), with the last component being the number of commits since last minor version bump.

For docs: https://github.com/dotnet/Nerdbank.GitVersioning

![image](https://user-images.githubusercontent.com/109974/116491566-d7958200-a8a2-11eb-97e6-799cee0c16ff.png)
![image](https://user-images.githubusercontent.com/109974/116491576-e1b78080-a8a2-11eb-94c3-2cfe2ef07aa2.png)
