### PR TITLE
Bug Fix: Prebuilds cannot be build, when host loads game from file

### DIFF
--- a/NebulaWorld/Factory/FactoryManager.cs
+++ b/NebulaWorld/Factory/FactoryManager.cs
@@ -4,6 +4,7 @@ using NebulaModel.Logger;
 using NebulaModel.Packets.Factory.Inserter;
 using System.Collections.Generic;
 using UnityEngine;
+using System.Linq;
 
 namespace NebulaWorld.Factory
 {
@@ -41,16 +42,15 @@ namespace NebulaWorld.Factory
             {
                 using (GetPrebuildRequests(out var prebuildRequests))
                 {
-                    for (int i = 0; i < GameMain.data.factoryCount; i++)
-                    {
-                        PlanetFactory factory = GameMain.data.factories[i];
+                    foreach (PlanetFactory factory in GameMain.data.factories)
+                    { 
                         if (factory != null)
                         {
-                            for (int j = 0; j < factory.prebuildPool.Length; j++)
+                            foreach (PrebuildData prebuild in factory.prebuildPool)
                             {
-                                if (factory.prebuildPool[j].id != 0)
+                                if (prebuild.id != 0)
                                 {
-                                    prebuildRequests[new PrebuildOwnerKey(factory.planetId, factory.prebuildPool[j].id)] = LocalPlayer.PlayerId;
+                                    prebuildRequests[new PrebuildOwnerKey(factory.planetId, prebuild.id)] = LocalPlayer.PlayerId;
                                 }
                             }
                         }

--- a/NebulaWorld/Factory/FactoryManager.cs
+++ b/NebulaWorld/Factory/FactoryManager.cs
@@ -46,11 +46,11 @@ namespace NebulaWorld.Factory
                     { 
                         if (factory != null)
                         {
-                            foreach (PrebuildData prebuild in factory.prebuildPool)
+                            for(int i = 0; i < factory.prebuildCursor; i++)
                             {
-                                if (prebuild.id != 0)
+                                if (factory.prebuildPool[i].id != 0)
                                 {
-                                    prebuildRequests[new PrebuildOwnerKey(factory.planetId, prebuild.id)] = LocalPlayer.PlayerId;
+                                    prebuildRequests[new PrebuildOwnerKey(factory.planetId, factory.prebuildPool[i].id)] = LocalPlayer.PlayerId;
                                 }
                             }
                         }

--- a/NebulaWorld/Factory/FactoryManager.cs
+++ b/NebulaWorld/Factory/FactoryManager.cs
@@ -34,6 +34,31 @@ namespace NebulaWorld.Factory
             TargetPlanet = PLANET_NONE;
         }
 
+        public static void InitializePrebuildRequests()
+        {
+            //Load existing prebuilds to the dictionary so it will be ready to build
+            if (LocalPlayer.IsMasterClient)
+            {
+                using (GetPrebuildRequests(out var prebuildRequests))
+                {
+                    for (int i = 0; i < GameMain.data.factoryCount; i++)
+                    {
+                        PlanetFactory factory = GameMain.data.factories[i];
+                        if (factory != null)
+                        {
+                            for (int j = 0; j < factory.prebuildPool.Length; j++)
+                            {
+                                if (factory.prebuildPool[j].id != 0)
+                                {
+                                    prebuildRequests[new PrebuildOwnerKey(factory.planetId, factory.prebuildPool[j].id)] = LocalPlayer.PlayerId;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         public static void SetPrebuildRequest(int planetId, int prebuildId, ushort playerId)
         {
             using (GetPrebuildRequests(out var prebuildRequests))

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -396,10 +396,7 @@ namespace NebulaWorld
             }
 
             //Initialization on the host side after game is loaded
-            if (LocalPlayer.IsMasterClient)
-            {
-                FactoryManager.InitializePrebuildRequests();
-            }
+            FactoryManager.InitializePrebuildRequests();
 
             LocalPlayer.SetReady();
 

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -395,6 +395,12 @@ namespace NebulaWorld
                 LocalPlayer.Data.Mecha.TechBonuses.UpdateMech(GameMain.mainPlayer.mecha);
             }
 
+            //Initialization on the host side after game is loaded
+            if (LocalPlayer.IsMasterClient)
+            {
+                FactoryManager.InitializePrebuildRequests();
+            }
+
             LocalPlayer.SetReady();
 
             IsGameLoaded = true;


### PR DESCRIPTION
This is a bug fix for #280 .

# Issue
Issue is, that host is checking if existing `PrebuildRequest` exists when `BuildFinally()` is called:
```cs
if (!FactoryManager.ContainsPrebuildRequest(__instance.planetId, prebuildId))
{
Log.Warn($"BuildFinally was called without having a corresponding PrebuildRequest for the prebuild {prebuildId} on the planet {__instance.planetId}");
return false;
}
```

When host loads game from file, this array is empty and all saved prebuilds cannot be build, since it will not pass this check.

# Fix

I have added a method that is executed when the game is loaded and it will go through all existing `prebuilds` and add them to the `PrebuildRequest` array.