### PR TITLE
NameInputPacket: Fix compatibility with GS

### DIFF
--- a/NebulaClient/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
+++ b/NebulaClient/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
@@ -32,7 +32,7 @@ namespace NebulaClient.PacketProcessors.Factory.Entity
                     planet.factory.BuildFinally(GameMain.mainPlayer, packet.PrebuildId);
                     DroneManager.RemoveBuildRequest(-packet.PrebuildId);
 
-                    FactoryManager.PacketAuthor = -1;
+                    FactoryManager.PacketAuthor = FactoryManager.AUTHOR_NONE;
                     FactoryManager.EventFactory = null;
                     FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
                 }

--- a/NebulaClient/PacketProcessors/Universe/NameInputProcessor.cs
+++ b/NebulaClient/PacketProcessors/Universe/NameInputProcessor.cs
@@ -22,18 +22,17 @@ namespace NebulaClient.PacketProcessors.Universe
             }
             using (FactoryManager.EventFromServer.On())
             {
-                // If stellarId > 100 then it must be a planet
-                if (packet.StellarId > 100)
+                if (packet.StarId != -1)
                 {
-                    var planet = GameMain.galaxy.PlanetById(packet.StellarId);
-                    planet.overrideName = packet.Name;
-                    planet.NotifyOnDisplayNameChange();
+                    var star = GameMain.galaxy.StarById(packet.StarId);
+                    star.overrideName = packet.Name;
+                    star.NotifyOnDisplayNameChange();
                 }
                 else
                 {
-                    var star = GameMain.galaxy.StarById(packet.StellarId);
-                    star.overrideName = packet.Name;
-                    star.NotifyOnDisplayNameChange();
+                    var planet = GameMain.galaxy.PlanetById(packet.PlanetId);
+                    planet.overrideName = packet.Name;
+                    planet.NotifyOnDisplayNameChange();
                 }
                 GameMain.galaxy.NotifyAstroNameChange();
             }

--- a/NebulaClient/PacketProcessors/Universe/NameInputProcessor.cs
+++ b/NebulaClient/PacketProcessors/Universe/NameInputProcessor.cs
@@ -22,7 +22,7 @@ namespace NebulaClient.PacketProcessors.Universe
             }
             using (FactoryManager.EventFromServer.On())
             {
-                if (packet.StarId != -1)
+                if (packet.StarId != FactoryManager.STAR_NONE)
                 {
                     var star = GameMain.galaxy.StarById(packet.StarId);
                     star.overrideName = packet.Name;

--- a/NebulaHost/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
+++ b/NebulaHost/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
@@ -33,7 +33,7 @@ namespace NebulaHost.PacketProcessors.Factory.Entity
                 planet.factory.BuildFinally(GameMain.mainPlayer, packet.PrebuildId);
 
                 FactoryManager.EventFactory = null;
-                FactoryManager.PacketAuthor = -1;
+                FactoryManager.PacketAuthor = FactoryManager.AUTHOR_NONE;
                 FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
             }
         }

--- a/NebulaHost/PacketProcessors/Session/SyncCompleteProcessor.cs
+++ b/NebulaHost/PacketProcessors/Session/SyncCompleteProcessor.cs
@@ -46,14 +46,14 @@ namespace NebulaHost.PacketProcessors.Session
             {
                 if (!string.IsNullOrEmpty(s.overrideName))
                 {
-                    player.SendPacket(new NameInputPacket(s.overrideName, s.id, LocalPlayer.PlayerId));
+                    player.SendPacket(new NameInputPacket(s.overrideName, s.id, -1, LocalPlayer.PlayerId));
                 }
 
                 foreach (PlanetData p in s.planets)
                 {
                     if (!string.IsNullOrEmpty(p.overrideName))
                     {
-                        player.SendPacket(new NameInputPacket(p.overrideName, p.id, LocalPlayer.PlayerId));
+                        player.SendPacket(new NameInputPacket(p.overrideName, -1, p.id, LocalPlayer.PlayerId));
                     }
                 }
             }

--- a/NebulaHost/PacketProcessors/Session/SyncCompleteProcessor.cs
+++ b/NebulaHost/PacketProcessors/Session/SyncCompleteProcessor.cs
@@ -5,6 +5,7 @@ using NebulaModel.Packets.Processors;
 using NebulaModel.Packets.Session;
 using NebulaModel.Packets.Universe;
 using NebulaWorld;
+using NebulaWorld.Factory;
 
 namespace NebulaHost.PacketProcessors.Session
 {
@@ -46,14 +47,14 @@ namespace NebulaHost.PacketProcessors.Session
             {
                 if (!string.IsNullOrEmpty(s.overrideName))
                 {
-                    player.SendPacket(new NameInputPacket(s.overrideName, s.id, -1, LocalPlayer.PlayerId));
+                    player.SendPacket(new NameInputPacket(s.overrideName, s.id, FactoryManager.PLANET_NONE, LocalPlayer.PlayerId));
                 }
 
                 foreach (PlanetData p in s.planets)
                 {
                     if (!string.IsNullOrEmpty(p.overrideName))
                     {
-                        player.SendPacket(new NameInputPacket(p.overrideName, -1, p.id, LocalPlayer.PlayerId));
+                        player.SendPacket(new NameInputPacket(p.overrideName, FactoryManager.STAR_NONE, p.id, LocalPlayer.PlayerId));
                     }
                 }
             }

--- a/NebulaHost/PacketProcessors/Universe/NameInputProcessor.cs
+++ b/NebulaHost/PacketProcessors/Universe/NameInputProcessor.cs
@@ -17,7 +17,7 @@ namespace NebulaHost.PacketProcessors.Universe
         {
             using (FactoryManager.EventFromClient.On())
             {
-                if (packet.StarId != -1)
+                if (packet.StarId != FactoryManager.STAR_NONE)
                 {
                     var star = GameMain.galaxy.StarById(packet.StarId);
                     star.overrideName = packet.Name;

--- a/NebulaHost/PacketProcessors/Universe/NameInputProcessor.cs
+++ b/NebulaHost/PacketProcessors/Universe/NameInputProcessor.cs
@@ -17,18 +17,17 @@ namespace NebulaHost.PacketProcessors.Universe
         {
             using (FactoryManager.EventFromClient.On())
             {
-                // If stellarId > 100 then it must be a planet
-                if (packet.StellarId > 100)
+                if (packet.StarId != -1)
                 {
-                    var planet = GameMain.galaxy.PlanetById(packet.StellarId);
-                    planet.overrideName = packet.Name;
-                    planet.NotifyOnDisplayNameChange();
+                    var star = GameMain.galaxy.StarById(packet.StarId);
+                    star.overrideName = packet.Name;
+                    star.NotifyOnDisplayNameChange();
                 }
                 else
                 {
-                    var star = GameMain.galaxy.StarById(packet.StellarId);
-                    star.overrideName = packet.Name;
-                    star.NotifyOnDisplayNameChange();
+                    var planet = GameMain.galaxy.PlanetById(packet.PlanetId);
+                    planet.overrideName = packet.Name;
+                    planet.NotifyOnDisplayNameChange();
                 }
                 GameMain.galaxy.NotifyAstroNameChange();
 

--- a/NebulaModel/Packets/Universe/NameInputPacket.cs
+++ b/NebulaModel/Packets/Universe/NameInputPacket.cs
@@ -1,24 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace NebulaModel.Packets.Universe
+﻿namespace NebulaModel.Packets.Universe
 {
     // Packet for name input for Planets and Stars
     public class NameInputPacket
     {
         public string Name { get; set; }
-        public int StellarId { get; set; }
+        public int PlanetId { get; set; }
+        public int StarId { get; set; }
         public int AuthorId { get; set; }
 
         public NameInputPacket() { }
-        public NameInputPacket(string name, int stellarId, int authorId)
+        public NameInputPacket(string name, int starId, int planetId, int authorId)
         {
-            this.Name = name;
-            this.StellarId = stellarId;
-            this.AuthorId = authorId;
+            Name = name;
+            StarId = starId;
+            PlanetId = planetId;
+            AuthorId = authorId;
         }
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/BuildTool_Common_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/BuildTool_Common_Patch.cs
@@ -32,13 +32,13 @@ namespace NebulaPatcher.Patches.Dynamic
             if (LocalPlayer.IsMasterClient)
             {
                 int planetId = FactoryManager.EventFactory?.planetId ?? GameMain.localPlanet?.id ?? -1;
-                LocalPlayer.SendPacketToStar(new CreatePrebuildsRequest(planetId, previews, FactoryManager.PacketAuthor == -1 ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor, __instance.GetType().ToString()), GameMain.galaxy.PlanetById(planetId).star.id);
+                LocalPlayer.SendPacketToStar(new CreatePrebuildsRequest(planetId, previews, FactoryManager.PacketAuthor == FactoryManager.AUTHOR_NONE ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor, __instance.GetType().ToString()), GameMain.galaxy.PlanetById(planetId).star.id);
             }
 
             //If client builds, he need to first send request to the host and wait for reply
             if (!LocalPlayer.IsMasterClient && !FactoryManager.EventFromServer)
             {
-                LocalPlayer.SendPacket(new CreatePrebuildsRequest(GameMain.localPlanet?.id ?? -1, previews, FactoryManager.PacketAuthor == -1 ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor, __instance.GetType().ToString()));
+                LocalPlayer.SendPacket(new CreatePrebuildsRequest(GameMain.localPlanet?.id ?? -1, previews, FactoryManager.PacketAuthor == FactoryManager.AUTHOR_NONE ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor, __instance.GetType().ToString()));
                 return false;
             }
             return true;

--- a/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
@@ -50,7 +50,7 @@ namespace NebulaPatcher.Patches.Dynamic
 
             if (LocalPlayer.IsMasterClient || !FactoryManager.EventFromServer)
             {
-                LocalPlayer.SendPacket(new BuildEntityRequest(__instance.planetId, prebuildId, FactoryManager.PacketAuthor == -1 ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor));
+                LocalPlayer.SendPacket(new BuildEntityRequest(__instance.planetId, prebuildId, FactoryManager.PacketAuthor == FactoryManager.AUTHOR_NONE ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor));
             }
 
             if (!LocalPlayer.IsMasterClient && !FactoryManager.EventFromServer && !DroneManager.IsPendingBuildRequest(-prebuildId))

--- a/NebulaPatcher/Patches/Dynamic/PlayerAction_Build_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlayerAction_Build_Patch.cs
@@ -42,6 +42,7 @@ namespace NebulaPatcher.Patches.Dynamic
             return LocalPlayer.IsMasterClient || FactoryManager.EventFromServer;
         }
 
+        [HarmonyPrefix]
         [HarmonyPatch(nameof(PlayerAction_Build.SetFactoryReferences))]
         public static bool SetFactoryReferences_Prefix()
         {

--- a/NebulaPatcher/Patches/Dynamic/PlayerAction_Build_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlayerAction_Build_Patch.cs
@@ -36,7 +36,7 @@ namespace NebulaPatcher.Patches.Dynamic
 
             if (LocalPlayer.IsMasterClient || !FactoryManager.EventFromServer)
             {
-                LocalPlayer.SendPacket(new DestructEntityRequest(planetId, objId, FactoryManager.PacketAuthor == -1 ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor));
+                LocalPlayer.SendPacket(new DestructEntityRequest(planetId, objId, FactoryManager.PacketAuthor == FactoryManager.AUTHOR_NONE ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor));
             }
 
             return LocalPlayer.IsMasterClient || FactoryManager.EventFromServer;
@@ -53,7 +53,7 @@ namespace NebulaPatcher.Patches.Dynamic
 
             if (LocalPlayer.IsMasterClient || !FactoryManager.EventFromServer)
             {
-                LocalPlayer.SendPacket(new UpgradeEntityRequest(FactoryManager.TargetPlanet != FactoryManager.PLANET_NONE ? FactoryManager.TargetPlanet : __instance.planet?.id ?? -1, objId, grade, upgrade, FactoryManager.PacketAuthor == -1 ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor));
+                LocalPlayer.SendPacket(new UpgradeEntityRequest(FactoryManager.TargetPlanet != FactoryManager.PLANET_NONE ? FactoryManager.TargetPlanet : __instance.planet?.id ?? -1, objId, grade, upgrade, FactoryManager.PacketAuthor == FactoryManager.AUTHOR_NONE ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor));
             }
 
             return LocalPlayer.IsMasterClient || FactoryManager.EventFromServer;

--- a/NebulaPatcher/Patches/Dynamic/Player_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/Player_Patch.cs
@@ -12,7 +12,7 @@ namespace NebulaPatcher.Patches.Dynamic
         public static bool RemoveLayer_Prefix()
         {
             //Soil should be given in singleplayer or to the player who is author of the "Build" request, or to the host if there is no author.
-            return !SimulatedWorld.Initialized || FactoryManager.PacketAuthor == LocalPlayer.PlayerId || (LocalPlayer.IsMasterClient && FactoryManager.PacketAuthor == -1) || (!FactoryManager.EventFromServer && !FactoryManager.EventFromClient);
+            return !SimulatedWorld.Initialized || FactoryManager.PacketAuthor == LocalPlayer.PlayerId || (LocalPlayer.IsMasterClient && FactoryManager.PacketAuthor == FactoryManager.AUTHOR_NONE) || (!FactoryManager.EventFromServer && !FactoryManager.EventFromClient);
         }
 
         [HarmonyPrefix]

--- a/NebulaPatcher/Patches/Dynamic/UIPlanetDetail_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIPlanetDetail_Patch.cs
@@ -17,7 +17,7 @@ namespace NebulaPatcher.Patches.Dynamic
                 if (__instance.planet != null && !string.IsNullOrEmpty(__instance.planet.overrideName))
                 {
                     // Send packet with new planet name
-                    LocalPlayer.SendPacket(new NameInputPacket(__instance.planet.overrideName, -1, __instance.planet.id, LocalPlayer.PlayerId));
+                    LocalPlayer.SendPacket(new NameInputPacket(__instance.planet.overrideName, FactoryManager.STAR_NONE, __instance.planet.id, LocalPlayer.PlayerId));
                 }
             }
         }

--- a/NebulaPatcher/Patches/Dynamic/UIPlanetDetail_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIPlanetDetail_Patch.cs
@@ -17,7 +17,7 @@ namespace NebulaPatcher.Patches.Dynamic
                 if (__instance.planet != null && !string.IsNullOrEmpty(__instance.planet.overrideName))
                 {
                     // Send packet with new planet name
-                    LocalPlayer.SendPacket(new NameInputPacket(__instance.planet.overrideName, __instance.planet.id, LocalPlayer.PlayerId));
+                    LocalPlayer.SendPacket(new NameInputPacket(__instance.planet.overrideName, -1, __instance.planet.id, LocalPlayer.PlayerId));
                 }
             }
         }

--- a/NebulaPatcher/Patches/Dynamic/UIPlanetGlobe_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIPlanetGlobe_Patch.cs
@@ -17,12 +17,12 @@ namespace NebulaPatcher.Patches.Dynamic
                 if (GameMain.localPlanet != null && !string.IsNullOrEmpty(GameMain.localPlanet.overrideName))
                 {
                     // Send packet with new planet name
-                    LocalPlayer.SendPacket(new NameInputPacket(GameMain.localPlanet.overrideName, -1, GameMain.localPlanet.id, LocalPlayer.PlayerId));
+                    LocalPlayer.SendPacket(new NameInputPacket(GameMain.localPlanet.overrideName, FactoryManager.STAR_NONE, GameMain.localPlanet.id, LocalPlayer.PlayerId));
                 }
                 else if (GameMain.localStar != null && !string.IsNullOrEmpty(GameMain.localStar.overrideName))
                 {
                     // Send packet with new star name
-                    LocalPlayer.SendPacket(new NameInputPacket(GameMain.localStar.overrideName, GameMain.localStar.id, -1, LocalPlayer.PlayerId));
+                    LocalPlayer.SendPacket(new NameInputPacket(GameMain.localStar.overrideName, GameMain.localStar.id, FactoryManager.PLANET_NONE, LocalPlayer.PlayerId));
                 }
             }
         }

--- a/NebulaPatcher/Patches/Dynamic/UIPlanetGlobe_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIPlanetGlobe_Patch.cs
@@ -17,12 +17,12 @@ namespace NebulaPatcher.Patches.Dynamic
                 if (GameMain.localPlanet != null && !string.IsNullOrEmpty(GameMain.localPlanet.overrideName))
                 {
                     // Send packet with new planet name
-                    LocalPlayer.SendPacket(new NameInputPacket(GameMain.localPlanet.overrideName, GameMain.localPlanet.id, LocalPlayer.PlayerId));
+                    LocalPlayer.SendPacket(new NameInputPacket(GameMain.localPlanet.overrideName, -1, GameMain.localPlanet.id, LocalPlayer.PlayerId));
                 }
                 else if (GameMain.localStar != null && !string.IsNullOrEmpty(GameMain.localStar.overrideName))
                 {
                     // Send packet with new star name
-                    LocalPlayer.SendPacket(new NameInputPacket(GameMain.localStar.overrideName, GameMain.localStar.id, LocalPlayer.PlayerId));
+                    LocalPlayer.SendPacket(new NameInputPacket(GameMain.localStar.overrideName, GameMain.localStar.id, -1, LocalPlayer.PlayerId));
                 }
             }
         }

--- a/NebulaPatcher/Patches/Dynamic/UIStarDetail_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIStarDetail_Patch.cs
@@ -17,7 +17,7 @@ namespace NebulaPatcher.Patches.Dynamic
                 if (__instance.star != null && !string.IsNullOrEmpty(__instance.star.overrideName))
                 {
                     // Send packet with new star name
-                    LocalPlayer.SendPacket(new NameInputPacket(__instance.star.overrideName, __instance.star.id, LocalPlayer.PlayerId));
+                    LocalPlayer.SendPacket(new NameInputPacket(__instance.star.overrideName, __instance.star.id, -1, LocalPlayer.PlayerId));
                 }
             }
         }

--- a/NebulaPatcher/Patches/Dynamic/UIStarDetail_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIStarDetail_Patch.cs
@@ -17,7 +17,7 @@ namespace NebulaPatcher.Patches.Dynamic
                 if (__instance.star != null && !string.IsNullOrEmpty(__instance.star.overrideName))
                 {
                     // Send packet with new star name
-                    LocalPlayer.SendPacket(new NameInputPacket(__instance.star.overrideName, __instance.star.id, -1, LocalPlayer.PlayerId));
+                    LocalPlayer.SendPacket(new NameInputPacket(__instance.star.overrideName, __instance.star.id, FactoryManager.PLANET_NONE, LocalPlayer.PlayerId));
                 }
             }
         }

--- a/NebulaWorld/Factory/BuildToolManager.cs
+++ b/NebulaWorld/Factory/BuildToolManager.cs
@@ -141,7 +141,7 @@ namespace NebulaWorld.Factory
                 }
 
                 FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
-                FactoryManager.PacketAuthor = -1;
+                FactoryManager.PacketAuthor = FactoryManager.AUTHOR_NONE;
             }
         }
 

--- a/NebulaWorld/Factory/DestructEntityRequestManager.cs
+++ b/NebulaWorld/Factory/DestructEntityRequestManager.cs
@@ -28,7 +28,7 @@ namespace NebulaWorld.Factory
             pab.factory = tmpFactory;
             pab.noneTool.factory = tmpFactory;
             FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
-            FactoryManager.PacketAuthor = -1;
+            FactoryManager.PacketAuthor = FactoryManager.AUTHOR_NONE;
         }
     }
 }

--- a/NebulaWorld/Factory/FactoryManager.cs
+++ b/NebulaWorld/Factory/FactoryManager.cs
@@ -34,10 +34,12 @@ namespace NebulaWorld.Factory
         public static int PacketAuthor { get; set; }
         public static int TargetPlanet { get; set; }
         public const int PLANET_NONE = -2;
+        public const int AUTHOR_NONE = -1;
+        public const int STAR_NONE = -1;
 
         public static void Initialize()
         {
-            PacketAuthor = -1;
+            PacketAuthor = AUTHOR_NONE;
             TargetPlanet = PLANET_NONE;
         }
 


### PR DESCRIPTION
Assuming ids of over 100 are planets doesn't work when there are 1000 stars, so let's just send either a planetid or a starid so we can determine which it is