### PR TITLE
Change DSP launch settings and set NebulaPatcher to default startup d…

### DIFF
--- a/Nebula.sln
+++ b/Nebula.sln
@@ -3,11 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30225.117
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NebulaPatcher", "NebulaPatcher\NebulaPatcher.csproj", "{28B0716C-3926-4865-AB43-6C4431D022D6}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NebulaClient", "NebulaClient\NebulaClient.csproj", "{5BE9C74B-7832-4EF1-A53D-BF461BBDB0BE}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NebulaModel", "NebulaModel\NebulaModel.csproj", "{C6237195-F77C-40C0-B06A-4AD51CAD314D}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NebulaPatcher", "NebulaPatcher\NebulaPatcher.csproj", "{28B0716C-3926-4865-AB43-6C4431D022D6}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{08DB0E29-5C9B-41F3-A130-4CB9CAFAED70}"
 	ProjectSection(SolutionItems) = preProject

--- a/NebulaPatcher/Properties/launchsettings.json
+++ b/NebulaPatcher/Properties/launchsettings.json
@@ -2,9 +2,10 @@
   "profiles": {
     "Launch Dyson Sphere Program": {
       "commandName": "Executable",
-      "executablePath": "$(SteamDir)steam.exe",
-      "commandLineArgs": "-applaunch 1366540",
-      "commandLineArgs_comment": "Running with browser protocol does not work ¯\\_(ツ)_/¯"
+      "executablePath": "$(DSPGameDir)DSPGAME.exe",
+      "environmentVariables": {
+        "STEAM_APPID": "1366540"
+      }
     }
   }
 }


### PR DESCRIPTION
…irectory

By launching the game through Steam we were preventing the debugger from attaching, so let's target the EXE directly.

Also changes NebulaPatcher to be the first project in the solution file so that it is selected on startup and everyone sees the launch profile