### PR TITLE
fix for the Power Tower error

### DIFF
--- a/NebulaClient/PacketProcessors/Factory/PowerTower/PowerTowerUserLoadResponseProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/PowerTower/PowerTowerUserLoadResponseProcessor.cs
@@ -23,7 +23,7 @@ namespace NebulaClient.PacketProcessors.Factory.PowerTower
                     {
                         int baseDemand = factory.powerSystem.nodePool[packet.NodeId].workEnergyPerTick - factory.powerSystem.nodePool[packet.NodeId].idleEnergyPerTick;
                         float mult = factory.powerSystem.networkServes[packet.NetId];
-                        PowerTowerManager.PlayerChargeAmount = (int)(mult * (float)baseDemand);
+                        PowerTowerManager.PlayerChargeAmount += (int)(mult * (float)baseDemand);
                     }
                 }
                 else

--- a/NebulaHost/PacketProcessors/Factory/PowerTower/PowerTowerUserLoadingRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/PowerTower/PowerTowerUserLoadingRequestProcessor.cs
@@ -4,7 +4,6 @@ using NebulaModel.Packets.Factory.PowerTower;
 using NebulaModel.Packets.Processors;
 using NebulaWorld;
 using NebulaWorld.Factory;
-using UnityEngine;
 
 namespace NebulaHost.PacketProcessors.Factory.PowerTower
 {

--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -7,6 +7,7 @@ using NebulaWorld.Logistics;
 using NebulaPatcher.Patches.Transpilers;
 using UnityEngine;
 using NebulaModel.Packets.Logistics;
+using NebulaWorld.Factory;
 
 namespace NebulaPatcher.Patches.Dynamic
 {
@@ -271,6 +272,14 @@ namespace NebulaPatcher.Patches.Dynamic
             {
                 GameMain.mainPlayer.mecha.droneLogic.serving.Clear();
             }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch("Destroy")]
+        public static void Destroy_Postfix()
+        {
+            PowerTowerManager.Energy.Clear();
+            PowerTowerManager.RequestsSent.Clear();
         }
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/PowerSystem_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PowerSystem_Patch.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using NebulaModel.Packets.Factory.PowerTower;
 using NebulaWorld;
 using NebulaWorld.Factory;
 
@@ -21,6 +22,21 @@ namespace NebulaPatcher.Patches.Dynamic
                 PowerTowerManager.GivePlayerPower();
                 PowerTowerManager.UpdateAllAnimations(__instance.planet.id);
             }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("RemoveNodeComponent")]
+        public static bool RemoveNodeComponent(PowerSystem __instance, int id)
+        {
+            if (SimulatedWorld.Initialized)
+            {
+                // as the destruct is synced accross players this event is too
+                // and as such we can safely remove power demand for every player
+                PowerNodeComponent pComp = __instance.nodePool[id];
+                PowerTowerManager.RemExtraDemand(__instance.planet.id, pComp.networkId, id);
+            }
+
+            return true;
         }
     }
 }

--- a/NebulaWorld/Factory/PowerTowerManager.cs
+++ b/NebulaWorld/Factory/PowerTowerManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using NebulaModel.Logger;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace NebulaWorld.Factory
@@ -162,6 +163,7 @@ namespace NebulaWorld.Factory
                                 }
 
                                 mapping[i].Activated[j] = false;
+                                AddRequested(PlanetId, NetId, NodeId, false);
                             }
                         }
 


### PR DESCRIPTION
As the game is threaded now and the PowerTower transpiler code seemingly runs inside them, it accessed a not thread save Dictionary potentially resulting in that error.

Now using a thread save Dictionary should solve it.