### PR TITLE
fix for #276 refactor of warp animation trigger

### DIFF
--- a/NebulaClient/PacketProcessors/Players/PlayerUseWarperProcessor.cs
+++ b/NebulaClient/PacketProcessors/Players/PlayerUseWarperProcessor.cs
@@ -1,0 +1,17 @@
+﻿using NebulaModel.Attributes;
+using NebulaModel.Networking;
+using NebulaModel.Packets.Players;
+using NebulaModel.Packets.Processors;
+using NebulaWorld;
+
+namespace NebulaClient.PacketProcessors.Players
+{
+    [RegisterPacketProcessor]
+    class PlayerUseWarperProcessor: IPacketProcessor<PlayerUseWarper>
+    {
+        public void ProcessPacket(PlayerUseWarper packet, NebulaConnection conn)
+        {
+            SimulatedWorld.UpdateRemotePlayerWarpState(packet);
+        }
+    }
+}

--- a/NebulaHost/PacketProcessors/Players/PlayerUseWarperProcessor.cs
+++ b/NebulaHost/PacketProcessors/Players/PlayerUseWarperProcessor.cs
@@ -1,0 +1,30 @@
+﻿using NebulaModel.Attributes;
+using NebulaModel.Networking;
+using NebulaModel.Packets.Players;
+using NebulaModel.Packets.Processors;
+using NebulaWorld;
+
+namespace NebulaHost.PacketProcessors.Players
+{
+    [RegisterPacketProcessor]
+    class PlayerUseWarperProcessor: IPacketProcessor<PlayerUseWarper>
+    {
+        private PlayerManager playerManager;
+
+        public PlayerUseWarperProcessor()
+        {
+            playerManager = MultiplayerHostSession.Instance.PlayerManager;
+        }
+        public void ProcessPacket(PlayerUseWarper packet, NebulaConnection conn)
+        {
+            Player player = playerManager.GetPlayer(conn);
+            if (player != null)
+            {
+                packet.PlayerId = player.Id;
+                playerManager.SendPacketToOtherPlayers(packet, player);
+
+                SimulatedWorld.UpdateRemotePlayerWarpState(packet);
+            }
+        }
+    }
+}

--- a/NebulaModel/Packets/Players/PlayerUseWarper.cs
+++ b/NebulaModel/Packets/Players/PlayerUseWarper.cs
@@ -1,0 +1,13 @@
+﻿namespace NebulaModel.Packets.Players
+{
+    public class PlayerUseWarper
+    {
+        public bool WarpCommand { get; set; }
+        public ushort PlayerId { get; set; }
+        public PlayerUseWarper() { }
+        public PlayerUseWarper(bool WarpCommand)
+        {
+            this.WarpCommand = WarpCommand;
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Transpilers/PlayerMove_Sail_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/PlayerMove_Sail_Transpiler.cs
@@ -1,0 +1,94 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using NebulaModel.Packets.Players;
+
+namespace NebulaPatcher.Patches.Transpilers
+{
+    [HarmonyPatch(typeof(PlayerMove_Sail))]
+    class PlayerMove_Sail_Transpiler
+    {
+
+        [HarmonyTranspiler]
+        [HarmonyPatch("GameTick")]
+        public static IEnumerable<CodeInstruction> GameTick_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            // c# 33 c# 69 c# 79 c# 87 this.player.warpCommand = false;
+            instructions = new CodeMatcher(instructions)
+                .MatchForward(true,
+                    new CodeMatch(OpCodes.Ldarg_0),
+                    new CodeMatch(OpCodes.Ldfld),
+                    new CodeMatch(OpCodes.Ldc_I4_0),
+                    new CodeMatch(OpCodes.Stfld),
+                    new CodeMatch(OpCodes.Ldstr))
+                .Repeat(matcher =>
+                {
+                    matcher
+                        .Advance(1)
+                        .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_I4_0)) // just to feed the delegate function
+                        .InsertAndAdvance(HarmonyLib.Transpilers.EmitDelegate<Func<int, int>>(dummy =>
+                        {
+                            // send to host / clients
+                            if (!SimulatedWorld.Initialized)
+                            {
+                                return 0;
+                            }
+
+                            if (LocalPlayer.IsMasterClient)
+                            {
+                                PlayerUseWarper packet = new PlayerUseWarper(false);
+                                packet.PlayerId = LocalPlayer.PlayerId;
+                                LocalPlayer.SendPacket(packet);
+                            }
+                            else
+                            {
+                                LocalPlayer.SendPacket(new PlayerUseWarper(false));
+                            }
+
+                            return 0;
+                        }))
+                        .Insert(new CodeInstruction(OpCodes.Pop));
+                })
+                .InstructionEnumeration();
+
+            // c# 42 this.player.warpCommand = true;
+            instructions = new CodeMatcher(instructions)
+                .MatchForward(true,
+                    new CodeMatch(OpCodes.Ldarg_0),
+                    new CodeMatch(OpCodes.Ldfld),
+                    new CodeMatch(OpCodes.Ldc_I4_1),
+                    new CodeMatch(OpCodes.Stfld),
+                    new CodeMatch(OpCodes.Ldstr))
+                .Advance(1)
+                .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_I4_1)) // just to feed the delegate function
+                .InsertAndAdvance(HarmonyLib.Transpilers.EmitDelegate<Func<int, int>>(dummy =>
+                {
+                    // send to host / clients
+                    if (!SimulatedWorld.Initialized)
+                    {
+                        return 0;
+                    }
+
+                    if (LocalPlayer.IsMasterClient)
+                    {
+                        PlayerUseWarper packet = new PlayerUseWarper(true);
+                        packet.PlayerId = LocalPlayer.PlayerId;
+                        LocalPlayer.SendPacket(packet);
+                    }
+                    else
+                    {
+                        LocalPlayer.SendPacket(new PlayerUseWarper(true));
+                    }
+
+                    return 0;
+                }))
+                .Insert(new CodeInstruction(OpCodes.Pop))
+                .InstructionEnumeration();
+
+            return instructions;
+        }
+
+    }
+}

--- a/NebulaWorld/MonoBehaviours/Remote/RemotePlayerEffects.cs
+++ b/NebulaWorld/MonoBehaviours/Remote/RemotePlayerEffects.cs
@@ -33,7 +33,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
         private float astrosMul;
         private float nebulasMul;
 
-        public float warpState = 0;
+        public float WarpState = 0;
         private bool warpEffectActivated = false;
 
         Vector4[] warpRotations;
@@ -126,7 +126,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
         {
             if (!rootAnimation.Sail.enabled || isWarping)
             {
-                return;
+                //return;
             }
 
             isWarping = true;
@@ -136,7 +136,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
         {
             if (!rootAnimation.Sail.enabled || !isWarping)
             {
-                return;
+                //return;
             }
 
             isWarping = false;
@@ -146,23 +146,23 @@ namespace NebulaWorld.MonoBehaviours.Remote
         {
             if (isWarping)
             {
-                warpState += 0.0055655558f;
-                if (warpState > 1f)
+                WarpState += 0.0055655558f;
+                if (WarpState > 1f)
                 {
-                    warpState = 1f;
+                    WarpState = 1f;
                 }
             }
             else
             {
-                warpState -= 0.06667667f;
-                if (warpState < 0f)
+                WarpState -= 0.06667667f;
+                if (WarpState < 0f)
                 {
-                    warpState = 0f;
+                    WarpState = 0f;
                 }
             }
 
             Vector4 playerRot = new Vector4(rootTransform.rotation.x, rootTransform.rotation.y, rootTransform.rotation.z, rootTransform.rotation.w);
-            if (warpState > 0.001f && !warpEffectActivated)
+            if (WarpState > 0.001f && !warpEffectActivated)
             {
                 for (int i = 0; i < warpRotations.Length; i++)
                 {
@@ -171,7 +171,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
                 VFAudio.Create("warp-begin", base.transform, Vector3.zero, true, 0);
                 toggleEffect(true);
             }
-            else if (warpState == 0 && warpEffectActivated)
+            else if (WarpState == 0 && warpEffectActivated)
             {
                 VFAudio.Create("warp-end", base.transform, Vector3.zero, true, 0);
                 toggleEffect(false);
@@ -197,8 +197,8 @@ namespace NebulaWorld.MonoBehaviours.Remote
 
             distortRenderer.GetComponent<Transform>().localRotation = rootTransform.rotation;
             nebulasRenderer.GetComponent<Transform>().localRotation = rootTransform.rotation;
-            float num1 = intensByState.Evaluate(warpState);
-            float num2 = intensByState_astro.Evaluate(warpState);
+            float num1 = intensByState.Evaluate(WarpState);
+            float num2 = intensByState_astro.Evaluate(WarpState);
             tunnelMat.SetFloat("_Multiplier", tunnelMul * num1);
             tunnelMat.SetVectorArray("_WarpRotations", warpRotations);
             distortMat.SetFloat("_DistortionStrength", distortMul * num1);
@@ -211,6 +211,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
         private RemotePlayerAnimation rootAnimation;
         private Transform rootTransform;
         private Transform rootModelTransform;
+        private RemoteWarpEffect rootWarp;
 
         private ParticleSystem[] WaterEffect;
         private ParticleSystem[][] FootSmokeEffect;
@@ -281,6 +282,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
             collider = new Collider[16];
 
             rootTransform.gameObject.AddComponent<RemoteWarpEffect>();
+            rootWarp = rootTransform.gameObject.GetComponent<RemoteWarpEffect>();
 
         }
 
@@ -292,6 +294,16 @@ namespace NebulaWorld.MonoBehaviours.Remote
                 miningAudio.Stop();
                 miningAudio = null;
             }
+        }
+
+        public void startWarp()
+        {
+            rootWarp.startWarp();
+        }
+
+        public void stopWarp()
+        {
+            rootWarp.stopWarp();
         }
 
         private void stopAllFlyAudio()

--- a/NebulaWorld/MonoBehaviours/Remote/RemotePlayerEffects.cs
+++ b/NebulaWorld/MonoBehaviours/Remote/RemotePlayerEffects.cs
@@ -126,7 +126,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
         {
             if (!rootAnimation.Sail.enabled || isWarping)
             {
-                //return;
+                return;
             }
 
             isWarping = true;
@@ -136,7 +136,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
         {
             if (!rootAnimation.Sail.enabled || !isWarping)
             {
-                //return;
+                return;
             }
 
             isWarping = false;

--- a/NebulaWorld/MonoBehaviours/Remote/RemotePlayerMovement.cs
+++ b/NebulaWorld/MonoBehaviours/Remote/RemotePlayerMovement.cs
@@ -22,7 +22,6 @@ namespace NebulaWorld.MonoBehaviours.Remote
 
         private Transform rootTransform;
         private Transform bodyTransform;
-        private RemoteWarpEffect rootWarp;
 
         public int localPlanetId;
         public VectorLF3 absolutePosition;
@@ -40,7 +39,6 @@ namespace NebulaWorld.MonoBehaviours.Remote
         {
             rootTransform = GetComponent<Transform>();
             bodyTransform = rootTransform.Find("Model");
-            rootWarp = rootTransform.GetComponent<RemoteWarpEffect>();
 
             localPlanetId = -1;
             absolutePosition = Vector3.zero;
@@ -124,21 +122,6 @@ namespace NebulaWorld.MonoBehaviours.Remote
             Vector3 currentAbsolutePosition = GetAbsolutePosition(current);
             float deltaPosition = Vector3.Distance(previousRelativePosition, currentRelativePosition);
             Vector3 velocity = (previousRelativePosition - currentRelativePosition) / (previous.Timestamp - current.Timestamp);
-
-            /*
-             * 170 is round about where vanilla warping starts, for better testing lower this to something like 30
-             * then you can trigger the warping animation by sailing at around 300
-             * when its at 170 you will probably not be able to see the effect ingame   
-             */
-            if (deltaPosition >= 170 && rootWarp != null)
-            {
-                rootWarp.startWarp();
-            }
-            else if (deltaPosition < 170 && rootWarp != null && rootWarp.warpState >= 0.9)
-            {
-                rootWarp.stopWarp();
-            }
-            rootWarp.updateVelocity(velocity);
 
             localPlanetId = current.LocalPlanetId;
 

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -105,10 +105,8 @@ namespace NebulaWorld
         {
             using (GetRemotePlayersModels(out var remotePlayersModels))
             {
-                Debug.Log("trying to add " + playerData.PlayerId);
                 if (!remotePlayersModels.ContainsKey(playerData.PlayerId))
                 {
-                    Debug.Log("added");
                     RemotePlayerModel model = new RemotePlayerModel(playerData.PlayerId, playerData.Username);
                     remotePlayersModels.Add(playerData.PlayerId, model);
                 }

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -105,8 +105,10 @@ namespace NebulaWorld
         {
             using (GetRemotePlayersModels(out var remotePlayersModels))
             {
+                Debug.Log("trying to add " + playerData.PlayerId);
                 if (!remotePlayersModels.ContainsKey(playerData.PlayerId))
                 {
+                    Debug.Log("added");
                     RemotePlayerModel model = new RemotePlayerModel(playerData.PlayerId, playerData.Username);
                     remotePlayersModels.Add(playerData.PlayerId, model);
                 }
@@ -146,6 +148,25 @@ namespace NebulaWorld
                 {
                     player.Animator.UpdateState(packet);
                     player.Effects.UpdateState(packet);
+                }
+            }
+        }
+
+        public static void UpdateRemotePlayerWarpState(PlayerUseWarper packet)
+        {
+            using (GetRemotePlayersModels(out var remotePlayersModels))
+            {
+                if(packet.PlayerId == 0) packet.PlayerId = 1; // host sends himself as PlayerId 0 but clients see him as id 1
+                if(remotePlayersModels.TryGetValue(packet.PlayerId, out RemotePlayerModel player))
+                {
+                    if (packet.WarpCommand)
+                    {
+                        player.Effects.startWarp();
+                    }
+                    else
+                    {
+                        player.Effects.stopWarp();
+                    }
                 }
             }
         }


### PR DESCRIPTION
The warp animation is no longer triggered by player movement speed (which caused #276 most likely due to the short freezes when loading a planet's factory from the server and the followed "jump").

It is now triggered by a network packet that gets send once the player truly enters/exits warping state.