### PR TITLE
When a client loads in on a different planet than host, it does not …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -366,3 +366,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Jetbrains IDE working folder
+.idea/

--- a/NebulaClient/PacketProcessors/Planet/RemoveVegetableProcessor.cs
+++ b/NebulaClient/PacketProcessors/Planet/RemoveVegetableProcessor.cs
@@ -3,7 +3,6 @@ using NebulaModel.Networking;
 using NebulaModel.Packets.Planet;
 using NebulaModel.Packets.Processors;
 using NebulaWorld.Planet;
-using UnityEngine;
 
 namespace NebulaClient.PacketProcessors.Planet
 {

--- a/NebulaClient/PacketProcessors/Planet/RemoveVegetableProcessor.cs
+++ b/NebulaClient/PacketProcessors/Planet/RemoveVegetableProcessor.cs
@@ -3,6 +3,7 @@ using NebulaModel.Networking;
 using NebulaModel.Packets.Planet;
 using NebulaModel.Packets.Processors;
 using NebulaWorld.Planet;
+using UnityEngine;
 
 namespace NebulaClient.PacketProcessors.Planet
 {
@@ -11,7 +12,7 @@ namespace NebulaClient.PacketProcessors.Planet
     {
         public void ProcessPacket(RemoveVegetablePacket packet, NebulaConnection conn)
         {
-            if (packet.FactorytIndex >= 0 && GameMain.data.factories[packet.FactorytIndex] != null)
+            if (packet.FactorytIndex >= 0 && GameMain.data.factories[packet.FactorytIndex] != null && GameMain.data.factories[packet.FactorytIndex].vegePool != null)
             {
                 using (PlanetManager.EventFromServer.On())
                 {


### PR DESCRIPTION
have real PlanetData for other planets. PlanetData.vegePool is null and was causing a nullref exception. This checks if vegePool is null before attempting RemoveVegeWithComponents.

I'm not entirely sure if a client should have received this or not at this point as I don't know the intent of what is planned to be host-authorative and re-loaded on demand and what is supposed to be synced once and then simulated on clients.

Obviously the client doesn't actually need this packet, since it has no PlanetData for the planet it's trying to remove vegetation on, but I think that is a seperate issue in trying to reduce packet count.