### PR TITLE
fix for #289

### DIFF
--- a/NebulaClient/PacketProcessors/GameHistory/GameHistoryUnlockTechProcessor.cs
+++ b/NebulaClient/PacketProcessors/GameHistory/GameHistoryUnlockTechProcessor.cs
@@ -15,9 +15,9 @@ namespace NebulaClient.PacketProcessors.GameHistory
             Log.Info($"Unlocking tech (ID: {packet.TechId})");
             using (GameDataHistoryManager.IsIncomingRequest.On())
             {
-                GameMain.history.UnlockTech(packet.TechId);
                 GameMain.mainPlayer.mecha.lab.itemPoints.Clear();
                 GameMain.history.DequeueTech();
+                GameMain.history.UnlockTech(packet.TechId);
             }
         }
     }


### PR DESCRIPTION
Changed unlockorder to first dequeue researched tech and then unlock it for the client.
This prevents dequeuing of the next item in the queue  for the non-researching players, which lead to desyncing.