### PR TITLE
Added version checking with disconnect reasons

### DIFF
--- a/NebulaClient/MultiplayerClientSession.cs
+++ b/NebulaClient/MultiplayerClientSession.cs
@@ -179,9 +179,10 @@ namespace NebulaClient
 
                 if (e.Code == (ushort)DisconnectionReason.ModVersionMismatch)
                 {
+                    string[] versions = e.Reason.Split(';');
                     InGamePopup.ShowWarning(
                         "Mod Version Mismatch",
-                        $"Your Nebula Multiplayer Mod is not the same as the Host version.\nMake sure to use the same version.",
+                        $"Your Nebula Multiplayer Mod is not the same as the Host version.\nYou:{versions[0]} - Remote:{versions[1]}",
                         "OK",
                         OnDisconnectPopupCloseBeforeGameLoad);
                     return;
@@ -189,9 +190,10 @@ namespace NebulaClient
 
                 if (e.Code == (ushort)DisconnectionReason.GameVersionMismatch)
                 {
+                    string[] versions = e.Reason.Split(';');
                     InGamePopup.ShowWarning(
                         "Game Version Mismatch",
-                        $"Your version of the game is not the same as the one used by the Host.\nMake sure to use the same version.",
+                        $"Your version of the game is not the same as the one used by the Host.\nYou:{versions[0]} - Remote:{versions[1]}",
                         "OK",
                         OnDisconnectPopupCloseBeforeGameLoad);
                     return;

--- a/NebulaHost/PacketProcessors/Session/HandshakeRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Session/HandshakeRequestProcessor.cs
@@ -37,15 +37,15 @@ namespace NebulaHost.PacketProcessors.Session
             }
 
 
-            if (packet.ModVersion != Config.ModVersion.ToString())
+            if (packet.ModVersion != Config.ModVersion)
             {
-                conn.Disconnect(DisconnectionReason.ModVersionMismatch);
+                conn.Disconnect(DisconnectionReason.ModVersionMismatch, $"{ packet.ModVersion };{ Config.ModVersion }");
                 return;
             }
 
             if (packet.GameVersionSig != GameConfig.gameVersion.sig)
             {
-                conn.Disconnect(DisconnectionReason.GameVersionMismatch);
+                conn.Disconnect(DisconnectionReason.GameVersionMismatch, $"{ packet.GameVersionSig };{ GameConfig.gameVersion.sig }");
                 return;
             }
 

--- a/NebulaModel/Config.cs
+++ b/NebulaModel/Config.cs
@@ -5,7 +5,7 @@ namespace NebulaModel
     public static class Config
     {
         public static PluginInfo ModInfo { get; set; }
-        public static System.Version ModVersion => ModInfo.Metadata.Version;
+        public static string ModVersion => ThisAssembly.AssemblyInformationalVersion;
         public static int DefaultPort => 8469;
     }
 }

--- a/NebulaModel/Networking/NebulaConnection.cs
+++ b/NebulaModel/Networking/NebulaConnection.cs
@@ -1,5 +1,6 @@
 ﻿using NebulaModel.Logger;
 using NebulaModel.Networking.Serialization;
+using System;
 using System.Net;
 using WebSocketSharp;
 
@@ -44,9 +45,23 @@ namespace NebulaModel.Networking
             }
         }
 
-        public void Disconnect(DisconnectionReason reason = DisconnectionReason.Normal)
+        public void Disconnect(DisconnectionReason reason = DisconnectionReason.Normal, string reasonString = null)
         {
-            peerSocket.Close((ushort)reason);
+            if(string.IsNullOrEmpty(reasonString))
+            {
+                peerSocket.Close((ushort)reason);
+            }
+            else
+            {
+                if (System.Text.Encoding.UTF8.GetBytes(reasonString).Length <= 123)
+                {
+                    peerSocket.Close((ushort)reason, reasonString);
+                }
+                else
+                {
+                    throw new ArgumentException("Reason string cannot take up more than 123 bytes");
+                }
+            }
         }
 
         public static bool operator ==(NebulaConnection left, NebulaConnection right)

--- a/NebulaModel/Packets/Session/HandshakeRequest.cs
+++ b/NebulaModel/Packets/Session/HandshakeRequest.cs
@@ -12,7 +12,7 @@
         public HandshakeRequest(byte[] clientCert, string username)
         {
             this.Username = username;
-            this.ModVersion = Config.ModVersion.ToString();
+            this.ModVersion = Config.ModVersion;
             this.GameVersionSig = GameConfig.gameVersion.sig;
             this.ClientCert = clientCert;
         }


### PR DESCRIPTION
This PR adds support for providing disconnect reasons, and also utilises them for the version checking.

It also switches the version checking to use the new autogenerated versions, so people who use the nightlies have specific version checking in case they are using different versions.