### PR TITLE
add CanPause check, enable pausing when no connections

### DIFF
--- a/NebulaWorld/Multiplayer.cs
+++ b/NebulaWorld/Multiplayer.cs
@@ -13,6 +13,13 @@ namespace NebulaWorld
 
         public static bool IsInMultiplayerMenu { get; set; }
 
+        public static bool CanPause
+        {
+            get => canPause;
+            set => SetCanPause(value);
+        }
+        
+        private static bool canPause = true;
 
         public static void HostGame(NetworkProvider server)
         {
@@ -25,6 +32,7 @@ namespace NebulaWorld
         public static void JoinGame(NetworkProvider client)
         {
             IsLeavingGame = false;
+            CanPause = false;
 
             Session = new MultiplayerSession(client);
             ((NetworkProvider)Session.Network).Start();
@@ -33,6 +41,7 @@ namespace NebulaWorld
         public static void LeaveGame()
         {
             IsLeavingGame = true;
+            CanPause = true;
 
             bool wasGameLoaded = Session?.IsGameLoaded ?? false;
 
@@ -58,6 +67,13 @@ namespace NebulaWorld
                 Transform multiplayerMenu = overlayCanvasGo.transform.Find("Nebula - Multiplayer Menu");
                 multiplayerMenu.gameObject.SetActive(true);
             }
+        }
+
+        private static void SetCanPause(bool status)
+        {
+            canPause = status;
+            //Tell the user if the game is paused or not
+            GameObject.Find("UI Root/Overlay Canvas/In Game/Esc Menu/pause-text").SetActive(status);
         }
     }
 }

--- a/NebulaWorld/Multiplayer.cs
+++ b/NebulaWorld/Multiplayer.cs
@@ -13,13 +13,6 @@ namespace NebulaWorld
 
         public static bool IsInMultiplayerMenu { get; set; }
 
-        public static bool CanPause
-        {
-            get => canPause;
-            set => SetCanPause(value);
-        }
-        
-        private static bool canPause = true;
 
         public static void HostGame(NetworkProvider server)
         {
@@ -32,7 +25,6 @@ namespace NebulaWorld
         public static void JoinGame(NetworkProvider client)
         {
             IsLeavingGame = false;
-            CanPause = false;
 
             Session = new MultiplayerSession(client);
             ((NetworkProvider)Session.Network).Start();
@@ -41,7 +33,6 @@ namespace NebulaWorld
         public static void LeaveGame()
         {
             IsLeavingGame = true;
-            CanPause = true;
 
             bool wasGameLoaded = Session?.IsGameLoaded ?? false;
 
@@ -67,13 +58,6 @@ namespace NebulaWorld
                 Transform multiplayerMenu = overlayCanvasGo.transform.Find("Nebula - Multiplayer Menu");
                 multiplayerMenu.gameObject.SetActive(true);
             }
-        }
-
-        private static void SetCanPause(bool status)
-        {
-            canPause = status;
-            //Tell the user if the game is paused or not
-            GameObject.Find("UI Root/Overlay Canvas/In Game/Esc Menu/pause-text").SetActive(status);
         }
     }
 }

--- a/NebulaWorld/MultiplayerSession.cs
+++ b/NebulaWorld/MultiplayerSession.cs
@@ -38,6 +38,16 @@ namespace NebulaWorld
 
 
         public bool IsGameLoaded { get; set; }
+        public bool CanPause
+        {
+            get => canPause;
+            set
+            {
+                canPause = value;
+                World?.SetPauseIndicator(value);
+            }
+        }
+        private bool canPause = true;
 
         public MultiplayerSession(NetworkProvider networkProvider)
         {
@@ -62,6 +72,8 @@ namespace NebulaWorld
 
         public void Dispose()
         {
+            CanPause = true;
+
             Network?.Dispose();
             Network = null;
 

--- a/NebulaWorld/MultiplayerSession.cs
+++ b/NebulaWorld/MultiplayerSession.cs
@@ -72,8 +72,6 @@ namespace NebulaWorld
 
         public void Dispose()
         {
-            CanPause = true;
-
             Network?.Dispose();
             Network = null;
 

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -138,6 +138,7 @@ namespace NebulaWorld
             if (!IsPlayerJoining)
             {
                 IsPlayerJoining = true;
+                Multiplayer.CanPause = true;
                 GameMain.isFullscreenPaused = true;
                 InGamePopup.ShowInfo("Loading", "Player joining the game, please wait", null);
             }
@@ -148,6 +149,7 @@ namespace NebulaWorld
             IsPlayerJoining = false;
             InGamePopup.FadeOut();
             GameMain.isFullscreenPaused = false;
+            Multiplayer.CanPause = false;
         }
 
         public void SpawnRemotePlayerModel(IPlayerData playerData)
@@ -172,6 +174,10 @@ namespace NebulaWorld
                 {
                     player.Destroy();
                     remotePlayersModels.Remove(playerId);
+                    if (remotePlayersModels.Count == 0)
+                    {
+                        Multiplayer.CanPause = true;
+                    }
                 }
             }
         }

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -138,7 +138,7 @@ namespace NebulaWorld
             if (!IsPlayerJoining)
             {
                 IsPlayerJoining = true;
-                Multiplayer.CanPause = true;
+                Multiplayer.Session.CanPause = true;
                 GameMain.isFullscreenPaused = true;
                 InGamePopup.ShowInfo("Loading", "Player joining the game, please wait", null);
             }
@@ -149,7 +149,7 @@ namespace NebulaWorld
             IsPlayerJoining = false;
             InGamePopup.FadeOut();
             GameMain.isFullscreenPaused = false;
-            Multiplayer.CanPause = false;
+            Multiplayer.Session.CanPause = false;
         }
 
         public void SpawnRemotePlayerModel(IPlayerData playerData)
@@ -176,7 +176,7 @@ namespace NebulaWorld
                     remotePlayersModels.Remove(playerId);
                     if (remotePlayersModels.Count == 0)
                     {
-                        Multiplayer.CanPause = true;
+                        Multiplayer.Session.CanPause = true;
                     }
                 }
             }
@@ -603,6 +603,28 @@ namespace NebulaWorld
             {
                 pingIndicator.text = text;
             }
+        }
+
+        public void SetPauseIndicator(bool canPause)
+        {
+            //Tell the user if the game is paused or not
+            var targetObject = GameObject.Find("UI Root/Overlay Canvas/In Game/Esc Menu/pause-text");
+            var pauseText = targetObject?.GetComponent<Text>();
+            var pauseLocalizer = targetObject?.GetComponent<Localizer>();
+            if (pauseText && pauseLocalizer)
+            {
+                if (!canPause)
+                {
+                    pauseText.text = "--  Nebula Multiplayer  --".Translate();
+                    pauseLocalizer.stringKey = "--  Nebula Multiplayer  --".Translate();
+                }
+                else
+                {
+                    pauseText.text = "游戏已暂停".Translate();
+                    pauseLocalizer.stringKey = "游戏已暂停".Translate();
+                }
+            }
+                
         }
     }
 }


### PR DESCRIPTION
Attempt to implement #435
- Add `Multiplayer.CanPause` (not sure if it is in the right place?), it is set to false when there are other players joined and set to true when there are no RemotePlayerModel.  
So if the host stays on ESC screen, the game will automatically pause when all connections are closed.
- Change GameMain_Transpiler to deal with both `_paused` and `_fullscreenPaused` (toggle by Run game in dyson editor)