### PR TITLE
Refactor UpgradeEntityRequest and DestructEntityRequest

### DIFF
--- a/NebulaClient/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
@@ -11,33 +11,9 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
     {
         public void ProcessPacket(DestructEntityRequest packet, NebulaConnection conn)
         {
-            PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
-            // We only execute the code if the client has loaded the factory at least once.
-            // Else it will get it once it goes to the planet for the first time. 
-            if (planet.factory != null)
+            using(FactoryManager.EventFromServer.On())
             {
-                using (FactoryManager.EventFromServer.On())
-                {
-                    FactoryManager.PacketAuthor = packet.AuthorId;
-                    FactoryManager.TargetPlanet = packet.PlanetId;
-
-                    var pab = GameMain.mainPlayer.controller.actionBuild;
-                    if (pab != null)
-                    {
-                        // Backup current factory & set factory to request planet factory
-                        var tmpFactory = pab.factory;
-                        pab.factory = planet.factory;
-                        pab.noneTool.factory = planet.factory;
-
-                        pab.DoDismantleObject(packet.ObjId);
-
-                        // Restore factory
-                        pab.factory = tmpFactory;
-                        pab.noneTool.factory = tmpFactory;
-                    }
-                    FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
-                    FactoryManager.PacketAuthor = -1;
-                }
+                DestructEntityRequestManager.DestructEntityRequest(packet);
             }
         }
     }

--- a/NebulaClient/PacketProcessors/Factory/Entity/UpgradeEntityRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/UpgradeEntityRequestProcessor.cs
@@ -11,35 +11,9 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
     {
         public void ProcessPacket(UpgradeEntityRequest packet, NebulaConnection conn)
         {
-            PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
-
-            // We only execute the code if the client has loaded the factory at least once.
-            // Else he will get it once it goes to the planet for the first time. 
-            if (planet.factory != null)
+            using(FactoryManager.EventFromServer.On())
             {
-                using (FactoryManager.EventFromServer.On())
-                {
-                    if (packet.PlanetId != GameMain.localPlanet?.id)
-                    {
-                        planet.physics = new PlanetPhysics(planet);
-                        planet.physics.Init();
-                        planet.audio = new PlanetAudio(planet);
-                        planet.audio.Init();
-                    }
-
-                    ItemProto itemProto = LDB.items.Select(packet.UpgradeProtoId);
-                    FactoryManager.TargetPlanet = packet.PlanetId;
-                    planet.factory.UpgradeFinally(GameMain.mainPlayer, packet.ObjId, itemProto);
-                    FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
-
-                    if (packet.PlanetId != GameMain.localPlanet?.id)
-                    {
-                        planet.physics.Free();
-                        planet.physics = null;
-                        planet.audio.Free();
-                        planet.audio = null;
-                    }
-                }
+                UpgradeEntityRequestManager.UpgradeEntityRequest(packet);
             }
         }
     }

--- a/NebulaHost/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/DestructEntityRequestProcessor.cs
@@ -11,39 +11,9 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
     {
         public void ProcessPacket(DestructEntityRequest packet, NebulaConnection conn)
         {
-            using (FactoryManager.EventFromClient.On())
+            using(FactoryManager.EventFromClient.On())
             {
-                PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
-                FactoryManager.PacketAuthor = packet.AuthorId;
-                FactoryManager.TargetPlanet = packet.PlanetId;
-                if (packet.PlanetId != GameMain.mainPlayer.planetId)
-                {
-                    //Creating rendering batches is required to properly handle DestructFinally for the belts, since model needs to be changed.
-                    //ToDo: Optimize it somehow, since creating and destroying rendering batches is not optimal.
-                    planet.factory.cargoTraffic.CreateRenderingBatches();
-                }
-
-                var pab = GameMain.mainPlayer.controller.actionBuild;
-                if (pab != null)
-                {
-                    // Backup current factory & set factory to request planet factory
-                    var tmpFactory = pab.factory;
-                    pab.factory = planet.factory;
-                    pab.noneTool.factory = planet.factory;
-
-                    pab.DoDismantleObject(packet.ObjId);
-
-                    // Restore factory
-                    pab.factory = tmpFactory;
-                    pab.noneTool.factory = tmpFactory;
-                }
-
-                if (packet.PlanetId != GameMain.mainPlayer.planetId)
-                {
-                    planet.factory.cargoTraffic.DestroyRenderingBatches();
-                }
-                FactoryManager.PacketAuthor = -1;
-                FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
+                DestructEntityRequestManager.DestructEntityRequest(packet);
             }
         }
     }

--- a/NebulaHost/PacketProcessors/Factory/Entity/UpgradeEntityRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/UpgradeEntityRequestProcessor.cs
@@ -13,29 +13,7 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
         {
             using (FactoryManager.EventFromClient.On())
             {
-                PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
-
-                // Physics could be null, if the host is not on the requested planet
-                if (packet.PlanetId != GameMain.localPlanet?.id)
-                {
-                    planet.physics = new PlanetPhysics(planet);
-                    planet.physics.Init();
-                    planet.audio = new PlanetAudio(planet);
-                    planet.audio.Init();
-                }
-
-                ItemProto itemProto = LDB.items.Select(packet.UpgradeProtoId);
-                FactoryManager.TargetPlanet = packet.PlanetId;
-                planet.factory.UpgradeFinally(GameMain.mainPlayer, packet.ObjId, itemProto);
-                FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
-
-                if (packet.PlanetId != GameMain.localPlanet?.id)
-                {
-                    planet.physics.Free();
-                    planet.physics = null;
-                    planet.audio.Free();
-                    planet.audio = null;
-                }
+                UpgradeEntityRequestManager.UpgradeEntityRequest(packet);
             }
         }
     }

--- a/NebulaModel/Packets/Factory/DestructEntityRequest.cs
+++ b/NebulaModel/Packets/Factory/DestructEntityRequest.cs
@@ -4,14 +4,16 @@
     {
         public int PlanetId { get; set; }
         public int ObjId { get; set; }
+        public int ProtoId { get; set; }
         public int AuthorId { get; set; }
 
         public DestructEntityRequest() { }
-        public DestructEntityRequest(int planetId, int objId, int authorId)
+        public DestructEntityRequest(int planetId, int objId, int protoId, int authorId)
         {
             AuthorId = authorId;
             PlanetId = planetId;
             ObjId = objId;
+            ProtoId = protoId;
         }
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
@@ -83,6 +83,11 @@ namespace NebulaPatcher.Patches.Dynamic
                 FactoryManager.RemovePrebuildRequest(__instance.planetId, -objId);
             }
 
+            if (LocalPlayer.IsMasterClient || !FactoryManager.EventFromServer)
+            {
+                LocalPlayer.SendPacket(new DestructEntityRequest(__instance.planetId, objId, protoId, FactoryManager.PacketAuthor == -1 ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor));
+            }
+
             return LocalPlayer.IsMasterClient || FactoryManager.EventFromServer;
         }
 

--- a/NebulaPatcher/Patches/Dynamic/PlayerAction_Build_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlayerAction_Build_Patch.cs
@@ -12,10 +12,16 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPatch(nameof(PlayerAction_Build.SetFactoryReferences))]
         public static bool SetFactoryReferences_Prefix()
         {
+            if(!SimulatedWorld.Initialized)
+            {
+                return true;
+            }
+
             if((FactoryManager.EventFromServer || FactoryManager.EventFromClient) && FactoryManager.PacketAuthor != LocalPlayer.PlayerId && FactoryManager.TargetPlanet != GameMain.localPlanet?.id)
             {
                 return false;
             }
+
             return true;
         }
     }

--- a/NebulaPatcher/Patches/Dynamic/PlayerAction_Build_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlayerAction_Build_Patch.cs
@@ -9,29 +9,10 @@ namespace NebulaPatcher.Patches.Dynamic
     class PlayerAction_Build_Patch
     {
         [HarmonyPrefix]
-        [HarmonyPatch("DoDismantleObject")]
-        public static bool DoDismantleObject_Prefix(PlayerAction_Build __instance, int objId)
-        {
-            if (!SimulatedWorld.Initialized)
-                return true;
-
-            // Make sure these are being set
-            __instance.SetFactoryReferences();
-            __instance.SetToolsFactoryReferences();
-
-            if (LocalPlayer.IsMasterClient || !FactoryManager.EventFromServer)
-            {
-                LocalPlayer.SendPacket(new DestructEntityRequest(__instance.factory.planetId, objId, FactoryManager.PacketAuthor == -1 ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor));
-            }
-
-            return LocalPlayer.IsMasterClient || FactoryManager.EventFromServer;
-        }
-
-        [HarmonyPrefix]
         [HarmonyPatch(nameof(PlayerAction_Build.SetFactoryReferences))]
         public static bool SetFactoryReferences_Prefix()
         {
-            if((FactoryManager.EventFromServer || FactoryManager.EventFromClient) && FactoryManager.PacketAuthor != LocalPlayer.PlayerId)
+            if((FactoryManager.EventFromServer || FactoryManager.EventFromClient) && FactoryManager.PacketAuthor != LocalPlayer.PlayerId && FactoryManager.TargetPlanet != GameMain.localPlanet?.id)
             {
                 return false;
             }

--- a/NebulaWorld/Factory/DestructEntityRequestManager.cs
+++ b/NebulaWorld/Factory/DestructEntityRequestManager.cs
@@ -1,0 +1,48 @@
+﻿using NebulaModel.Packets.Factory;
+
+namespace NebulaWorld.Factory
+{
+    public class DestructEntityRequestManager
+    {
+        public static void DestructEntityRequest(DestructEntityRequest packet)
+        {
+            PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
+
+            // We only execute the code if the client has loaded the factory at least once.
+            // Else it will get it once it goes to the planet for the first time. 
+            if (planet.factory == null)
+            {
+                return;
+            }
+
+            // Physics could be null, if the host is not on the requested planet
+            if (packet.PlanetId != GameMain.localPlanet?.id)
+            {
+                planet.physics = new PlanetPhysics(planet);
+                planet.physics.Init();
+                planet.audio = new PlanetAudio(planet);
+                planet.audio.Init();
+
+                //Creating rendering batches is required to properly handle DestructFinally for the belts, since model needs to be changed.
+                //ToDo: Optimize it somehow, since creating and destroying rendering batches is not optimal.
+                planet.factory.cargoTraffic.CreateRenderingBatches();
+            }
+
+            FactoryManager.TargetPlanet = packet.PlanetId;
+            FactoryManager.PacketAuthor = packet.AuthorId;
+            int protoId = packet.ProtoId;
+            planet.factory.DismantleFinally(GameMain.mainPlayer, packet.ObjId, ref protoId);
+            FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
+            FactoryManager.PacketAuthor = -1;
+
+            if (packet.PlanetId != GameMain.localPlanet?.id)
+            {
+                planet.physics.Free();
+                planet.physics = null;
+                planet.audio.Free();
+                planet.audio = null;
+                planet.factory.cargoTraffic.DestroyRenderingBatches();
+            }
+        }
+    }
+}

--- a/NebulaWorld/Factory/UpgradeEntityRequestManager.cs
+++ b/NebulaWorld/Factory/UpgradeEntityRequestManager.cs
@@ -1,0 +1,41 @@
+﻿using NebulaModel.Packets.Factory;
+
+namespace NebulaWorld.Factory
+{
+    public class UpgradeEntityRequestManager
+    {
+        public static void UpgradeEntityRequest(UpgradeEntityRequest packet)
+        {
+            PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
+
+            // We only execute the code if the client has loaded the factory at least once.
+            // Else he will get it once it goes to the planet for the first time. 
+            if (planet.factory == null)
+            {
+                return;
+            }
+
+            // Physics could be null, if the host is not on the requested planet
+            if (packet.PlanetId != GameMain.localPlanet?.id)
+            {
+                planet.physics = new PlanetPhysics(planet);
+                planet.physics.Init();
+                planet.audio = new PlanetAudio(planet);
+                planet.audio.Init();
+            }
+
+            ItemProto itemProto = LDB.items.Select(packet.UpgradeProtoId);
+            FactoryManager.TargetPlanet = packet.PlanetId;
+            planet.factory.UpgradeFinally(GameMain.mainPlayer, packet.ObjId, itemProto);
+            FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
+
+            if (packet.PlanetId != GameMain.localPlanet?.id)
+            {
+                planet.physics.Free();
+                planet.physics = null;
+                planet.audio.Free();
+                planet.audio = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Use centralized managers for client & host so that changes only need to be made once.

* Change DestructEntityRequest to function the same as UpgradeEntityRequest which should fix errors that occurred when the player was transitioning to or from a planet.