### PR TITLE
Assume all blueprint buildings require items in MP

### DIFF
--- a/NebulaModel/Packets/Factory/UpgradeEntityRequest.cs
+++ b/NebulaModel/Packets/Factory/UpgradeEntityRequest.cs
@@ -4,7 +4,6 @@
     {
         public int PlanetId { get; set; }
         public int ObjId { get; set; }
-        public int Grade { get; set; }
         public int UpgradeProtoId { get; set; }
         public int AuthorId { get; set; }
 

--- a/NebulaModel/Packets/Factory/UpgradeEntityRequest.cs
+++ b/NebulaModel/Packets/Factory/UpgradeEntityRequest.cs
@@ -9,11 +9,10 @@
         public int AuthorId { get; set; }
 
         public UpgradeEntityRequest() { }
-        public UpgradeEntityRequest(int planetId, int objId, int grade, int upgradeProtoId, int authorId)
+        public UpgradeEntityRequest(int planetId, int objId, int upgradeProtoId, int authorId)
         {
             PlanetId = planetId;
             ObjId = objId;
-            Grade = grade;
             UpgradeProtoId = upgradeProtoId;
             AuthorId = authorId;
         }

--- a/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
@@ -62,6 +62,21 @@ namespace NebulaPatcher.Patches.Dynamic
         }
 
         [HarmonyPrefix]
+        [HarmonyPatch("UpgradeFinally")]
+        public static bool UpgradeFinally_Prefix(PlanetFactory __instance, Player player, int objId, ItemProto replace_item_proto)
+        {
+            if (!SimulatedWorld.Initialized)
+                return true;
+
+            if (LocalPlayer.IsMasterClient || !FactoryManager.EventFromServer)
+            {
+                LocalPlayer.SendPacket(new UpgradeEntityRequest(__instance.planetId, objId, replace_item_proto.ID, FactoryManager.PacketAuthor == -1 ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor));
+            }
+
+            return LocalPlayer.IsMasterClient || FactoryManager.EventFromServer;
+        }
+
+        [HarmonyPrefix]
         [HarmonyPatch(nameof(PlanetFactory.GameTick))]
         public static bool InternalUpdate_Prefix()
         {

--- a/NebulaPatcher/Patches/Dynamic/PlayerAction_Build_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlayerAction_Build_Patch.cs
@@ -43,23 +43,6 @@ namespace NebulaPatcher.Patches.Dynamic
         }
 
         [HarmonyPrefix]
-        [HarmonyPatch(nameof(PlayerAction_Build.DoUpgradeObject))]
-        public static bool DoUpgradeObject_Prefix(PlayerAction_Build __instance, int objId, int grade, int upgrade)
-        {
-            if (!SimulatedWorld.Initialized)
-            {
-                return true;
-            }
-
-            if (LocalPlayer.IsMasterClient || !FactoryManager.EventFromServer)
-            {
-                LocalPlayer.SendPacket(new UpgradeEntityRequest(FactoryManager.TargetPlanet != FactoryManager.PLANET_NONE ? FactoryManager.TargetPlanet : __instance.planet?.id ?? -1, objId, grade, upgrade, FactoryManager.PacketAuthor == -1 ? LocalPlayer.PlayerId : FactoryManager.PacketAuthor));
-            }
-
-            return LocalPlayer.IsMasterClient || FactoryManager.EventFromServer;
-        }
-
-        [HarmonyPrefix]
         [HarmonyPatch(nameof(PlayerAction_Build.SetFactoryReferences))]
         public static bool SetFactoryReferences_Prefix()
         {

--- a/NebulaPatcher/Patches/Transpilers/BuildTool_BlueprintPaste_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/BuildTool_BlueprintPaste_Transpiler.cs
@@ -1,0 +1,61 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace NebulaPatcher.Patches.Transpiler
+{
+    [HarmonyPatch(typeof(BuildTool_BlueprintPaste))]
+    class BuildTool_BlueprintPaste_Transpiler
+    {
+        [HarmonyTranspiler]
+        [HarmonyPatch(nameof(BuildTool_BlueprintPaste.CreatePrebuilds))]
+        static IEnumerable<CodeInstruction> CreatePrebuilds_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator il)
+        {
+            /*
+             * Inserts
+             *  if(!SimulatedWorld.Initialized)
+             * Before trying to take items, so that all prebuilds are assumed to require items while in MP
+            */ 
+            CodeMatcher matcher = new CodeMatcher(instructions, il)
+                .MatchForward(true,
+                    new CodeMatch(i => i.IsLdloc()), // count
+                    new CodeMatch(OpCodes.Ldc_I4_1),
+                    new CodeMatch(OpCodes.Ceq),
+                    new CodeMatch(OpCodes.Brfalse)
+                );
+
+            if (matcher.IsInvalid)
+            {
+                NebulaModel.Logger.Log.Error("BuildTool_BlueprintPaste.CreatePrebuilds_Transpiler failed. Mod version not compatible with game version.");
+                return instructions;
+            }
+
+            var jumpOperand = matcher.Instruction.operand;
+
+            matcher = matcher
+                        .MatchBack(false,
+                            new CodeMatch(i => i.IsLdloc()),
+                            new CodeMatch(i => i.opcode == OpCodes.Ldfld && ((FieldInfo)i.operand).Name == "item"),
+                            new CodeMatch(i => i.opcode == OpCodes.Ldfld && ((FieldInfo)i.operand).Name == "ID"),
+                            new CodeMatch(i => i.IsStloc())
+                        );
+
+            if (matcher.IsInvalid)
+            {
+                NebulaModel.Logger.Log.Error("BuildTool_BlueprintPaste.CreatePrebuilds_Transpiler 2 failed. Mod version not compatible with game version.");
+                return instructions;
+            }
+
+            return matcher
+                    .InsertAndAdvance(HarmonyLib.Transpilers.EmitDelegate<Func<bool>>(() =>
+                    {
+                        return SimulatedWorld.Initialized;
+                    }))
+                    .InsertAndAdvance(new CodeInstruction(OpCodes.Brtrue, jumpOperand))
+                    .InstructionEnumeration();
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Transpilers/BuildTool_Common_Transpiler .cs
+++ b/NebulaPatcher/Patches/Transpilers/BuildTool_Common_Transpiler .cs
@@ -21,7 +21,6 @@ namespace NebulaPatcher.Patches.Transpiler
         [HarmonyPatch(typeof(BuildTool_Click), nameof(BuildTool_Click.CreatePrebuilds))]
         [HarmonyPatch(typeof(BuildTool_Path), nameof(BuildTool_Path.CreatePrebuilds))]
         [HarmonyPatch(typeof(BuildTool_Inserter), nameof(BuildTool_Inserter.CreatePrebuilds))]
-        [HarmonyPatch(typeof(BuildTool_BlueprintPaste), nameof(BuildTool_BlueprintPaste.CreatePrebuilds))]
         static IEnumerable<CodeInstruction> CreatePrebuilds_Transpiler(IEnumerable<CodeInstruction> instructions)
         {
             var codeMatcher = new CodeMatcher(instructions)

--- a/NebulaWorld/Factory/UpgradeEntityRequestManager.cs
+++ b/NebulaWorld/Factory/UpgradeEntityRequestManager.cs
@@ -7,27 +7,23 @@ namespace NebulaWorld.Factory
         public static void UpgradeEntityRequest(UpgradeEntityRequest packet)
         {
             PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
-            PlayerAction_Build pab = GameMain.mainPlayer.controller != null ? GameMain.mainPlayer.controller.actionBuild : null;
 
             // We only execute the code if the client has loaded the factory at least once.
             // Else they will get it once they go to the planet for the first time. 
-            if (planet?.factory == null || pab == null)
+            if (planet?.factory == null)
             {
                 return;
             }
 
             FactoryManager.TargetPlanet = packet.PlanetId;
             FactoryManager.PacketAuthor = packet.AuthorId;
-            PlanetFactory tmpFactory = pab.factory;
-            pab.factory = planet.factory;
-            pab.noneTool.factory = planet.factory;
 
             FactoryManager.AddPlanetTimer(packet.PlanetId);
-            pab.DoUpgradeObject(packet.ObjId, packet.Grade, packet.UpgradeProtoId, out int _);
+            ItemProto itemProto = LDB.items.Select(packet.UpgradeProtoId);
+            planet.factory.UpgradeFinally(GameMain.mainPlayer, packet.ObjId, itemProto);
 
-            pab.factory = tmpFactory;
-            pab.noneTool.factory = tmpFactory;
             FactoryManager.TargetPlanet = FactoryManager.PLANET_NONE;
+            FactoryManager.PacketAuthor = -1;
         }
     }
 }


### PR DESCRIPTION
Prevents players from being able to build blueprint buildings without having the required items