### PR TITLE
Refactor loading of planet data

### DIFF
--- a/NebulaClient/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
@@ -25,30 +25,13 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                     FactoryManager.TargetPlanet = packet.PlanetId;
                     FactoryManager.PacketAuthor = packet.AuthorId;
 
-                    // Physics could be null, if the host is not on the requested planet
-                    if (packet.PlanetId != GameMain.localPlanet?.id)
-                    {
-                        planet.physics = new PlanetPhysics(planet);
-                        planet.physics.Init();
-
-                        planet.audio = new PlanetAudio(planet);
-                        planet.audio.Init();
-                    }
+                    FactoryManager.AddPlanetTimer(packet.PlanetId);
 
                     //Remove building from drone queue
                     GameMain.mainPlayer.mecha.droneLogic.serving.Remove(-packet.PrebuildId);
                     planet.factory.BuildFinally(GameMain.mainPlayer, packet.PrebuildId);
                     DroneManager.RemoveBuildRequest(-packet.PrebuildId);
 
-                    // Make sure to free the physics once the FlattenTerrain is done
-                    if (packet.PlanetId != GameMain.localPlanet?.id)
-                    {
-                        planet.physics.Free();
-                        planet.physics = null;
-
-                        planet.audio.Free();
-                        planet.audio = null;
-                    }
                     FactoryManager.PacketAuthor = -1;
                     FactoryManager.EventFactory = null;
                     FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;

--- a/NebulaClient/PacketProcessors/Factory/Foundation/FoundationBuildUpdateProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Foundation/FoundationBuildUpdateProcessor.cs
@@ -29,15 +29,9 @@ namespace NebulaClient.PacketProcessors.Factory.Foundation
                 {
                     factory.platformSystem.InitReformData();
                 }
-                if (planet.physics == null || planet.physics.colChunks == null)
-                {
-                    planet.physics = new PlanetPhysics(planet);
-                    planet.physics.Init();
-                }
-                if (planet.aux == null)
-                {
-                    planet.aux = new PlanetAuxData(planet); 
-                }
+                
+                FactoryManager.AddPlanetTimer(packet.PlanetId);
+
                 int reformPointsCount = factory.planet.aux.ReformSnap(packet.GroundTestPos.ToVector3(), packet.ReformSize, packet.ReformType, packet.ReformColor, reformPoints, packet.ReformIndices, factory.platformSystem, out reformCenterPoint);
                 factory.ComputeFlattenTerrainReform(reformPoints, reformCenterPoint, packet.Radius, reformPointsCount, 3f, 1f);
                 using (FactoryManager.EventFromServer.On())

--- a/NebulaHost/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
@@ -26,30 +26,12 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                 FactoryManager.PacketAuthor = packet.AuthorId;
                 FactoryManager.TargetPlanet = packet.PlanetId;
 
-                // Physics could be null, if the host is not on the requested planet
-                // Make sure to init all the planet data required to perform the BuildFinally of the distant planet
-                if (packet.PlanetId != GameMain.localPlanet?.id)
-                {
-                    planet.physics = new PlanetPhysics(planet);
-                    planet.physics.Init();
-
-                    planet.audio = new PlanetAudio(planet);
-                    planet.audio.Init();
-                }
+                FactoryManager.AddPlanetTimer(packet.PlanetId);
 
                 //Remove building from drone queue
                 GameMain.mainPlayer.mecha.droneLogic.serving.Remove(-packet.PrebuildId);
                 planet.factory.BuildFinally(GameMain.mainPlayer, packet.PrebuildId);
 
-                // Make sure to free all temp data if we were not on this planet once the BuildFinally is done
-                if (packet.PlanetId != GameMain.localPlanet?.id)
-                {
-                    planet.physics.Free();
-                    planet.physics = null;
-
-                    planet.audio.Free();
-                    planet.audio = null;
-                }
                 FactoryManager.EventFactory = null;
                 FactoryManager.PacketAuthor = -1;
                 FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;

--- a/NebulaHost/PacketProcessors/Factory/Foundation/FoundationBuildUpdateProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Foundation/FoundationBuildUpdateProcessor.cs
@@ -27,15 +27,7 @@ namespace NebulaHost.PacketProcessors.Factory.Foundation
                 factory.platformSystem.InitReformData();
             }
             
-            if (planet.physics == null || planet.physics.colChunks == null)
-            {
-                planet.physics = new PlanetPhysics(planet);
-                planet.physics.Init();
-            }
-            if (planet.aux == null)
-            {
-                planet.aux = new PlanetAuxData(planet);
-            }
+            FactoryManager.AddPlanetTimer(packet.PlanetId);
 
             //Perform terrain operation
             int reformPointsCount = factory.planet.aux.ReformSnap(packet.GroundTestPos.ToVector3(), packet.ReformSize, packet.ReformType, packet.ReformColor, reformPoints, packet.ReformIndices, factory.platformSystem, out reformCenterPoint);

--- a/NebulaHost/PacketProcessors/Factory/Foundation/FoundationBuildUpdateProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Foundation/FoundationBuildUpdateProcessor.cs
@@ -27,7 +27,9 @@ namespace NebulaHost.PacketProcessors.Factory.Foundation
                 factory.platformSystem.InitReformData();
             }
             
+            FactoryManager.TargetPlanet = packet.PlanetId;
             FactoryManager.AddPlanetTimer(packet.PlanetId);
+            FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
 
             //Perform terrain operation
             int reformPointsCount = factory.planet.aux.ReformSnap(packet.GroundTestPos.ToVector3(), packet.ReformSize, packet.ReformType, packet.ReformColor, reformPoints, packet.ReformIndices, factory.platformSystem, out reformCenterPoint);

--- a/NebulaWorld/Factory/BuildToolManager.cs
+++ b/NebulaWorld/Factory/BuildToolManager.cs
@@ -49,11 +49,7 @@ namespace NebulaWorld.Factory
                     tmpFactory = buildTool.factory;
                     tmpNearcdLogic = buildTool.actionBuild.nearcdLogic;
                     tmpPlanetPhysics = buildTool.actionBuild.planetPhysics;
-                    planet.physics = new PlanetPhysics(planet);
-                    planet.physics.Init();
-                    planet.aux = new PlanetAuxData(planet);
-                    planet.audio = new PlanetAudio(planet);
-                    planet.audio.Init();
+                    FactoryManager.AddPlanetTimer(packet.PlanetId);
                 }
 
                 //Create Prebuilds from incoming packet and prepare new position
@@ -109,10 +105,6 @@ namespace NebulaWorld.Factory
                     pab.noneTool.factory = tmpFactory;
                     pab.planetPhysics = tmpPlanetPhysics;
                     pab.nearcdLogic = tmpNearcdLogic;
-                    planet.physics.Free();
-                    planet.physics = null;
-                    planet.audio.Free();
-                    planet.audio = null;
                 }
 
                 GameMain.mainPlayer.mecha.buildArea = Configs.freeMode.mechaBuildArea;

--- a/NebulaWorld/Factory/DestructEntityRequestManager.cs
+++ b/NebulaWorld/Factory/DestructEntityRequestManager.cs
@@ -15,12 +15,13 @@ namespace NebulaWorld.Factory
                 return;
             }
 
-            FactoryManager.AddPlanetTimer(packet.PlanetId);
-
             FactoryManager.TargetPlanet = packet.PlanetId;
             FactoryManager.PacketAuthor = packet.AuthorId;
+
+            FactoryManager.AddPlanetTimer(packet.PlanetId);
             int protoId = packet.ProtoId;
             planet.factory.DismantleFinally(GameMain.mainPlayer, packet.ObjId, ref protoId);
+
             FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
             FactoryManager.PacketAuthor = -1;
         }

--- a/NebulaWorld/Factory/DestructEntityRequestManager.cs
+++ b/NebulaWorld/Factory/DestructEntityRequestManager.cs
@@ -15,13 +15,7 @@ namespace NebulaWorld.Factory
                 return;
             }
 
-            // Physics could be null, if the host is not on the requested planet
-            if (packet.PlanetId != GameMain.localPlanet?.id)
-            {
-                //Creating rendering batches is required to properly handle DestructFinally for the belts, since model needs to be changed.
-                //ToDo: Optimize it somehow, since creating and destroying rendering batches is not optimal.
-                planet.factory.cargoTraffic.CreateRenderingBatches();
-            }
+            FactoryManager.AddPlanetTimer(packet.PlanetId);
 
             FactoryManager.TargetPlanet = packet.PlanetId;
             FactoryManager.PacketAuthor = packet.AuthorId;
@@ -29,11 +23,6 @@ namespace NebulaWorld.Factory
             planet.factory.DismantleFinally(GameMain.mainPlayer, packet.ObjId, ref protoId);
             FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
             FactoryManager.PacketAuthor = -1;
-
-            if (packet.PlanetId != GameMain.localPlanet?.id)
-            {
-                planet.factory.cargoTraffic.DestroyRenderingBatches();
-            }
         }
     }
 }

--- a/NebulaWorld/Factory/FactoryManager.cs
+++ b/NebulaWorld/Factory/FactoryManager.cs
@@ -1,8 +1,11 @@
-﻿using HarmonyLib;
+﻿using BepInEx;
+using HarmonyLib;
 using NebulaModel.DataStructures;
 using NebulaModel.Logger;
 using NebulaModel.Packets.Factory.Inserter;
+using System;
 using System.Collections.Generic;
+using System.Timers;
 using UnityEngine;
 
 namespace NebulaWorld.Factory
@@ -11,12 +14,16 @@ namespace NebulaWorld.Factory
     {
         sealed class ThreadSafe
         {
-            internal readonly Dictionary<PrebuildOwnerKey, ushort> prebuildRequests = new Dictionary<PrebuildOwnerKey, ushort>();
+            internal readonly Dictionary<PrebuildOwnerKey, ushort> PrebuildRequests = new Dictionary<PrebuildOwnerKey, ushort>();
+            internal readonly Dictionary<int, Timer> PlanetTimers = new Dictionary<int, Timer>();
         }
         private static readonly ThreadSafe threadSafe = new ThreadSafe();
 
         static Locker GetPrebuildRequests(out Dictionary<PrebuildOwnerKey, ushort> prebuildRequests) =>
-            threadSafe.prebuildRequests.GetLocked(out prebuildRequests);
+            threadSafe.PrebuildRequests.GetLocked(out prebuildRequests);
+
+        static Locker GetPlanetTimers(out Dictionary<int, Timer> planetTimers) =>
+            threadSafe.PlanetTimers.GetLocked(out planetTimers);
 
         public static readonly ToggleSwitch EventFromServer = new ToggleSwitch();
         public static readonly ToggleSwitch EventFromClient = new ToggleSwitch();
@@ -34,6 +41,109 @@ namespace NebulaWorld.Factory
             TargetPlanet = PLANET_NONE;
         }
 
+        public static void AddPlanetTimer(int planetId)
+        {
+            using (GetPlanetTimers(out var planetTimers))
+            {
+                // We don't want to load or unload the planet we are currently on
+                if (planetId == GameMain.localPlanet?.id)
+                {
+                    return;
+                }
+
+                // .NET Framework 4.7.2 does not have TryAdd so we must make sure the dictionary does not already contain the planet
+                if (!planetTimers.ContainsKey(planetId))
+                {
+                    // We haven't loaded this planet, let's load it
+                    LoadPlanetData(planetId);
+
+                    // Create a new 10 second timer for this planet
+                    planetTimers.Add(planetId, new Timer(TimeSpan.FromSeconds(10).TotalMilliseconds));
+
+                    var planetTimer = planetTimers[planetId];
+                    planetTimer.Elapsed += (sender, e) => PlanetTimer_Elapsed(planetId);
+                    planetTimer.Start();
+                }
+                // If a timer for the planet already exists, reset it.
+                else
+                {
+                    planetTimers[planetId].Stop();
+                    planetTimers[planetId].Start();
+                }
+            }
+        }
+
+        private static void PlanetTimer_Elapsed(int planetId)
+        {
+            // Timer has finished without another event resetting it so we can unload the planet's data
+            // We must use ThreadingHelper in order to ensure this runs on the main thread, otherwise this will trigger a crash
+            ThreadingHelper.Instance.StartSyncInvoke(() => UnloadPlanetData(planetId));
+            RemovePlanetTimer(planetId);
+        }
+
+        private static bool RemovePlanetTimer(int planetId)
+        {
+            using (GetPlanetTimers(out var planetTimers))
+            {
+                planetTimers[planetId].Stop();
+                planetTimers[planetId] = null;
+                return planetTimers.Remove(planetId);
+            }
+        }
+
+        public static void LoadPlanetData(int planetId)
+        {
+            PlanetData planet = GameMain.galaxy.PlanetById(planetId);
+
+            if (planet.physics == null || planet.physics.colChunks == null)
+            {
+                planet.physics = new PlanetPhysics(planet);
+                planet.physics.Init();
+            }
+
+            if (planet.aux == null)
+            {
+                planet.aux = new PlanetAuxData(planet);
+            }
+
+            if (planet.audio == null)
+            {
+                planet.audio = new PlanetAudio(planet);
+                planet.audio.Init();
+            }
+
+            if (AccessTools.Field(typeof(CargoTraffic), "beltRenderingBatch").GetValue(planet.factory.cargoTraffic) == null ||
+                AccessTools.Field(typeof(CargoTraffic), "pathRenderingBatch").GetValue(planet.factory.cargoTraffic) == null)
+            {
+                planet.factory.cargoTraffic.CreateRenderingBatches();
+            }
+        }
+
+        public static void UnloadPlanetData(int planetId)
+        {
+            // We don't want to unload the planet that we are currently on
+            if (planetId == GameMain.localPlanet?.id)
+            {
+                return;
+            }
+
+            PlanetData planet = GameMain.galaxy.PlanetById(planetId);
+
+            if (planet.physics != null)
+            {
+                planet.physics.Free();
+                planet.physics = null;
+            }
+
+            if (planet.audio != null)
+            {
+                planet.audio.Free();
+                planet.audio = null;
+            }
+
+            planet.factory.cargoTraffic.DestroyRenderingBatches();
+        }
+
         public static void InitializePrebuildRequests()
         {
             //Load existing prebuilds to the dictionary so it will be ready to build
@@ -42,10 +152,10 @@ namespace NebulaWorld.Factory
                 using (GetPrebuildRequests(out var prebuildRequests))
                 {
                     foreach (PlanetFactory factory in GameMain.data.factories)
-                    { 
+                    {
                         if (factory != null)
                         {
-                            for(int i = 0; i < factory.prebuildCursor; i++)
+                            for (int i = 0; i < factory.prebuildCursor; i++)
                             {
                                 if (factory.prebuildPool[i].id != 0)
                                 {
@@ -120,7 +230,7 @@ namespace NebulaWorld.Factory
 
             int prebuildRecycleCursor = GetPrebuildRecycleCursor(factory);
             int[] prebuildRecycle = GetPrebuildRecycle(factory);
-            return prebuildRecycleCursor <= 0 ? factory.prebuildCursor+1 : prebuildRecycle[prebuildRecycleCursor - 1];
+            return prebuildRecycleCursor <= 0 ? factory.prebuildCursor + 1 : prebuildRecycle[prebuildRecycleCursor - 1];
         }
     }
 

--- a/NebulaWorld/Factory/FactoryManager.cs
+++ b/NebulaWorld/Factory/FactoryManager.cs
@@ -62,6 +62,7 @@ namespace NebulaWorld.Factory
 
                     var planetTimer = planetTimers[planetId];
                     planetTimer.Elapsed += (sender, e) => PlanetTimer_Elapsed(planetId);
+                    planetTimer.AutoReset = false;
                     planetTimer.Start();
                 }
                 // If a timer for the planet already exists, reset it.
@@ -75,10 +76,11 @@ namespace NebulaWorld.Factory
 
         private static void PlanetTimer_Elapsed(int planetId)
         {
+            RemovePlanetTimer(planetId);
+
             // Timer has finished without another event resetting it so we can unload the planet's data
             // We must use ThreadingHelper in order to ensure this runs on the main thread, otherwise this will trigger a crash
             ThreadingHelper.Instance.StartSyncInvoke(() => UnloadPlanetData(planetId));
-            RemovePlanetTimer(planetId);
         }
 
         private static bool RemovePlanetTimer(int planetId)
@@ -86,6 +88,7 @@ namespace NebulaWorld.Factory
             using (GetPlanetTimers(out var planetTimers))
             {
                 planetTimers[planetId].Stop();
+                planetTimers[planetId].Dispose();
                 planetTimers[planetId] = null;
                 return planetTimers.Remove(planetId);
             }

--- a/NebulaWorld/Factory/FactoryManager.cs
+++ b/NebulaWorld/Factory/FactoryManager.cs
@@ -127,6 +127,9 @@ namespace NebulaWorld.Factory
                 return;
             }
 
+            int tmpTargetPlanet = FactoryManager.TargetPlanet;
+            FactoryManager.TargetPlanet = planetId;
+
             PlanetData planet = GameMain.galaxy.PlanetById(planetId);
 
             if (planet.physics != null)
@@ -142,6 +145,8 @@ namespace NebulaWorld.Factory
             }
 
             planet.factory.cargoTraffic.DestroyRenderingBatches();
+
+            FactoryManager.TargetPlanet = tmpTargetPlanet;
         }
 
         public static void InitializePrebuildRequests()

--- a/NebulaWorld/Factory/UpgradeEntityRequestManager.cs
+++ b/NebulaWorld/Factory/UpgradeEntityRequestManager.cs
@@ -15,11 +15,12 @@ namespace NebulaWorld.Factory
                 return;
             }
 
-            FactoryManager.AddPlanetTimer(packet.PlanetId);
-
-            ItemProto itemProto = LDB.items.Select(packet.UpgradeProtoId);
             FactoryManager.TargetPlanet = packet.PlanetId;
+
+            FactoryManager.AddPlanetTimer(packet.PlanetId);
+            ItemProto itemProto = LDB.items.Select(packet.UpgradeProtoId);
             planet.factory.UpgradeFinally(GameMain.mainPlayer, packet.ObjId, itemProto);
+
             FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
         }
     }

--- a/NebulaWorld/Factory/UpgradeEntityRequestManager.cs
+++ b/NebulaWorld/Factory/UpgradeEntityRequestManager.cs
@@ -15,27 +15,12 @@ namespace NebulaWorld.Factory
                 return;
             }
 
-            // Physics could be null, if the host is not on the requested planet
-            if (packet.PlanetId != GameMain.localPlanet?.id)
-            {
-                planet.physics = new PlanetPhysics(planet);
-                planet.physics.Init();
-                planet.audio = new PlanetAudio(planet);
-                planet.audio.Init();
-            }
+            FactoryManager.AddPlanetTimer(packet.PlanetId);
 
             ItemProto itemProto = LDB.items.Select(packet.UpgradeProtoId);
             FactoryManager.TargetPlanet = packet.PlanetId;
             planet.factory.UpgradeFinally(GameMain.mainPlayer, packet.ObjId, itemProto);
             FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
-
-            if (packet.PlanetId != GameMain.localPlanet?.id)
-            {
-                planet.physics.Free();
-                planet.physics = null;
-                planet.audio.Free();
-                planet.audio = null;
-            }
         }
     }
 }


### PR DESCRIPTION
Rather than load and unload planet data (physics, audio, etc.) for every request when the host is not on the same planet that the request is coming from, let's load it once and only unload it if we have gone some time without a request.

I have set this timeout period to 10 seconds but perhaps another value would be preferred, or maybe it should be user configurable?