### PR TITLE
Code Cleanup + Additional Debugging Functionality

### DIFF
--- a/NebulaClient/PacketProcessors/Factory/Entity/PasteBuildingSettingUpdateProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/PasteBuildingSettingUpdateProcessor.cs
@@ -4,7 +4,7 @@ using NebulaModel.Packets.Factory;
 using NebulaModel.Packets.Processors;
 using NebulaWorld.Factory;
 
-namespace NebulaClient.PacketProcessors.Factory
+namespace NebulaClient.PacketProcessors.Factory.Entity
 {
     // Processes pasting settings (e.g. item to make in an assembler) onto buildings events
     [RegisterPacketProcessor]

--- a/NebulaHost/PacketProcessors/Factory/Entity/PasteBuildingSettingUpdateProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/PasteBuildingSettingUpdateProcessor.cs
@@ -4,7 +4,7 @@ using NebulaModel.Packets.Factory;
 using NebulaModel.Packets.Processors;
 using NebulaWorld.Factory;
 
-namespace NebulaHost.PacketProcessors.Factory
+namespace NebulaHost.PacketProcessors.Factory.Entity
 {
     // Processes pasting settings (e.g. item to make in an assembler) onto buildings events
     [RegisterPacketProcessor]

--- a/NebulaPatcher/PluginInfo.cs
+++ b/NebulaPatcher/PluginInfo.cs
@@ -1,0 +1,34 @@
+﻿namespace NebulaPatcher
+{
+    /// <summary>
+    /// The main metadata of the plugin.
+    /// This information is used for BepInEx plugin metadata.
+    /// </summary>
+    /// <remarks>
+    /// See also description of BepInEx metadata:
+    /// https://bepinex.github.io/bepinex_docs/master/articles/dev_guide/plugin_tutorial/2_plugin_start.html#basic-information-about-the-plug-in
+    /// </remarks>
+    internal static class PluginInfo
+    {
+        /// <summary>
+        /// Human-readable name of the plugin. In general, it should be short and concise.
+        /// This is the name that is shown to the users who run BepInEx and to modders that inspect BepInEx logs. 
+        /// </summary>
+        public const string PLUGIN_NAME = "Nebula - Multiplayer Mod";
+
+        /// <summary>
+        /// Unique ID of the plugin.
+        /// This must be a unique string that contains only characters a-z, 0-9 underscores (_) and dots (.)
+        /// Prefer using the reverse domain name notation: https://eqdn.tech/reverse-domain-notation/
+        ///
+        /// When creating Harmony patches, prefer using this ID for Harmony instances as well.
+        /// </summary>
+        public const string PLUGIN_ID = "dsp.nebula-multiplayer";
+
+        /// <summary>
+        /// Version of the plugin. Must be in form <major>.<minor>.<build>.<revision>.
+        /// Major and minor versions are mandatory, but build and revision can be left unspecified.
+        /// </summary>
+        public const string PLUGIN_VERSION = "0.2.0.0";
+    }
+}


### PR DESCRIPTION
* Moves PasteBuildingSettingUpdateProcessor to Entity/
* Moves plugin info to its own file so that it can be changed and referenced from one central location (inline with the BepInEx.PluginTemplate https://github.com/BepInEx/BepInEx.PluginTemplate/blob/main/src/PluginInfo.cs)
* Switches to the HarmonyX CreateAndPatchAll functionality (https://github.com/BepInEx/HarmonyX/wiki/Patching-with-Harmony#creating-an-instance-and-patching-methods)
* Dumps transpiled dlls when both the user is running a debug version of the mod **and** the user has a "mmdump" folder in their game directory.