### PR TITLE
Bug Fix: Parallel belt building

### DIFF
--- a/NebulaClient/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
@@ -78,12 +78,14 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                 if (packet.AuthorId == LocalPlayer.PlayerId)
                 {
                     pab.AfterPrebuild();
+                } else
+                {
+                    pab.buildPreviews = tmpList;
                 }
 
                 //Revert changes back
                 AccessTools.Field(typeof(PlayerAction_Build), "planetPhysics").SetValue(GameMain.mainPlayer.controller.actionBuild, tmpPlanetPhysics);
                 AccessTools.Field(typeof(PlayerAction_Build), "factory").SetValue(GameMain.mainPlayer.controller.actionBuild, tmpFactory);
-                pab.buildPreviews = tmpList;
                 pab.waitConfirm = tmpConfirm;
                 pab.previewPose.position = tmpPos;
                 pab.previewPose.rotation = tmpRot;

--- a/NebulaHost/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
@@ -6,6 +6,7 @@ using NebulaModel.Packets.Factory;
 using NebulaModel.Packets.Processors;
 using NebulaWorld.Factory;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace NebulaHost.PacketProcessors.Factory.Entity
 {
@@ -88,6 +89,7 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                     if (canBuild)
                     {
                         FactoryManager.PacketAuthor = packet.AuthorId;
+                        CheckAndFixConnections(pab, planet);
                         pab.CreatePrebuilds();
                         FactoryManager.PacketAuthor = -1;
                     }
@@ -106,20 +108,55 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                     GameMain.mainPlayer.mecha.buildArea = tmpBuildArea;
                     FactoryManager.EventFactory = null;
                 }
-                
+
                 pab.buildPreviews = tmpList;
                 pab.waitConfirm = tmpConfirm;
-                pab.previewPose.position = tmpPos; 
+                pab.previewPose.position = tmpPos;
                 pab.previewPose.rotation = tmpRot;
 
                 FactoryManager.TargetPlanet = -2;
             }
         }
 
+        public void CheckAndFixConnections(PlayerAction_Build pab, PlanetData planet)
+        {
+            //Check and fix references to prebuilds
+            Vector3 tmpVector = Vector3.zero;
+            foreach (BuildPreview preview in pab.buildPreviews)
+            {
+                //Check only, if buildPreview has some connection to another prebuild
+                if (preview.coverObjId < 0)
+                {
+                    tmpVector = pab.previewPose.position + pab.previewPose.rotation * preview.lpos;
+                    if (planet.factory.prebuildPool[-preview.coverObjId].id != 0)
+                    {
+                        //Prebuild exists, check if it is same prebuild that client wants by comparing prebuild positions
+                        if (tmpVector == planet.factory.prebuildPool[-preview.coverObjId].pos)
+                        {
+                            //Position of prebuilds are same, everything is OK.
+                            continue;
+                        }
+                    }
+                    // Prebuild does not exists, check what is the new ID of the finished building that was constructed from prebuild
+                    // or
+                    // Positions of prebuilds are different, which means this is different prebuild and we need to find ID of contructed building
+                    foreach (EntityData entity in planet.factory.entityPool)
+                    {
+                        // `entity.pos == tmpVector` does not work in every cases (rounding errors?).
+                        if ((entity.pos - tmpVector).sqrMagnitude < 0.1f)
+                        {
+                            preview.coverObjId = entity.id;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
         public bool CheckBuildingConnections(List<BuildPreview> buildPreviews, EntityData[] entityPool, PrebuildData[] prebuildPool)
         {
             //Check if some entity that is suppose to be connected to this building is missing
-            for(int i = 0; i < buildPreviews.Count; i++)
+            for (int i = 0; i < buildPreviews.Count; i++)
             {
                 var buildPreview = buildPreviews[i];
                 int inputObjId = buildPreview.inputObjId;


### PR DESCRIPTION
# Issue
So the issue is following:
Client with high ping starts drawing belts and selects some prebuild (`id = -2`) as a starting point.
When host receives the build request, one of the 3 situations can happen:
1. The starting point prebuild was not built yet and no issues happen.
2. Prebuild (`id = -2`) was already built and does not exist, which results in the connection from starting point will not be created.
   - Gif of the issue, when a client has ping 2000.
![output](https://user-images.githubusercontent.com/79051050/116820340-cb484800-ab74-11eb-9677-01f167337a5c.gif)

3. Prebuild (`id = -2`) was already built, and the host builds another prebuild that has the same `id = -2`. In this case, the starting point of the belt will be created from the host's new prebuild `id=-2` , which is not same as the client's intended prebuild `id=-2`. And this happens:
![image](https://user-images.githubusercontent.com/79051050/116820392-1f532c80-ab75-11eb-9c19-76d23b6bcb13.png)


# Solution

1. When a host receives a request to build any `BuildPreview` that has some "connection" to another prebuild, there is executed check on it.
2. Host will check if prebuild with target `id` exists, if it does not exist, it means that it was already built and it will look for a new ID that represents the constructed entity.
3. If prebuild with target `id` exists, there is a check, if it is the same prebuild as the client's prebuild by comparing the positions. If the position is not the same, it will again look for a new ID that represents the constructed prebuild.
