### PR TITLE
Refactored large part of the UIStationWindow and UIStationStorage sync logic

### DIFF
--- a/NebulaHost/PacketProcessors/Logistics/StationSubscribeUIUpdatesProcessor.cs
+++ b/NebulaHost/PacketProcessors/Logistics/StationSubscribeUIUpdatesProcessor.cs
@@ -11,13 +11,13 @@ namespace NebulaHost.PacketProcessors.Logistics
     {
         public void ProcessPacket(StationSubscribeUIUpdates packet, NebulaConnection conn)
         {
-            if (packet.subscribe)
+            if (packet.Subscribe)
             {
-                StationUIManager.AddSubscriber(packet.stationGId, conn);
+                StationUIManager.AddSubscriber(packet.PlanetId, packet.StationId, packet.StationGId, conn);
             }
             else
             {
-                StationUIManager.RemoveSubscriber(packet.stationGId, conn);
+                StationUIManager.RemoveSubscriber(packet.PlanetId, packet.StationId, packet.StationGId, conn);
             }
         }
     }

--- a/NebulaHost/PacketProcessors/Logistics/StationUIBroadcaster.cs
+++ b/NebulaHost/PacketProcessors/Logistics/StationUIBroadcaster.cs
@@ -24,17 +24,14 @@ namespace NebulaHost.PacketProcessors.Logistics
         {
             Player player = playerManager.GetPlayer(conn);
             // if a user adds/removes a ship, drone or warper or changes max power input broadcast to everyone.
-            if (
-                (
-                    packet.SettingIndex == StationUI.EUISettings.MaxChargePower
-                    || packet.SettingIndex == StationUI.EUISettings.SetDroneCount
-                    || packet.SettingIndex == StationUI.EUISettings.SetShipCount
-                    || packet.SettingIndex == StationUI.EUISettings.SetWarperCount
-                    || packet.SettingIndex == StationUI.EUISettings.AddOrRemoveItemFromStorageRequest
-                    || packet.SettingIndex == StationUI.EUISettings.AddOrRemoveItemFromStorageResponse
+            if (player != null && StationUIManager.UpdateCooldown == 0 &&
+                (packet.SettingIndex == StationUI.EUISettings.MaxChargePower
+                 || packet.SettingIndex == StationUI.EUISettings.SetDroneCount
+                 || packet.SettingIndex == StationUI.EUISettings.SetShipCount
+                 || packet.SettingIndex == StationUI.EUISettings.SetWarperCount
+                 || packet.SettingIndex == StationUI.EUISettings.AddOrRemoveItemFromStorageRequest
+                 || packet.SettingIndex == StationUI.EUISettings.AddOrRemoveItemFromStorageResponse)
                 )
-                && player != null && StationUIManager.UpdateCooldown == 0
-            )
             {
                 playerManager.SendPacketToAllPlayers(packet);
             }

--- a/NebulaHost/PacketProcessors/Logistics/StationUIBroadcaster.cs
+++ b/NebulaHost/PacketProcessors/Logistics/StationUIBroadcaster.cs
@@ -24,13 +24,14 @@ namespace NebulaHost.PacketProcessors.Logistics
         {
             Player player = playerManager.GetPlayer(conn);
             // if a user adds/removes a ship, drone or warper or changes max power input broadcast to everyone.
-            if((packet.settingIndex == StationUI.UIsettings.MaxChargePower || packet.settingIndex == StationUI.UIsettings.setDroneCount || packet.settingIndex == StationUI.UIsettings.setShipCount || packet.settingIndex == StationUI.UIsettings.setWarperCount) && player != null && StationUIManager.UpdateCooldown == 0)
+            if((packet.SettingIndex == StationUI.EUISettings.MaxChargePower || packet.SettingIndex == StationUI.EUISettings.SetDroneCount || packet.SettingIndex == StationUI.EUISettings.SetShipCount || packet.SettingIndex == StationUI.EUISettings.SetWarperCount) && player != null && StationUIManager.UpdateCooldown == 0)
             {
                 playerManager.SendPacketToAllPlayers(packet);
             }
-            else if(StationUIManager.UpdateCooldown == 0 || !packet.isStorageUI)
+            else if(StationUIManager.UpdateCooldown == 0 || !packet.IsStorageUI)
             {
-                List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(packet.stationGId);
+                List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(packet.PlanetId, packet.StationId, packet.StationGId);
+                
                 for (int i = 0; i < subscribers.Count; i++)
                 {
                     if(subscribers[i] != null)
@@ -41,7 +42,7 @@ namespace NebulaHost.PacketProcessors.Logistics
                              * as we block the normal method for the client he must run it once he receives this packet.
                              * but only the one issued the request should do it, we indicate this here
                              */
-                            packet.shouldMimick = true;
+                            packet.ShouldMimic = true;
                         }
                         subscribers[i].SendPacket(packet);
                     }

--- a/NebulaHost/PacketProcessors/Logistics/StationUIBroadcaster.cs
+++ b/NebulaHost/PacketProcessors/Logistics/StationUIBroadcaster.cs
@@ -24,7 +24,17 @@ namespace NebulaHost.PacketProcessors.Logistics
         {
             Player player = playerManager.GetPlayer(conn);
             // if a user adds/removes a ship, drone or warper or changes max power input broadcast to everyone.
-            if((packet.SettingIndex == StationUI.EUISettings.MaxChargePower || packet.SettingIndex == StationUI.EUISettings.SetDroneCount || packet.SettingIndex == StationUI.EUISettings.SetShipCount || packet.SettingIndex == StationUI.EUISettings.SetWarperCount) && player != null && StationUIManager.UpdateCooldown == 0)
+            if (
+                (
+                    packet.SettingIndex == StationUI.EUISettings.MaxChargePower
+                    || packet.SettingIndex == StationUI.EUISettings.SetDroneCount
+                    || packet.SettingIndex == StationUI.EUISettings.SetShipCount
+                    || packet.SettingIndex == StationUI.EUISettings.SetWarperCount
+                    || packet.SettingIndex == StationUI.EUISettings.AddOrRemoveItemFromStorageRequest
+                    || packet.SettingIndex == StationUI.EUISettings.AddOrRemoveItemFromStorageResponse
+                )
+                && player != null && StationUIManager.UpdateCooldown == 0
+            )
             {
                 playerManager.SendPacketToAllPlayers(packet);
             }

--- a/NebulaHost/PacketProcessors/Logistics/StationUIInitialSyncRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Logistics/StationUIInitialSyncRequestProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using NebulaModel.Attributes;
+using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets.Logistics;
 using NebulaModel.Packets.Processors;
@@ -14,61 +15,57 @@ namespace NebulaHost.PacketProcessors.Logistics
     {
         public void ProcessPacket(StationUIInitialSyncRequest packet, NebulaConnection conn)
         {
+            StationComponent stationComponent = null;
             StationComponent[] gStationPool = GameMain.data.galacticTransport.stationPool;
-            if(packet.stationGId < gStationPool.Length)
+            StationComponent[] stationPool = GameMain.data.galaxy?.PlanetById(packet.PlanetId)?.factory?.transport?.stationPool;
+
+            stationComponent = packet.StationGId > 0 ? gStationPool[packet.StationGId] : stationPool?[packet.StationId];
+            
+            if (stationComponent == null)
             {
-                StationComponent stationComponent = null;
-                if(packet.planetId == 0)
-                {
-                    stationComponent = gStationPool[packet.stationGId];
-                }
-                else
-                {
-                    PlanetData pData = GameMain.galaxy.PlanetById(packet.planetId);
-                    // GId is the id in this case as we look at a PLS
-                    if(pData?.factory?.transport != null && pData.factory.transport.stationPool.Length > packet.stationGId)
-                    {
-                        stationComponent = pData.factory.transport.stationPool[packet.stationGId];
-                    }
-                }
-                if(stationComponent != null)
-                {
-                    StationStore[] storage = stationComponent.storage;
-                    int[] itemId = new int[storage.Length];
-                    int[] itemCountMax = new int[storage.Length];
-                    int[] itemCount = new int[storage.Length];
-                    int[] localLogic = new int[storage.Length];
-                    int[] remoteLogic = new int[storage.Length];
-                    int[] remoteOrder = new int[storage.Length];
-                    for(int i = 0; i < stationComponent.storage.Length; i++)
-                    {
-                        itemId[i] = storage[i].itemId;
-                        itemCountMax[i] = storage[i].max;
-                        itemCount[i] = storage[i].count;
-                        localLogic[i] = (int)storage[i].localLogic;
-                        remoteLogic[i] = (int)storage[i].remoteLogic;
-                        remoteOrder[i] = storage[i].remoteOrder;
-                    }
-                    StationUIInitialSync packet2 = new StationUIInitialSync(packet.stationGId,
-                                                                            packet.planetId,
-                                                                            stationComponent.tripRangeDrones,
-                                                                            stationComponent.tripRangeShips,
-                                                                            stationComponent.deliveryDrones,
-                                                                            stationComponent.deliveryShips,
-                                                                            stationComponent.warpEnableDist,
-                                                                            stationComponent.warperNecessary,
-                                                                            stationComponent.includeOrbitCollector,
-                                                                            stationComponent.energy,
-                                                                            stationComponent.energyPerTick,
-                                                                            itemId,
-                                                                            itemCountMax,
-                                                                            itemCount,
-                                                                            localLogic,
-                                                                            remoteLogic,
-                                                                            remoteOrder);
-                    conn.SendPacket(packet2);
-                }
+                Log.Error($"StationUIInitialSyncRequestProcessor: Unable to find requested station on planet {packet.PlanetId} with id {packet.StationId} and gid of {packet.StationGId}");
+                return;
             }
+
+            StationStore[] storage = stationComponent.storage;
+            
+            int[] itemId = new int[storage.Length];
+            int[] itemCountMax = new int[storage.Length];
+            int[] itemCount = new int[storage.Length];
+            int[] localLogic = new int[storage.Length];
+            int[] remoteLogic = new int[storage.Length];
+            int[] remoteOrder = new int[storage.Length];
+            
+            for(int i = 0; i < stationComponent.storage.Length; i++)
+            {
+                itemId[i] = storage[i].itemId;
+                itemCountMax[i] = storage[i].max;
+                itemCount[i] = storage[i].count;
+                localLogic[i] = (int)storage[i].localLogic;
+                remoteLogic[i] = (int)storage[i].remoteLogic;
+                remoteOrder[i] = storage[i].remoteOrder;
+            }
+
+            conn.SendPacket(new StationUIInitialSync(
+                packet.PlanetId,
+                packet.StationId,
+                packet.StationGId,
+                stationComponent.tripRangeDrones,
+                stationComponent.tripRangeShips,
+                stationComponent.deliveryDrones,
+                stationComponent.deliveryShips,
+                stationComponent.warpEnableDist,
+                stationComponent.warperNecessary,
+                stationComponent.includeOrbitCollector,
+                stationComponent.energy,
+                stationComponent.energyPerTick,
+                itemId,
+                itemCountMax,
+                itemCount,
+                localLogic,
+                remoteLogic,
+                remoteOrder
+            ));
         }
     }
 }

--- a/NebulaModel/Packets/Logistics/StationSubscribeUIUpdates.cs
+++ b/NebulaModel/Packets/Logistics/StationSubscribeUIUpdates.cs
@@ -2,13 +2,17 @@
 {
     public class StationSubscribeUIUpdates
     {
-        public bool subscribe { get; set; }
-        public int stationGId { get; set; }
+        public int PlanetId { get; set; }
+        public int StationId { get; set; }
+        public int StationGId { get; set; }
+        public bool Subscribe { get; set; }
         public StationSubscribeUIUpdates() { }
-        public StationSubscribeUIUpdates(bool subscribe, int stationGId)
+        public StationSubscribeUIUpdates(bool subscribe, int planetId, int stationId, int stationGId)
         {
-            this.subscribe = subscribe;
-            this.stationGId = stationGId;
+            PlanetId = planetId;
+            StationId = stationId;
+            StationGId = stationGId;
+            Subscribe = subscribe;
         }
     }
 }

--- a/NebulaModel/Packets/Logistics/StationUI.cs
+++ b/NebulaModel/Packets/Logistics/StationUI.cs
@@ -2,7 +2,7 @@
 {
     public class StationUI
     {
-        public enum UIsettings
+        public enum EUISettings
         {
             MaxChargePower,
             MaxTripDrones,
@@ -10,59 +10,62 @@
             MinDeliverDrone,
             MinDeliverVessel,
             WarpDistance,
-            warperNeeded,
-            includeCollectors,
-            setDroneCount,
-            setShipCount,
-            setWarperCount,
-            addOrRemoveItemFromStorageReq,
-            addOrRemoveItemFromStorageResp
+            WarperNeeded,
+            IncludeCollectors,
+            SetDroneCount,
+            SetShipCount,
+            SetWarperCount,
+            AddOrRemoveItemFromStorageRequest,
+            AddOrRemoveItemFromStorageResponse
         }
-        public bool isStorageUI { get; set; }
-        public StationUI.UIsettings settingIndex { get; set; }
-        public float settingValue { get; set; }
-        public int stationGId { get; set;} // NOTE: this can also be the id when handling a PLS
-        public int planetId { get; set; }
-        public int storageIdx { get; set; }
-        public int itemId { get; set; }
-        public int itemCountMax { get; set; }
-        public ELogisticStorage localLogic { get; set; }
-        public ELogisticStorage remoteLogic { get; set; }
-        public bool shouldMimick { get; set; }
-        public bool isStellar { get; set; }
+
+        public int PlanetId { get; set; }
+        public int StationId { get; set; }
+        public int StationGId { get; set;}
+        public bool IsStorageUI { get; set; }
+        public StationUI.EUISettings SettingIndex { get; set; }
+        public float SettingValue { get; set; }
+        public int StorageIdx { get; set; }
+        public int ItemId { get; set; }
+        public int ItemCountMax { get; set; }
+        public ELogisticStorage LocalLogic { get; set; }
+        public ELogisticStorage RemoteLogic { get; set; }
+        public bool ShouldMimic { get; set; }
 
         public StationUI() { }
-        public StationUI(int stationGId, int planetId, int storageIdx, int itemId, int itemCountMax, ELogisticStorage localLogic, ELogisticStorage remoteLogic, bool isStellar)
+        public StationUI(int planetId, int stationId, int stationGId, int storageIdx, int itemId, int itemCountMax, ELogisticStorage localLogic, ELogisticStorage remoteLogic)
         {
-            this.isStorageUI = true;
-            this.stationGId = stationGId;
-            this.planetId = planetId;
-            this.storageIdx = storageIdx;
-            this.itemId = itemId;
-            this.itemCountMax = itemCountMax;
-            this.localLogic = localLogic;
-            this.remoteLogic = remoteLogic;
-            this.shouldMimick = false;
-            this.isStellar = isStellar;
+            IsStorageUI = true;
+            ShouldMimic = false;
+            
+            PlanetId = planetId;
+            StationId = stationId;
+            StationGId = stationGId;
+            StorageIdx = storageIdx;
+            ItemId = itemId;
+            ItemCountMax = itemCountMax;
+            LocalLogic = localLogic;
+            RemoteLogic = remoteLogic;
         }
-        public StationUI(int stationGId, int planetId, StationUI.UIsettings settingIndex, float value)
+        public StationUI(int planetId, int stationId, int stationGId, StationUI.EUISettings settingIndex, float value)
         {
-            this.stationGId = stationGId;
-            this.planetId = planetId;
-            this.isStorageUI = false;
-            this.settingIndex = settingIndex;
-            this.settingValue = value;
-            this.isStellar = true;
+            IsStorageUI = false;
+
+            PlanetId = planetId;
+            StationId = stationId;
+            StationGId = stationGId;
+            SettingIndex = settingIndex;
+            SettingValue = value;
         }
-        public StationUI(int stationGId, int planetId, int storageIdx, StationUI.UIsettings settingIndex, int itemId, int settingValue, bool isStellar)
+        public StationUI(int planetId, int stationId, int stationGId, int storageIdx, StationUI.EUISettings settingIndex, int itemId, int settingValue)
         {
-            this.stationGId = stationGId;
-            this.planetId = planetId;
-            this.settingIndex = settingIndex;
-            this.itemId = itemId;
-            this.settingValue = settingValue;
-            this.storageIdx = storageIdx;
-            this.isStellar = isStellar;
+            PlanetId = planetId;
+            StationId = stationId;
+            StationGId = stationGId;
+            StorageIdx = storageIdx;
+            SettingIndex = settingIndex;
+            ItemId = itemId;
+            SettingValue = settingValue;
         }
     }
 }

--- a/NebulaModel/Packets/Logistics/StationUIInitialSync.cs
+++ b/NebulaModel/Packets/Logistics/StationUIInitialSync.cs
@@ -2,60 +2,66 @@
 {
     public class StationUIInitialSync
     {
-        public int stationGId { get; set; }
-        public int planetId { get; set; }
-        public double tripRangeDrones { get; set; }
-        public double tripRangeShips { get; set; }
-        public int deliveryDrones { get; set; }
-        public int deliveryShips { get; set; }
-        public double warpEnableDist { get; set; }
-        public bool warperNecessary { get; set; }
-        public bool includeOrbitCollector { get; set; }
-        public long energy { get; set; }
-        public long energyPerTick { get; set; }
-        public int[] itemId { get; set; }
-        public int[] itemCountMax { get; set; }
-        public int[] itemCount { get; set; }
-        public int[] localLogic { get; set; }
-        public int[] remoteLogic { get; set; }
-        public int[] remoteOrder { get; set; }
+        public int PlanetId { get; set; }
+        public int StationGId { get; set; }
+        public int StationId { get; set; }
+        public double TripRangeDrones { get; set; }
+        public double TripRangeShips { get; set; }
+        public int DeliveryDrones { get; set; }
+        public int DeliveryShips { get; set; }
+        public double WarperEnableDistance { get; set; }
+        public bool WarperNecessary { get; set; }
+        public bool IncludeOrbitCollector { get; set; }
+        public long Energy { get; set; }
+        public long EnergyPerTick { get; set; }
+        public int[] ItemId { get; set; }
+        public int[] ItemCountMax { get; set; }
+        public int[] ItemCount { get; set; }
+        public int[] LocalLogic { get; set; }
+        public int[] RemoteLogic { get; set; }
+        public int[] RemoteOrder { get; set; }
         public StationUIInitialSync() { }
-        public StationUIInitialSync(int stationGId,
-                                    int planetId,
-                                    double tripRangeDrones,
-                                    double tripRangeShips,
-                                    int deliveryDrones,
-                                    int deliveryShips,
-                                    double warpEnableDist,
-                                    bool warperNecessary,
-                                    bool includeOrbitCollector,
-                                    long energy,
-                                    long energyPerTick,
-                                    int[] itemId,
-                                    int[] itemCountMax,
-                                    int[] itemCount,
-                                    int[] localLogic,
-                                    int[] remoteLogic,
-                                    int[] remoteOrder)
-        {
-            this.stationGId = stationGId;
-            this.planetId = planetId;
-            this.tripRangeDrones = tripRangeDrones;
-            this.tripRangeShips = tripRangeShips;
-            this.deliveryDrones = deliveryDrones;
-            this.deliveryShips = deliveryShips;
-            this.warpEnableDist = warpEnableDist;
-            this.warperNecessary = warperNecessary;
-            this.includeOrbitCollector = includeOrbitCollector;
-            this.energy = energy;
-            this.energyPerTick = energyPerTick;
 
-            this.itemId = itemId;
-            this.itemCountMax = itemCountMax;
-            this.itemCount = itemCount;
-            this.localLogic = localLogic;
-            this.remoteLogic = remoteLogic;
-            this.remoteOrder = remoteOrder;
+        public StationUIInitialSync(
+            int planetId,
+            int stationId,
+            int stationGId,
+            double tripRangeDrones,
+            double tripRangeShips,
+            int deliveryDrones,
+            int deliveryShips,
+            double warperEnableDistance,
+            bool warperNecessary,
+            bool includeOrbitCollector,
+            long energy,
+            long energyPerTick,
+            int[] itemId,
+            int[] itemCountMax,
+            int[] itemCount,
+            int[] localLogic,
+            int[] remoteLogic,
+            int[] remoteOrder
+        )
+        {
+            PlanetId = planetId;
+            StationId = stationId;
+            StationGId = stationGId;
+            TripRangeDrones = tripRangeDrones;
+            TripRangeShips = tripRangeShips;
+            DeliveryDrones = deliveryDrones;
+            DeliveryShips = deliveryShips;
+            WarperEnableDistance = warperEnableDistance;
+            WarperNecessary = warperNecessary;
+            IncludeOrbitCollector = includeOrbitCollector;
+            Energy = energy;
+            EnergyPerTick = energyPerTick;
+
+            ItemId = itemId;
+            ItemCountMax = itemCountMax;
+            ItemCount = itemCount;
+            LocalLogic = localLogic;
+            RemoteLogic = remoteLogic;
+            RemoteOrder = remoteOrder;
         }
     }
 }

--- a/NebulaModel/Packets/Logistics/StationUIInitialSyncRequest.cs
+++ b/NebulaModel/Packets/Logistics/StationUIInitialSyncRequest.cs
@@ -2,13 +2,15 @@
 {
     public class StationUIInitialSyncRequest
     {
-        public int stationGId { get; set; }
-        public int planetId { get; set; }
+        public int PlanetId { get; set; }
+        public int StationId { get; set; }
+        public int StationGId { get; set; }
         public StationUIInitialSyncRequest() { }
-        public StationUIInitialSyncRequest(int stationGId, int planetId)
+        public StationUIInitialSyncRequest(int planetId, int stationId, int stationGId)
         {
-            this.stationGId = stationGId;
-            this.planetId = planetId;
+            PlanetId = planetId;
+            StationId = stationId;
+            StationGId = stationGId;
         }
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/PlanetTransport_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetTransport_Patch.cs
@@ -15,16 +15,18 @@ namespace NebulaPatcher.Patches.Dynamic
             if (SimulatedWorld.Initialized && !ILSShipManager.PatchLockILS)
             {
                 StationComponent stationComponent = __instance.stationPool[stationId];
+                
                 if(stationComponent != null)
                 {
-                    int id = ((stationComponent.isStellar == true) ? stationComponent.gid : stationComponent.id);
-                    StationUI packet = new StationUI(id, __instance.planet.id, storageIdx, itemId, itemCountMax, localLogic, remoteLogic, stationComponent.isStellar);
+                    StationUI packet = new StationUI(__instance.planet.id, stationComponent.id, stationComponent.gid, storageIdx, itemId, itemCountMax, localLogic, remoteLogic);
                     LocalPlayer.SendPacket(packet);
                 }
+                
                 if (LocalPlayer.IsMasterClient)
                 {
                     return true;
                 }
+                
                 return false;
             }
             return true;

--- a/NebulaPatcher/Patches/Dynamic/UIStationStorage_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIStationStorage_Patch.cs
@@ -19,8 +19,8 @@ namespace NebulaPatcher.Patches.Dynamic
         {
             if (SimulatedWorld.Initialized && !ILSShipManager.PatchLockILS)
             {
-                StationUIManager.lastMouseEvent = evt;
-                StationUIManager.lastMouseEventWasDown = true;
+                StationUIManager.LastMouseEvent = evt;
+                StationUIManager.LastMouseEventWasDown = true;
                 StationUI packet;
                 if (LocalPlayer.IsMasterClient)
                 {
@@ -33,15 +33,13 @@ namespace NebulaPatcher.Patches.Dynamic
                         {
                             amount = 0;
                         }
-                        int id = ((__instance.station.isStellar == true) ? __instance.station.gid : __instance.station.id);
-                        packet = new StationUI(id, __instance.stationWindow.factory.planet.id, __instance.index, StationUI.UIsettings.addOrRemoveItemFromStorageResp, __instance.station.storage[__instance.index].itemId, __instance.station.storage[__instance.index].count + amount, __instance.station.isStellar);
+                        packet = new StationUI(__instance.stationWindow.factory.planet.id, __instance.station.id, __instance.station.gid, __instance.index, StationUI.EUISettings.AddOrRemoveItemFromStorageResponse, __instance.station.storage[__instance.index].itemId, __instance.station.storage[__instance.index].count + amount);
                         LocalPlayer.SendPacket(packet);
                     }
                 }
                 else
                 {
-                    int id = ((__instance.station.isStellar == true) ? __instance.station.gid : __instance.station.id);
-                    packet = new StationUI(id, __instance.stationWindow.factory.planet.id, __instance.index, StationUI.UIsettings.addOrRemoveItemFromStorageReq, __instance.station.storage[__instance.index].itemId, __instance.station.storage[__instance.index].count, __instance.station.isStellar);
+                    packet = new StationUI(__instance.stationWindow.factory.planet.id, __instance.station.id, __instance.station.gid, __instance.index, StationUI.EUISettings.AddOrRemoveItemFromStorageRequest, __instance.station.storage[__instance.index].itemId, __instance.station.storage[__instance.index].count);
                     LocalPlayer.SendPacket(packet);
                 }
                 if (LocalPlayer.IsMasterClient)
@@ -63,8 +61,8 @@ namespace NebulaPatcher.Patches.Dynamic
         {
             if (SimulatedWorld.Initialized && !ILSShipManager.PatchLockILS)
             {
-                StationUIManager.lastMouseEvent = evt;
-                StationUIManager.lastMouseEventWasDown = false;
+                StationUIManager.LastMouseEvent = evt;
+                StationUIManager.LastMouseEventWasDown = false;
                 StationUI packet;
                 if (LocalPlayer.IsMasterClient)
                 {
@@ -72,15 +70,13 @@ namespace NebulaPatcher.Patches.Dynamic
                     {
                         int splitVal = UIRoot.instance.uiGame.gridSplit.value;
                         int diff = (splitVal >= __instance.station.storage[__instance.index].count) ? __instance.station.storage[__instance.index].count : splitVal;
-                        int id = ((__instance.station.isStellar == true) ? __instance.station.gid : __instance.station.id);
-                        packet = new StationUI(id, __instance.stationWindow.factory.planet.id, __instance.index, StationUI.UIsettings.addOrRemoveItemFromStorageResp, __instance.station.storage[__instance.index].itemId, __instance.station.storage[__instance.index].count - diff, __instance.station.isStellar);
+                        packet = new StationUI(__instance.stationWindow.factory.planet.id, __instance.station.id, __instance.station.gid, __instance.index, StationUI.EUISettings.AddOrRemoveItemFromStorageResponse, __instance.station.storage[__instance.index].itemId, __instance.station.storage[__instance.index].count - diff);
                         LocalPlayer.SendPacket(packet);
                     }
                 }
                 else
                 {
-                    int id = ((__instance.station.isStellar == true) ? __instance.station.gid : __instance.station.id);
-                    packet = new StationUI(id, __instance.stationWindow.factory.planet.id, __instance.index, StationUI.UIsettings.addOrRemoveItemFromStorageReq, __instance.station.storage[__instance.index].itemId, __instance.station.storage[__instance.index].count, __instance.station.isStellar);
+                    packet = new StationUI(__instance.stationWindow.factory.planet.id, __instance.station.id, __instance.station.gid, __instance.index, StationUI.EUISettings.AddOrRemoveItemFromStorageRequest, __instance.station.storage[__instance.index].itemId, __instance.station.storage[__instance.index].count);
                     LocalPlayer.SendPacket(packet);
                 }
                 if (LocalPlayer.IsMasterClient)

--- a/NebulaPatcher/Patches/Dynamic/UIStationWindow_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIStationWindow_Patch.cs
@@ -16,7 +16,7 @@ namespace NebulaPatcher.Patches.Dynamic
         {
             if (SimulatedWorld.Initialized && !ILSShipManager.PatchLockILS)
             {
-                StationUI packet = new StationUI(__instance.factory.transport.stationPool[__instance.stationId].gid, __instance.factory.planet.id, StationUI.UIsettings.MaxChargePower, value);
+                StationUI packet = new StationUI(__instance.factory.planet.id, __instance.factory.transport.stationPool[__instance.stationId].id, __instance.factory.transport.stationPool[__instance.stationId].gid, StationUI.EUISettings.MaxChargePower, value);
                 LocalPlayer.SendPacket(packet);
                 if (LocalPlayer.IsMasterClient)
                 {
@@ -33,7 +33,7 @@ namespace NebulaPatcher.Patches.Dynamic
         {
             if (SimulatedWorld.Initialized && !ILSShipManager.PatchLockILS && (StationUIManager.UIIsSyncedStage == 2 || LocalPlayer.IsMasterClient))
             {
-                StationUI packet = new StationUI(__instance.factory.transport.stationPool[__instance.stationId].gid, __instance.factory.planet.id, StationUI.UIsettings.MaxTripDrones, value);
+                StationUI packet = new StationUI(__instance.factory.planet.id, __instance.factory.transport.stationPool[__instance.stationId].id,__instance.factory.transport.stationPool[__instance.stationId].gid, StationUI.EUISettings.MaxTripDrones, value);
                 LocalPlayer.SendPacket(packet);
                 if (LocalPlayer.IsMasterClient)
                 {
@@ -50,7 +50,7 @@ namespace NebulaPatcher.Patches.Dynamic
         {
             if (SimulatedWorld.Initialized && !ILSShipManager.PatchLockILS && (StationUIManager.UIIsSyncedStage == 2 || LocalPlayer.IsMasterClient))
             {
-                StationUI packet = new StationUI(__instance.factory.transport.stationPool[__instance.stationId].gid, __instance.factory.planet.id, StationUI.UIsettings.MaxTripVessel, value);
+                StationUI packet = new StationUI(__instance.factory.planet.id, __instance.factory.transport.stationPool[__instance.stationId].id, __instance.factory.transport.stationPool[__instance.stationId].gid, StationUI.EUISettings.MaxTripVessel, value);
                 LocalPlayer.SendPacket(packet);
                 if (LocalPlayer.IsMasterClient)
                 {
@@ -67,7 +67,7 @@ namespace NebulaPatcher.Patches.Dynamic
         {
             if (SimulatedWorld.Initialized && !ILSShipManager.PatchLockILS && (StationUIManager.UIIsSyncedStage == 2 || LocalPlayer.IsMasterClient))
             {
-                StationUI packet = new StationUI(__instance.factory.transport.stationPool[__instance.stationId].gid, __instance.factory.planet.id, StationUI.UIsettings.MinDeliverDrone, value);
+                StationUI packet = new StationUI(__instance.factory.planet.id, __instance.factory.transport.stationPool[__instance.stationId].id, __instance.factory.transport.stationPool[__instance.stationId].gid, StationUI.EUISettings.MinDeliverDrone, value);
                 LocalPlayer.SendPacket(packet);
                 if (LocalPlayer.IsMasterClient)
                 {
@@ -84,7 +84,7 @@ namespace NebulaPatcher.Patches.Dynamic
         {
             if (SimulatedWorld.Initialized && !ILSShipManager.PatchLockILS && (StationUIManager.UIIsSyncedStage == 2 || LocalPlayer.IsMasterClient))
             {
-                StationUI packet = new StationUI(__instance.factory.transport.stationPool[__instance.stationId].gid, __instance.factory.planet.id, StationUI.UIsettings.MinDeliverVessel, value);
+                StationUI packet = new StationUI(__instance.factory.planet.id, __instance.factory.transport.stationPool[__instance.stationId].id, __instance.factory.transport.stationPool[__instance.stationId].gid, StationUI.EUISettings.MinDeliverVessel, value);
                 LocalPlayer.SendPacket(packet);
                 if (LocalPlayer.IsMasterClient)
                 {
@@ -101,7 +101,7 @@ namespace NebulaPatcher.Patches.Dynamic
         {
             if (SimulatedWorld.Initialized && !ILSShipManager.PatchLockILS && (StationUIManager.UIIsSyncedStage == 2 || LocalPlayer.IsMasterClient))
             {
-                StationUI packet = new StationUI(__instance.factory.transport.stationPool[__instance.stationId].gid, __instance.factory.planet.id, StationUI.UIsettings.WarpDistance, value);
+                StationUI packet = new StationUI(__instance.factory.planet.id, __instance.factory.transport.stationPool[__instance.stationId].id, __instance.factory.transport.stationPool[__instance.stationId].gid, StationUI.EUISettings.WarpDistance, value);
                 LocalPlayer.SendPacket(packet);
                 if (LocalPlayer.IsMasterClient)
                 {
@@ -118,7 +118,7 @@ namespace NebulaPatcher.Patches.Dynamic
         {
             if (SimulatedWorld.Initialized && !ILSShipManager.PatchLockILS && (StationUIManager.UIIsSyncedStage == 2 || LocalPlayer.IsMasterClient))
             {
-                StationUI packet = new StationUI(__instance.factory.transport.stationPool[__instance.stationId].gid, __instance.factory.planet.id, StationUI.UIsettings.warperNeeded, 0f);
+                StationUI packet = new StationUI(__instance.factory.planet.id, __instance.factory.transport.stationPool[__instance.stationId].id, __instance.factory.transport.stationPool[__instance.stationId].gid, StationUI.EUISettings.WarperNeeded, 0f);
                 LocalPlayer.SendPacket(packet);
                 if (LocalPlayer.IsMasterClient)
                 {
@@ -135,7 +135,7 @@ namespace NebulaPatcher.Patches.Dynamic
         {
             if (SimulatedWorld.Initialized && !ILSShipManager.PatchLockILS && (StationUIManager.UIIsSyncedStage == 2 || LocalPlayer.IsMasterClient))
             {
-                StationUI packet = new StationUI(__instance.factory.transport.stationPool[__instance.stationId].gid, __instance.factory.planet.id, StationUI.UIsettings.includeCollectors, 0f);
+                StationUI packet = new StationUI(__instance.factory.planet.id, __instance.factory.transport.stationPool[__instance.stationId].id, __instance.factory.transport.stationPool[__instance.stationId].gid, StationUI.EUISettings.IncludeCollectors, 0f);
                 LocalPlayer.SendPacket(packet);
                 if (LocalPlayer.IsMasterClient)
                 {
@@ -180,7 +180,7 @@ namespace NebulaPatcher.Patches.Dynamic
                     StationUIManager.UIRequestedShipDronWarpChange = true;
                 }
 
-                StationUI packet = new StationUI(stationComponent.gid, __instance.factory.planet.id, StationUI.UIsettings.setDroneCount, stationComponent.idleDroneCount + toAdd);
+                StationUI packet = new StationUI(__instance.factory.planet.id, stationComponent.id, stationComponent.gid, StationUI.EUISettings.SetDroneCount, stationComponent.idleDroneCount + toAdd);
                 LocalPlayer.SendPacket(packet);
                 if (LocalPlayer.IsMasterClient)
                 {
@@ -224,7 +224,7 @@ namespace NebulaPatcher.Patches.Dynamic
                 {
                     StationUIManager.UIRequestedShipDronWarpChange = true;
                 }
-                StationUI packet = new StationUI(stationComponent.gid, __instance.factory.planet.id, StationUI.UIsettings.setShipCount, stationComponent.idleShipCount + toAdd);
+                StationUI packet = new StationUI(__instance.factory.planet.id, stationComponent.id, stationComponent.gid, StationUI.EUISettings.SetShipCount, stationComponent.idleShipCount + toAdd);
                 LocalPlayer.SendPacket(packet);
 
                 if (LocalPlayer.IsMasterClient)
@@ -269,7 +269,7 @@ namespace NebulaPatcher.Patches.Dynamic
                     StationUIManager.UIRequestedShipDronWarpChange = true;
                 }
 
-                StationUI packet = new StationUI(stationComponent.gid, __instance.factory.planet.id, StationUI.UIsettings.setWarperCount, stationComponent.warperCount + toAdd);
+                StationUI packet = new StationUI(__instance.factory.planet.id, stationComponent.id, stationComponent.gid, StationUI.EUISettings.SetWarperCount, stationComponent.warperCount + toAdd);
                 LocalPlayer.SendPacket(packet);
                 if (LocalPlayer.IsMasterClient)
                 {
@@ -289,7 +289,7 @@ namespace NebulaPatcher.Patches.Dynamic
                 return true;
             }
             ((Text)AccessTools.Field(typeof(UIStationWindow), "titleText").GetValue(__instance)).text = "Loading...";
-            StationUIManager.lastSelectedGameObj = EventSystem.current.currentSelectedGameObject;
+            StationUIManager.LastSelectedGameObj = EventSystem.current.currentSelectedGameObject;
             if(__instance.factory == null)
             {
                 __instance.factory = GameMain.localPlanet.factory;
@@ -315,7 +315,7 @@ namespace NebulaPatcher.Patches.Dynamic
             {
                 int id = (stationComponent.isStellar == true) ? stationComponent.gid : stationComponent.id;
                 // for some reason PLS has planetId set to 0, so we use players localPlanet here (he should be on a planet anyways when opening the UI)
-                LocalPlayer.SendPacket(new StationUIInitialSyncRequest(id, (stationComponent.isStellar == true) ? 0 : GameMain.localPlanet.id));
+                LocalPlayer.SendPacket(new StationUIInitialSyncRequest(stationComponent.planetId, stationComponent.id, stationComponent.gid));
                 StationUIManager.UIIsSyncedStage++;
             }
             return false;
@@ -351,8 +351,8 @@ namespace NebulaPatcher.Patches.Dynamic
             if(__instance.stationId != 0 || StationUIManager.UIStationId != 0)
             {
                 // it is actually 0 before we manually set it to the right value in StationUIInitialSyncProcessor.cs and thus its a good check to skip sending the packet on the Free() call
-                LocalPlayer.SendPacket(new StationSubscribeUIUpdates(false, __instance.transport.stationPool[StationUIManager.UIStationId].gid));
-                StationUIManager.lastSelectedGameObj = null;
+                LocalPlayer.SendPacket(new StationSubscribeUIUpdates(false, __instance.transport.planet.id, __instance.transport.stationPool[StationUIManager.UIStationId].id, __instance.transport.stationPool[StationUIManager.UIStationId].gid));
+                StationUIManager.LastSelectedGameObj = null;
                 StationUIManager.UIIsSyncedStage = 0;
                 StationUIManager.UIStationId = 0;
             }

--- a/NebulaPatcher/Patches/Transpilers/StationComponent_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/StationComponent_Transpiler.cs
@@ -67,7 +67,7 @@ namespace NebulaPatcher.Patches.Transpilers
                     {
                         if (SimulatedWorld.Initialized && LocalPlayer.IsMasterClient)
                         {
-                            List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.gid);
+                            List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.planetId, stationComponent.id, stationComponent.gid);
                             ILSRemoteOrderData packet = new ILSRemoteOrderData(stationComponent.gid, index, stationComponent.storage[index].remoteOrder);
                             for(int i = 0; i < subscribers.Count; i++)
                             {
@@ -114,7 +114,8 @@ namespace NebulaPatcher.Patches.Transpilers
                             StationStore[] storeArray = gStationComponent[gIndex]?.storage;
                             if (storeArray != null)
                             {
-                                List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(gStationComponent[gIndex].gid);
+                                List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(gStationComponent[gIndex].planetId, gStationComponent[gIndex].id, gStationComponent[gIndex].gid);
+                                
                                 int otherIndex = stationComponent.workShipOrders[n].otherIndex;
                                 ILSRemoteOrderData packet = new ILSRemoteOrderData(gStationComponent[gIndex].gid, otherIndex, storeArray[otherIndex].remoteOrder);
                                 for(int i = 0; i < subscribers.Count; i++)
@@ -153,7 +154,7 @@ namespace NebulaPatcher.Patches.Transpilers
                         {
                             if (SimulatedWorld.Initialized && LocalPlayer.IsMasterClient)
                             {
-                                List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.gid);
+                                List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.planetId, stationComponent.id, stationComponent.gid);
                                 ILSRemoteOrderData packet = new ILSRemoteOrderData(stationComponent.gid, index, stationComponent.storage[index].remoteOrder);
                                 for(int i = 0; i < subscribers.Count; i++)
                                 {
@@ -175,7 +176,7 @@ namespace NebulaPatcher.Patches.Transpilers
                                 StationStore[] storeArray = gStationComponent[gIndex]?.storage;
                                 if (storeArray != null)
                                 {
-                                    List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(gStationComponent[gIndex].gid);
+                                    List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(gStationComponent[gIndex].planetId, gStationComponent[gIndex].id, gStationComponent[gIndex].gid);
                                     int otherIndex = stationComponent.workShipOrders[n].otherIndex;
                                     ILSRemoteOrderData packet = new ILSRemoteOrderData(gStationComponent[gIndex].gid, otherIndex, storeArray[otherIndex].remoteOrder);
                                     for(int i = 0; i < subscribers.Count; i++)
@@ -199,7 +200,7 @@ namespace NebulaPatcher.Patches.Transpilers
                         {
                             if (SimulatedWorld.Initialized && LocalPlayer.IsMasterClient)
                             {
-                                List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.gid);
+                                List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.planetId, stationComponent.id, stationComponent.gid);
                                 ILSRemoteOrderData packet = new ILSRemoteOrderData(stationComponent.gid, index, stationComponent.storage[index].remoteOrder);
                                 for(int i = 0; i < subscribers.Count; i++)
                                 {
@@ -221,7 +222,7 @@ namespace NebulaPatcher.Patches.Transpilers
                                 StationStore[] storeArray = gStationComponent[gIndex]?.storage;
                                 if (storeArray != null)
                                 {
-                                    List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(gStationComponent[gIndex].gid);
+                                    List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(gStationComponent[gIndex].planetId, gStationComponent[gIndex].id, gStationComponent[gIndex].gid);
                                     int otherIndex = stationComponent.workShipOrders[n].otherIndex;
                                     ILSRemoteOrderData packet = new ILSRemoteOrderData(gStationComponent[gIndex].gid, otherIndex, storeArray[otherIndex].remoteOrder);
                                     for(int i = 0; i < subscribers.Count; i++)
@@ -451,7 +452,7 @@ namespace NebulaPatcher.Patches.Transpilers
                         {
                             if (SimulatedWorld.Initialized && LocalPlayer.IsMasterClient)
                             {
-                                List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.gid);
+                                List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.planetId, stationComponent.id, stationComponent.gid);
                                 ILSRemoteOrderData packet = new ILSRemoteOrderData(stationComponent.gid, supplyDemandPair.demandIndex, stationComponent.storage[supplyDemandPair.demandIndex].remoteOrder);
                                 for (int i = 0; i < subscribers.Count; i++)
                                 {
@@ -474,7 +475,7 @@ namespace NebulaPatcher.Patches.Transpilers
                         {
                             if (SimulatedWorld.Initialized && LocalPlayer.IsMasterClient)
                             {
-                                List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.gid);
+                                List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.planetId, stationComponent.id, stationComponent.gid);
                                 ILSRemoteOrderData packet = new ILSRemoteOrderData(stationComponent.gid, supplyDemandPair.demandIndex, stationComponent.storage[supplyDemandPair.demandIndex].remoteOrder);
                                 for (int i = 0; i < subscribers.Count; i++)
                                 {
@@ -497,7 +498,7 @@ namespace NebulaPatcher.Patches.Transpilers
                         {
                             if (SimulatedWorld.Initialized && LocalPlayer.IsMasterClient)
                             {
-                                List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.gid);
+                                List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.planetId, stationComponent.id, stationComponent.gid);
                                 ILSRemoteOrderData packet = new ILSRemoteOrderData(stationComponent.gid, supplyDemandPair.demandIndex, stationComponent.storage[supplyDemandPair.demandIndex].remoteOrder);
                                 for (int i = 0; i < subscribers.Count; i++)
                                 {
@@ -533,7 +534,7 @@ namespace NebulaPatcher.Patches.Transpilers
                 {
                     if (SimulatedWorld.Initialized && LocalPlayer.IsMasterClient)
                     {
-                        List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.gid);
+                        List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.planetId, stationComponent.id, stationComponent.gid);
                         ILSRemoteOrderData packet = new ILSRemoteOrderData(stationComponent.gid, supplyDemandPair.demandIndex, stationComponent.storage[supplyDemandPair.demandIndex].remoteOrder);
                         for(int i = 0; i < subscribers.Count; i++)
                         {
@@ -565,7 +566,7 @@ namespace NebulaPatcher.Patches.Transpilers
                 {
                     if (SimulatedWorld.Initialized && LocalPlayer.IsMasterClient)
                     {
-                        List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.gid);
+                        List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.planetId, stationComponent.id, stationComponent.gid);
                         ILSRemoteOrderData packet = new ILSRemoteOrderData(stationComponent.gid, supplyDemandPair.supplyIndex, stationComponent.storage[supplyDemandPair.supplyIndex].remoteOrder);
                         for(int i = 0; i < subscribers.Count; i++)
                         {
@@ -609,7 +610,7 @@ namespace NebulaPatcher.Patches.Transpilers
                             // needed as some times game passes 5 as index causing out of bounds exception (really weird this happens..)
                             return 0;
                         }
-                        List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.gid);
+                        List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.planetId, stationComponent.id, stationComponent.gid);
                         ILSRemoteOrderData packet = new ILSRemoteOrderData(stationComponent.gid, index, stationComponent.storage[index].remoteOrder);
                         for(int i = 0; i < subscribers.Count; i++)
                         {
@@ -661,7 +662,7 @@ namespace NebulaPatcher.Patches.Transpilers
                                         // needed as some times game passes 5 as index causing out of bounds exception (really weird this happens..)
                                         return 0;
                                     }
-                                    List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.gid);
+                                    List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.planetId, stationComponent.id, stationComponent.gid);
                                     ILSRemoteOrderData packet = new ILSRemoteOrderData(stationComponent.gid, index, stationComponent.storage[index].remoteOrder);
                                     for (int i = 0; i < subscribers.Count; i++)
                                     {
@@ -708,7 +709,7 @@ namespace NebulaPatcher.Patches.Transpilers
                             // needed as some times game passes 5 as index causing out of bounds exception (really weird this happens..)
                             return 0;
                         }
-                        List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.gid);
+                        List<NebulaConnection> subscribers = StationUIManager.GetSubscribers(stationComponent.planetId, stationComponent.id, stationComponent.gid);
                         ILSRemoteOrderData packet = new ILSRemoteOrderData(stationComponent.gid, index, stationComponent.storage[index].remoteOrder);
                         for(int i = 0; i < subscribers.Count; i++)
                         {
@@ -741,7 +742,7 @@ namespace NebulaPatcher.Patches.Transpilers
                                     new CodeInstruction(OpCodes.Ldloca_S, 35))
                 .InsertAndAdvance(HarmonyLib.Transpilers.EmitDelegate<ShipFunc>((StationComponent stationComponent, ref ShipData shipData) =>
                 {
-                    LocalPlayer.SendPacket(new StationUI(stationComponent.gid, stationComponent.planetId, StationUI.UIsettings.setWarperCount, stationComponent.warperCount));
+                    LocalPlayer.SendPacket(new StationUI(stationComponent.planetId, stationComponent.id, stationComponent.gid, StationUI.EUISettings.SetWarperCount, stationComponent.warperCount));
                     LocalPlayer.SendPacket(new ILSShipUpdateWarperCnt(stationComponent.gid, shipData.shipIndex, shipData.warperCnt));
                     return 0;
                 }))

--- a/NebulaWorld/Logistics/StationUIManager.cs
+++ b/NebulaWorld/Logistics/StationUIManager.cs
@@ -158,13 +158,6 @@ namespace NebulaWorld.Logistics
                 }
             }
 
-            // Only should should update everything
-            // Todo: Confirm if this is correct since some logic still runs on clients
-            if (!LocalPlayer.IsMasterClient)
-            {
-                return;
-            }
-
             if (packet.SettingIndex == StationUI.EUISettings.MaxTripDrones)
             {
                 stationComponent.tripRangeDrones = Math.Cos((double)packet.SettingValue / 180.0 * 3.141592653589793);

--- a/NebulaWorld/Logistics/StationUIManager.cs
+++ b/NebulaWorld/Logistics/StationUIManager.cs
@@ -1,5 +1,6 @@
 ﻿using NebulaModel.Packets.Logistics;
 using HarmonyLib;
+using NebulaModel.Logger;
 using System;
 using System.Collections.Generic;
 using NebulaModel.Networking;
@@ -8,63 +9,82 @@ using UnityEngine.EventSystems;
 
 namespace NebulaWorld.Logistics
 {
+    public class Subscribers
+    {
+        public int PlanetId { get; }
+        public int StationId { get; }
+        public int StationGId { get; }
+        public List<NebulaConnection> Connections { get; set; }
+        public Subscribers(int planetId, int stationId, int stationGId)
+        {
+            PlanetId = planetId;
+            StationId = stationId;
+            StationGId = stationGId;
+            Connections = new List<NebulaConnection>();
+        }
+
+        public override string ToString() => $"{PlanetId}.{StationId}.{StationGId}";
+
+        public static string GetKey(int planetId, int stationId, int statgionGId)
+        {
+            return $"{planetId}.{stationId}.{statgionGId}";
+        }
+    }
+    
     public static class StationUIManager
     {
-        private static Dictionary<int, List<NebulaConnection>> StationUISubscribers;
+        private static Dictionary<string, Subscribers> _stationUISubscribers;
         public static int UpdateCooldown; // cooldown is used to slow down updates on storage slider
-        public static BaseEventData lastMouseEvent;
-        public static bool lastMouseEventWasDown;
-        public static GameObject lastSelectedGameObj;
+        public static BaseEventData LastMouseEvent;
+        public static bool LastMouseEventWasDown;
+        public static GameObject LastSelectedGameObj;
         public static int UIIsSyncedStage; // 0 == not synced, 1 == request sent, 2 == synced | this is only used client side
         public static int UIStationId;
         public static bool UIRequestedShipDronWarpChange; // when receiving a ship, drone or warp change only take/add items from the one issuing the request
 
         public static void Initialize()
         {
-            StationUISubscribers = new Dictionary<int, List<NebulaConnection>>();
+            _stationUISubscribers = new Dictionary<string, Subscribers>();
             UpdateCooldown = 0;
             UIIsSyncedStage = 0;
             UIStationId = 0;
             UIRequestedShipDronWarpChange = false;
         }
         // When a client opens a station's UI he requests a subscription for live updates, so add him to the list
-        public static void AddSubscriber(int stationGId, NebulaConnection player)
+        public static void AddSubscriber(int planetId, int stationId, int stationGId, NebulaConnection connection)
         {
-            List<NebulaConnection> players;
-            if(!StationUISubscribers.TryGetValue(stationGId, out players))
+            // Attempt to find existing subscribers to a specific station, if we couldn't find an existing one
+            // we must initialize a new Subscribers for this specific station.
+            if(!_stationUISubscribers.TryGetValue(Subscribers.GetKey(planetId, stationId, stationGId), out Subscribers subscribers))
             {
-                players = new List<NebulaConnection>();
-                StationUISubscribers.Add(stationGId, players);
+                _stationUISubscribers.Add(Subscribers.GetKey(planetId, stationId, stationGId), new Subscribers(planetId, stationId, stationGId));
             }
-            for (int i = 0; i < StationUISubscribers[stationGId].Count; i++)
-            {
-                if(StationUISubscribers[stationGId][i] == player)
-                {
-                    return;
-                }
-            }
-            StationUISubscribers[stationGId].Add(player);
+
+            _stationUISubscribers.TryGetValue(Subscribers.GetKey(planetId, stationId, stationGId), out subscribers);
+            
+            subscribers?.Connections.Add(connection);
         }
-        public static void RemoveSubscriber(int stationGId, NebulaConnection player)
+        public static void RemoveSubscriber(int planetId, int stationId, int stationGId, NebulaConnection connection)
         {
-            List<NebulaConnection> players;
-            if(StationUISubscribers.TryGetValue(stationGId, out players))
+            if(_stationUISubscribers.TryGetValue(Subscribers.GetKey(planetId, stationId, stationGId), out Subscribers subscribers))
             {
-                StationUISubscribers[stationGId].Remove(player);
-                if(StationUISubscribers[stationGId].Count == 0)
+                subscribers.Connections.Remove(connection);
+
+                if (subscribers.Connections.Count == 0)
                 {
-                    StationUISubscribers.Remove(stationGId);
+                    _stationUISubscribers.Remove(subscribers.ToString());
                 }
             }
         }
-        public static List<NebulaConnection> GetSubscribers(int stationGId)
+        
+        public static List<NebulaConnection> GetSubscribers(int planetId, int stationId, int stationGId)
         {
-            List<NebulaConnection> players;
-            if(!StationUISubscribers.TryGetValue(stationGId, out players))
+            if(!_stationUISubscribers.TryGetValue(Subscribers.GetKey(planetId, stationId, stationGId), out Subscribers subscribers))
             {
                 return new List<NebulaConnection>();
             }
-            return players;
+            
+            return subscribers.Connections;
         }
 
         public static void DecreaseCooldown()
@@ -78,10 +98,10 @@ namespace NebulaWorld.Logistics
 
         public static void UpdateUI(StationUI packet)
         {
-            if((UpdateCooldown == 0 || !packet.isStorageUI) && LocalPlayer.IsMasterClient)
+            if((UpdateCooldown == 0 || !packet.IsStorageUI) && LocalPlayer.IsMasterClient)
             {
                 UpdateCooldown = 10;
-                if (packet.isStorageUI)
+                if (packet.IsStorageUI)
                 {
                     UpdateStorageUI(packet);
                 }
@@ -92,7 +112,7 @@ namespace NebulaWorld.Logistics
             }
             else if(!LocalPlayer.IsMasterClient)
             {
-                if (packet.isStorageUI)
+                if (packet.IsStorageUI)
                 {
                     UpdateStorageUI(packet);
                 }
@@ -102,321 +122,296 @@ namespace NebulaWorld.Logistics
                 }
             }
         }
-        /*
-         * if the local player does not have the corresponding station window opened we still need to update some (or all for host) settings
-         * so do that here
+        
+        /**
+         * Updates to a given station that should happen in the background.
          */
-        private static void UpdateSettingsUIBackground(StationUI packet, PlanetData pData, int stationGId)
+        private static void UpdateSettingsUIBackground(StationUI packet, PlanetData planet, StationComponent stationComponent)
         {
-            StationComponent[] stationPool = GameMain.data.galacticTransport.stationPool;
-            int stationId = stationGId;
-            // if we have the planet factory loaded take the local transport array, if not take the global galactic array
-            if (pData?.factory != null && pData?.factory?.transport != null)
-            {
-                stationPool = pData.factory.transport.stationPool;
-                for (int i = 0; i < stationPool.Length; i++)
-                {
-                    if (stationPool[i] != null && stationPool[i].gid == stationGId)
-                    {
-                        stationId = stationPool[i].id;
-                        break;
-                    }
-                }
-            }
+            StationComponent[] gStationPool = GameMain.data.galacticTransport.stationPool;
+
             // update drones, ships, warpers and energy consumption for everyone
-            if ((packet.settingIndex >= StationUI.UIsettings.setDroneCount && packet.settingIndex <= StationUI.UIsettings.setWarperCount) || packet.settingIndex == StationUI.UIsettings.MaxChargePower)
+            if ((packet.SettingIndex >= StationUI.EUISettings.SetDroneCount && packet.SettingIndex <= StationUI.EUISettings.SetWarperCount) || packet.SettingIndex == StationUI.EUISettings.MaxChargePower)
             {
-                if (stationPool.Length > stationId)
+                if (packet.SettingIndex == (int)StationUI.EUISettings.MaxChargePower && planet.factory?.powerSystem != null)
                 {
-                    if (packet.settingIndex == (int)StationUI.UIsettings.MaxChargePower && pData.factory?.powerSystem != null)
+                    PowerConsumerComponent[] consumerPool = planet.factory.powerSystem.consumerPool;
+                    if (consumerPool.Length > stationComponent.pcId)
                     {
-                        PowerConsumerComponent[] consumerPool = pData.factory.powerSystem.consumerPool;
-                        if (consumerPool.Length > stationPool[stationId].pcId)
-                        {
-                            consumerPool[stationPool[stationId].pcId].workEnergyPerTick = (long)(50000.0 * (double)packet.settingValue + 0.5);
-                        }
-                    }
-                    if (packet.settingIndex == StationUI.UIsettings.setDroneCount)
-                    {
-                        stationPool[stationId].idleDroneCount = (int)packet.settingValue;
-                    }
-                    if (packet.settingIndex == StationUI.UIsettings.setShipCount)
-                    {
-                        stationPool[stationId].idleShipCount = (int)packet.settingValue;
-                    }
-                    if (packet.settingIndex == StationUI.UIsettings.setWarperCount)
-                    {
-                        stationPool[stationId].warperCount = (int)packet.settingValue;
+                        consumerPool[stationComponent.pcId].workEnergyPerTick = (long)(50000.0 * (double)packet.SettingValue + 0.5);
                     }
                 }
+
+                if (packet.SettingIndex == StationUI.EUISettings.SetDroneCount)
+                {
+                    stationComponent.idleDroneCount = (int)packet.SettingValue;
+                }
+
+                if (packet.SettingIndex == StationUI.EUISettings.SetShipCount)
+                {
+                    stationComponent.idleShipCount = (int)packet.SettingValue;
+                }
+
+                if (packet.SettingIndex == StationUI.EUISettings.SetWarperCount)
+                {
+                    stationComponent.warperCount = (int)packet.SettingValue;
+                }
             }
-            // only host should update everything
+
+            // Only should should update everything
+            // Todo: Confirm if this is correct since some logic still runs on clients
             if (!LocalPlayer.IsMasterClient)
             {
                 return;
             }
-            if(packet.settingIndex == StationUI.UIsettings.MaxTripDrones)
+
+            if (packet.SettingIndex == StationUI.EUISettings.MaxTripDrones)
             {
-                if (stationPool.Length > stationId)
-                {
-                    stationPool[stationId].tripRangeDrones = Math.Cos((double)packet.settingValue / 180.0 * 3.141592653589793);
-                }
+                stationComponent.tripRangeDrones = Math.Cos((double)packet.SettingValue / 180.0 * 3.141592653589793);
             }
-            if(packet.settingIndex == StationUI.UIsettings.MaxTripVessel)
+
+            if (packet.SettingIndex == StationUI.EUISettings.MaxTripVessel)
             {
-                if (stationPool.Length > stationId)
+                double value = packet.SettingValue;
+                if (value > 40.5)
                 {
-                    double value = packet.settingValue;
-                    if (value > 40.5)
-                    {
-                        value = 10000.0;
-                    }
-                    else if (value > 20.5)
-                    {
-                        value = value * 2f - 20f;
-                    }
-                    stationPool[stationId].tripRangeShips = 2400000.0 * value;
+                    value = 10000.0;
                 }
-            }
-            if(packet.settingIndex == StationUI.UIsettings.MinDeliverDrone)
-            {
-                if (stationPool.Length > stationId)
+                else if (value > 20.5)
                 {
-                    int value = (int)(packet.settingValue * 10f + 0.5f);
-                    if (value < 1)
-                    {
-                        value = 1;
-                    }
-                    stationPool[stationId].deliveryDrones = value;
+                    value = value * 2f - 20f;
                 }
+
+                stationComponent.tripRangeShips = 2400000.0 * value;
             }
-            if(packet.settingIndex == StationUI.UIsettings.MinDeliverVessel)
+
+            if (packet.SettingIndex == StationUI.EUISettings.MinDeliverDrone)
             {
-                if (stationPool.Length > stationId)
+                int value = (int)(packet.SettingValue * 10f + 0.5f);
+                if (value < 1)
                 {
-                    int value = (int)(packet.settingValue * 10f + 0.5f);
-                    if (value < 1)
-                    {
-                        value = 1;
-                    }
-                    stationPool[stationId].deliveryShips = value;
+                    value = 1;
                 }
+
+                stationComponent.deliveryDrones = value;
             }
-            if(packet.settingIndex == StationUI.UIsettings.WarpDistance)
+
+            if (packet.SettingIndex == StationUI.EUISettings.MinDeliverVessel)
             {
-                if (stationPool.Length > stationId)
+                int value = (int)(packet.SettingValue * 10f + 0.5f);
+                if (value < 1)
                 {
-                    double value = packet.settingValue;
-                    if (value < 1.5)
-                    {
-                        value = 0.2;
-                    }
-                    else if (value < 7.5)
-                    {
-                        value = value * 0.5 - 0.5;
-                    }
-                    else if (value < 16.5)
-                    {
-                        value -= 4f;
-                    }
-                    else if (value < 20.5)
-                    {
-                        value = value * 2f - 20f;
-                    }
-                    else
-                    {
-                        value = 60;
-                    }
-                    stationPool[stationId].warpEnableDist = 40000.0 * value;
+                    value = 1;
                 }
+
+                stationComponent.deliveryShips = value;
             }
-            if(packet.settingIndex == StationUI.UIsettings.warperNeeded)
+
+            if (packet.SettingIndex == StationUI.EUISettings.WarpDistance)
             {
-                if (stationPool.Length > stationId)
+                double value = packet.SettingValue;
+                if (value < 1.5)
                 {
-                    stationPool[stationId].warperNecessary = !stationPool[stationId].warperNecessary;
+                    value = 0.2;
                 }
-            }
-            if(packet.settingIndex == StationUI.UIsettings.includeCollectors)
-            {
-                if (stationPool.Length > stationId)
+                else if (value < 7.5)
                 {
-                    stationPool[stationId].includeOrbitCollector = !stationPool[stationId].includeOrbitCollector;
+                    value = value * 0.5 - 0.5;
                 }
-            }
-            if (packet.settingIndex == StationUI.UIsettings.addOrRemoveItemFromStorageResp)
-            {
-                if (stationPool[stationId].storage != null)
+                else if (value < 16.5)
                 {
-                    stationPool[stationId].storage[packet.storageIdx].count = (int)packet.settingValue;
+                    value -= 4f;
+                }
+                else if (value < 20.5)
+                {
+                    value = value * 2f - 20f;
+                }
+                else
+                {
+                    value = 60;
+                }
+
+                stationComponent.warpEnableDist = 40000.0 * value;
+            }
+
+            if (packet.SettingIndex == StationUI.EUISettings.WarperNeeded)
+            {
+                stationComponent.warperNecessary = !stationComponent.warperNecessary;
+            }
+
+            if (packet.SettingIndex == StationUI.EUISettings.IncludeCollectors)
+            {
+                stationComponent.includeOrbitCollector = !stationComponent.includeOrbitCollector;
+            }
+
+            if (packet.SettingIndex == StationUI.EUISettings.AddOrRemoveItemFromStorageResponse)
+            {
+                if (stationComponent.storage != null)
+                {
+                    stationComponent.storage[packet.StorageIdx].count = (int)packet.SettingValue;
                 }
             }
         }
+        
         /*
-         * update settings and item, drone, ship and warper count
-         * first determine if the local player has the station window opened and hadle that accordingly.
+         * Update station settings and drone, ship and warper counts.
+         * 
+         * First determine if the local player has the station window opened and handle that accordingly.
          */
         private static void UpdateSettingsUI(StationUI packet)
         {
             UIStationWindow stationWindow = UIRoot.instance.uiGame.stationWindow;
-            if (stationWindow != null)
+            
+            StationComponent stationComponent = null;
+            PlanetData planet = GameMain.galaxy?.PlanetById(packet.PlanetId);
+            
+            // If we can't find planet or the factory for said planet, we can just skip this
+            if (planet?.factory?.transport == null) return;
+            
+            StationComponent[] gStationPool = GameMain.data.galacticTransport.stationPool;
+            StationComponent[] stationPool = planet?.factory?.transport?.stationPool;
+            
+            // Figure out if we're dealing with a PLS or a ILS station
+            stationComponent = packet.StationGId > 0 ? gStationPool[packet.StationGId] : stationPool?[packet.StationId];
+            
+            if (stationComponent == null)
             {
-                int _stationId = (int)AccessTools.Field(typeof(UIStationWindow), "_stationId")?.GetValue(stationWindow);
-                PlanetData pData = GameMain.galaxy.PlanetById(packet.planetId);
-                if(pData?.factory == null || pData?.factory?.transport == null)
-                {
-                    if(GameMain.data.galacticTransport.stationPool.Length > packet.stationGId && GameMain.data.galacticTransport.stationPool[packet.stationGId] != null)
-                    {
-                        // client never was on this planet before or has it unloaded, but has a fake structure created, so update it
-                        UpdateSettingsUIBackground(packet, pData, packet.stationGId);
-                    }
-                    return;
-                }
-                for (int i = 0; i < pData.factory.transport.stationPool.Length; i++)
-                {
-                    if(pData.factory.transport.stationPool[i] != null)
-                    {
-                        int id = ((packet.isStellar == true) ? pData.factory.transport.stationPool[i].gid : pData.factory.transport.stationPool[i].id);
-                        if (id == packet.stationGId)
-                        {
-                            if (pData.factory.transport.stationPool[i].id != _stationId)
-                            {
-                                // receiving side has the UI closed or another stations UI opened. still update drones, ships, warpers and power consumption for clients and update all for host
-                                UpdateSettingsUIBackground(packet, pData, pData.factory.transport.stationPool[i].gid);
-                                return;
-                            }
-                            else
-                            {
-                                break;
-                            }
-                        }
-                    }
-                }
+                Log.Error($"UpdateStorageUI: Unable to find requested station on planet {packet.PlanetId} with id {packet.StationId} and gid of {packet.StationGId}");
+                return;
+            }
 
-                // this locks the patches so we can call vanilla functions without triggering our patches to avoid endless loops
-                using (ILSShipManager.PatchLockILS.On())
+            if (stationWindow == null) return;
+            
+            int _stationId = (int)AccessTools.Field(typeof(UIStationWindow), "_stationId")?.GetValue(stationWindow);
+
+            // Client has no knowledge of the planet, closed the window or
+            // opened a different station, do all updates in the background.
+            if(planet?.factory?.transport == null || stationComponent.id != _stationId)
+            {
+                UpdateSettingsUIBackground(packet, planet, stationComponent);
+                return;
+            }
+
+            // this locks the patches so we can call vanilla functions without triggering our patches to avoid endless loops
+            using (ILSShipManager.PatchLockILS.On())
+            {
+                if (packet.SettingIndex == StationUI.EUISettings.MaxChargePower)
                 {
-                    if (packet.settingIndex == StationUI.UIsettings.MaxChargePower)
-                    {
-                        stationWindow.OnMaxChargePowerSliderValueChange(packet.settingValue);
-                    }
-                    if (packet.settingIndex == StationUI.UIsettings.MaxTripDrones)
-                    {
-                        stationWindow.OnMaxTripDroneSliderValueChange(packet.settingValue);
-                    }
-                    if (packet.settingIndex == StationUI.UIsettings.MaxTripVessel)
-                    {
-                        stationWindow.OnMaxTripVesselSliderValueChange(packet.settingValue);
-                    }
-                    if (packet.settingIndex == StationUI.UIsettings.MinDeliverDrone)
-                    {
-                        stationWindow.OnMinDeliverDroneValueChange(packet.settingValue);
-                    }
-                    if (packet.settingIndex == StationUI.UIsettings.MinDeliverVessel)
-                    {
-                        stationWindow.OnMinDeliverVesselValueChange(packet.settingValue);
-                    }
-                    if (packet.settingIndex == StationUI.UIsettings.WarpDistance)
-                    {
-                        stationWindow.OnWarperDistanceValueChange(packet.settingValue);
-                    }
-                    if (packet.settingIndex == StationUI.UIsettings.warperNeeded)
-                    {
-                        stationWindow.OnWarperNecessaryClick(0);
-                    }
-                    if (packet.settingIndex == StationUI.UIsettings.includeCollectors)
+                    stationWindow.OnMaxChargePowerSliderValueChange(packet.SettingValue);
+                }
+                if (packet.SettingIndex == StationUI.EUISettings.MaxTripDrones)
+                {
+                    stationWindow.OnMaxTripDroneSliderValueChange(packet.SettingValue);
+                }
+                if (packet.SettingIndex == StationUI.EUISettings.MaxTripVessel)
+                {
+                    stationWindow.OnMaxTripVesselSliderValueChange(packet.SettingValue);
+                }
+                if (packet.SettingIndex == StationUI.EUISettings.MinDeliverDrone)
+                {
+                    stationWindow.OnMinDeliverDroneValueChange(packet.SettingValue);
+                }
+                if (packet.SettingIndex == StationUI.EUISettings.MinDeliverVessel)
+                {
+                    stationWindow.OnMinDeliverVesselValueChange(packet.SettingValue);
+                }
+                if (packet.SettingIndex == StationUI.EUISettings.WarpDistance)
+                {
+                    stationWindow.OnWarperDistanceValueChange(packet.SettingValue);
+                }
+                if (packet.SettingIndex == StationUI.EUISettings.WarperNeeded)
+                {
+                    stationWindow.OnWarperNecessaryClick(0);
+                }
+                if (packet.SettingIndex == StationUI.EUISettings.IncludeCollectors)
+                {
+                    Type[] args = new Type[1];
+                    object[] values = new object[1];
+                    args[0] = typeof(int);
+                    values[0] = 0;
+                    AccessTools.Method(typeof(UIStationWindow), "OnIncludeOrbitCollectorClick", args).Invoke(stationWindow, values);
+                }
+                if (packet.SettingIndex >= StationUI.EUISettings.SetDroneCount && packet.SettingIndex <= StationUI.EUISettings.SetWarperCount)
+                {
+                    if (packet.SettingIndex == StationUI.EUISettings.SetDroneCount)
                     {
                         Type[] args = new Type[1];
                         object[] values = new object[1];
                         args[0] = typeof(int);
                         values[0] = 0;
-                        AccessTools.Method(typeof(UIStationWindow), "OnIncludeOrbitCollectorClick", args).Invoke(stationWindow, values);
+                        if (UIRequestedShipDronWarpChange)
+                        {
+                            AccessTools.Method(typeof(UIStationWindow), "OnDroneIconClick", args).Invoke(stationWindow, values);
+                            UIRequestedShipDronWarpChange = false;
+                        }
+                        stationComponent.idleDroneCount = (int)packet.SettingValue;
                     }
-                    if (packet.settingIndex >= StationUI.UIsettings.setDroneCount && packet.settingIndex <= StationUI.UIsettings.setWarperCount)
+                    if (packet.SettingIndex == StationUI.EUISettings.SetShipCount)
                     {
-                        StationComponent[] stationPool = pData.factory.transport.stationPool;
-                        if (packet.settingIndex == StationUI.UIsettings.setDroneCount)
+                        Type[] args = new Type[1];
+                        object[] values = new object[1];
+                        args[0] = typeof(int);
+                        values[0] = 0;
+                        if (UIRequestedShipDronWarpChange)
                         {
-                            Type[] args = new Type[1];
-                            object[] values = new object[1];
-                            args[0] = typeof(int);
-                            values[0] = 0;
-                            if (UIRequestedShipDronWarpChange)
-                            {
-                                AccessTools.Method(typeof(UIStationWindow), "OnDroneIconClick", args).Invoke(stationWindow, values);
-                                UIRequestedShipDronWarpChange = false;
-                            }
-                            stationPool[_stationId].idleDroneCount = (int)packet.settingValue;
+                            AccessTools.Method(typeof(UIStationWindow), "OnShipIconClick", args).Invoke(stationWindow, values);
+                            UIRequestedShipDronWarpChange = false;
                         }
-                        if (packet.settingIndex == StationUI.UIsettings.setShipCount)
-                        {
-                            Type[] args = new Type[1];
-                            object[] values = new object[1];
-                            args[0] = typeof(int);
-                            values[0] = 0;
-                            if (UIRequestedShipDronWarpChange)
-                            {
-                                AccessTools.Method(typeof(UIStationWindow), "OnShipIconClick", args).Invoke(stationWindow, values);
-                                UIRequestedShipDronWarpChange = false;
-                            }
-                            stationPool[_stationId].idleShipCount = (int)packet.settingValue;
-                        }
-                        if (packet.settingIndex == StationUI.UIsettings.setWarperCount)
-                        {
-                            Type[] args = new Type[1];
-                            object[] values = new object[1];
-                            args[0] = typeof(int);
-                            values[0] = 0;
-                            if (UIRequestedShipDronWarpChange)
-                            {
-                                AccessTools.Method(typeof(UIStationWindow), "OnWarperIconClick", args).Invoke(stationWindow, values);
-                                UIRequestedShipDronWarpChange = false;
-                            }
-                            stationPool[_stationId].warperCount = (int)packet.settingValue;
-                        }
+                        stationComponent.idleShipCount = (int)packet.SettingValue;
                     }
-                    /*
-                     * the idea is that clients request that they want to apply a change and do so once the server responded with an okay.
-                     * the calls to OnItemIconMouseDown() and OnItemIconMouseUp() are blocked for clients and called only from here.
-                     */
-                    if (packet.settingIndex == StationUI.UIsettings.addOrRemoveItemFromStorageReq)
+                    if (packet.SettingIndex == StationUI.EUISettings.SetWarperCount)
                     {
-                        StationComponent[] stationPool = pData.factory.transport.stationPool;
-                        if (stationPool[_stationId].storage != null)
+                        Type[] args = new Type[1];
+                        object[] values = new object[1];
+                        args[0] = typeof(int);
+                        values[0] = 0;
+                        if (UIRequestedShipDronWarpChange)
                         {
-                            if (packet.shouldMimick)
-                            {
-                                BaseEventData mouseEvent = lastMouseEvent;
-                                UIStationStorage[] storageUIs = (UIStationStorage[])AccessTools.Field(typeof(UIStationWindow), "storageUIs").GetValue(stationWindow);
+                            AccessTools.Method(typeof(UIStationWindow), "OnWarperIconClick", args).Invoke(stationWindow, values);
+                            UIRequestedShipDronWarpChange = false;
+                        }
+                        stationComponent.warperCount = (int)packet.SettingValue;
+                    }
+                }
+                /*
+                 * the idea is that clients request that they want to apply a change and do so once the server responded with an okay.
+                 * the calls to OnItemIconMouseDown() and OnItemIconMouseUp() are blocked for clients and called only from here.
+                 */
+                if (packet.SettingIndex == StationUI.EUISettings.AddOrRemoveItemFromStorageRequest)
+                {
+                    if (stationComponent.storage != null)
+                    {
+                        if (packet.ShouldMimic)
+                        {
+                            BaseEventData mouseEvent = LastMouseEvent;
+                            UIStationStorage[] storageUIs = (UIStationStorage[])AccessTools.Field(typeof(UIStationWindow), "storageUIs").GetValue(stationWindow);
 
-                                if (lastMouseEvent != null)
+                            if (LastMouseEvent != null)
+                            {
+                                // TODO: change this such that only server sends the response, else clients with a desynced state could change servers storage to a faulty value
+                                // issue #249
+                                if (LastMouseEventWasDown)
                                 {
-                                    // TODO: change this such that only server sends the response, else clients with a desynced state could change servers storage to a faulty value
-                                    // issue #249
-                                    if (lastMouseEventWasDown)
-                                    {
-                                        storageUIs[packet.storageIdx].OnItemIconMouseDown(mouseEvent);
-                                        StationUI packet2 = new StationUI(packet.stationGId, packet.planetId, packet.storageIdx, StationUI.UIsettings.addOrRemoveItemFromStorageResp, packet.itemId, stationPool[_stationId].storage[packet.storageIdx].count, packet.isStellar);
-                                        LocalPlayer.SendPacket(packet2);
-                                    }
-                                    else
-                                    {
-                                        storageUIs[packet.storageIdx].OnItemIconMouseUp(mouseEvent);
-                                        StationUI packet2 = new StationUI(packet.stationGId, packet.planetId, packet.storageIdx, StationUI.UIsettings.addOrRemoveItemFromStorageResp, packet.itemId, stationPool[_stationId].storage[packet.storageIdx].count, packet.isStellar);
-                                        LocalPlayer.SendPacket(packet2);
-                                    }
-                                    lastMouseEvent = null;
+                                    storageUIs[packet.StorageIdx].OnItemIconMouseDown(mouseEvent);
+                                    StationUI packet2 = new StationUI(packet.PlanetId, packet.StationId, packet.StationGId, packet.StorageIdx, StationUI.EUISettings.AddOrRemoveItemFromStorageResponse, packet.ItemId, stationComponent.storage[packet.StorageIdx].count);
+                                    LocalPlayer.SendPacket(packet2);
                                 }
+                                else
+                                {
+                                    storageUIs[packet.StorageIdx].OnItemIconMouseUp(mouseEvent);
+                                    StationUI packet2 = new StationUI(packet.PlanetId, packet.StationId, packet.StationGId, packet.StorageIdx, StationUI.EUISettings.AddOrRemoveItemFromStorageResponse, packet.ItemId, stationComponent.storage[packet.StorageIdx].count);
+                                    LocalPlayer.SendPacket(packet2);
+                                }
+                                LastMouseEvent = null;
                             }
                         }
                     }
-                    if (packet.settingIndex == StationUI.UIsettings.addOrRemoveItemFromStorageResp)
+                }
+                if (packet.SettingIndex == StationUI.EUISettings.AddOrRemoveItemFromStorageResponse)
+                {
+                    if (stationComponent.storage != null)
                     {
-                        StationComponent[] stationPool = pData.factory.transport.stationPool;
-                        if (stationPool[_stationId].storage != null)
-                        {
-                            stationPool[_stationId].storage[packet.storageIdx].count = (int)packet.settingValue;
-                        }
+                        stationComponent.storage[packet.StorageIdx].count = (int)packet.SettingValue;
                     }
                 }
             }
@@ -424,55 +419,26 @@ namespace NebulaWorld.Logistics
 
         private static void UpdateStorageUI(StationUI packet)
         {
-            PlanetData pData = GameMain.galaxy.PlanetById(packet.planetId);
-            if (pData == null)
+            StationComponent stationComponent = null;
+            PlanetData planet = GameMain.galaxy?.PlanetById(packet.PlanetId);
+            
+            // If we can't find planet or the factory for said planet, we can just skip this
+            if (planet?.factory?.transport == null) return;
+            
+            StationComponent[] gStationPool = GameMain.data.galacticTransport.stationPool;
+            StationComponent[] stationPool = planet?.factory?.transport?.stationPool;
+            
+            stationComponent = packet.StationGId > 0 ? gStationPool[packet.StationGId] : stationPool?[packet.StationId];
+            
+            if (stationComponent == null)
             {
-                // this should never happen
+                Log.Error($"UpdateStorageUI: Unable to find requested station on planet {packet.PlanetId} with id {packet.StationId} and gid of {packet.StationGId}");
                 return;
             }
-            if (pData.factory == null && !LocalPlayer.IsMasterClient)
+            
+            using (ILSShipManager.PatchLockILS.On())
             {
-                // in this case client will receive the settings once he arrives at the planet and receives the PlanetFactory
-            }
-            else
-            {
-                /*
-                 * we need to find the stations id in the PlanetTransport structure to call SetStationStorage
-                 */
-                int id = -1;
-                if(pData.factory?.transport == null)
-                {
-                    return;
-                }
-                if((!packet.isStellar && packet.stationGId >= pData.factory.transport.stationPool.Length) || pData.factory.transport == null)
-                {
-                    return;
-                }
-                else if (packet.isStellar)
-                {
-                    foreach(StationComponent stationComponent in pData.factory.transport.stationPool)
-                    {
-                        if(stationComponent != null && stationComponent.gid == packet.stationGId)
-                        {
-                            id = stationComponent.id;
-                        }
-                    }
-                }
-                else
-                {
-                    // if its a PLS server sends the id and not GId
-                    id = pData.factory.transport.stationPool[packet.stationGId].id;
-                }
-
-                if(id == -1)
-                {
-                    return;
-                }
-
-                using (ILSShipManager.PatchLockILS.On())
-                {
-                    pData.factory.transport.SetStationStorage(id, packet.storageIdx, packet.itemId, packet.itemCountMax, packet.localLogic, packet.remoteLogic, null);
-                }
+                planet.factory.transport.SetStationStorage(stationComponent.id, packet.StorageIdx, packet.ItemId, packet.ItemCountMax, packet.LocalLogic, packet.RemoteLogic, null);
             }
         }
     }


### PR DESCRIPTION
Updating PLS's wasn't working because a lot of checks were being made on GalacticTransport.stationPool.Length even when sending data about a non-stellar station. Instead of trying to force in fixes for those specific cases I did some refactoring of the UIStationWindow and UIStationStorage functionality.

- Subscriptions to Station updates are now based on planetId, stationId and stationGid to make sure subscriptions work on both ILS and PLS stations.
- With the subscription change packets also send planetId, stationId and stationGid along with their changes.
- Refactored UIStation packets to follow .editorconfig.
- Changed processors and logic that follows processors to resolve which station were making changes to based on planetId, stationId and stationGid.
- Removed a lot of reduntant Null checks by doing more checks further up in StationUIManager's UpdateSettingsUI and UpdateSettingsUIBackground methods.