### PR TITLE
Bug Fix: Build preview sometimes does not disappear from the clients.

### DIFF
--- a/NebulaClient/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/CreatePrebuildsRequestProcessor.cs
@@ -78,9 +78,6 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                 if (packet.AuthorId == LocalPlayer.PlayerId)
                 {
                     pab.AfterPrebuild();
-                } else
-                {
-                    pab.buildPreviews = tmpList;
                 }
 
                 //Revert changes back
@@ -89,6 +86,7 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                 pab.waitConfirm = tmpConfirm;
                 pab.previewPose.position = tmpPos;
                 pab.previewPose.rotation = tmpRot;
+                pab.buildPreviews = tmpList;
 
                 FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
             }


### PR DESCRIPTION
I am not sure why, but in the last PR #272 I have introduced a bug, that sometimes caused that BuildPreview was not removed.

This small change will fix it.