### PR TITLE
Bug Fix: Remove Vege Packet reflection back to host

### DIFF
--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -276,7 +276,10 @@ namespace NebulaWorld
                     VFEffectEmitter.Emit(vProto.MiningEffect, vData.pos, vData.rot);
                     VFAudio.Create(vProto.MiningAudio, null, vData.pos, true);
                 }
-                factory.RemoveVegeWithComponents(vData.id);
+                using (PlanetManager.EventFromServer.On())
+                {
+                    factory.RemoveVegeWithComponents(vData.id);
+                }
             }
             else // veins
             {
@@ -309,8 +312,10 @@ namespace NebulaWorld
                             VFEffectEmitter.Emit(vProto.MiningEffect, vData.pos, Maths.SphericalRotation(vData.pos, 0f));
                             VFAudio.Create(vProto.MiningAudio, null, vData.pos, true);
                         }
-
-                        factory.RemoveVeinWithComponents(vData.id);
+                        using (PlanetManager.EventFromServer.On())
+                        {
+                            factory.RemoveVeinWithComponents(vData.id);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This is a fix for the #278 

# Issue
When the vegetable is mined, the host will send a packet to the client that the vegetable is removed and the client would reflect it back to the host with incorrect data (request to remove already removed vege which resulted in `Index out of array`).

# Fix
Added scope `using (PlanetManager.EventFromServer.On())` to prevent sending packet back to host.