### PR TITLE
When a fake ILS station is created through ILSShipManager we create them with ShipRenderers...

### DIFF
--- a/NebulaClient/PacketProcessors/Logistics/ILSgStationPoolSyncProcessor.cs
+++ b/NebulaClient/PacketProcessors/Logistics/ILSgStationPoolSyncProcessor.cs
@@ -36,6 +36,8 @@ namespace NebulaClient.PacketProcessors.Logistics
                 gStationPool[packet.stationGId[i]].idleShipCount = packet.idleShipCount[i];
                 gStationPool[packet.stationGId[i]].workShipIndices = packet.workShipIndices[i];
                 gStationPool[packet.stationGId[i]].idleShipIndices = packet.idleShipIndices[i];
+                gStationPool[packet.stationGId[i]].shipRenderers = new ShipRenderingData[ILSShipManager.ILSMaxShipCount];
+                gStationPool[packet.stationGId[i]].shipUIRenderers = new ShipUIRenderingData[ILSShipManager.ILSMaxShipCount];
 
                 gStationPool[packet.stationGId[i]].shipDiskPos = new Vector3[ILSShipManager.ILSMaxShipCount];
                 gStationPool[packet.stationGId[i]].shipDiskRot = new Quaternion[ILSShipManager.ILSMaxShipCount];


### PR DESCRIPTION
... and UIShipRenderers, this was not being done on ILS's that are created on initial StationPoolSync causing errors and non-functional renderers for clients, when LogisticShipRenderer::Update gets called on the station.