### PR TITLE
0.5.1

### DIFF
--- a/.github/scripts/thunderstore_bundle.js
+++ b/.github/scripts/thunderstore_bundle.js
@@ -135,7 +135,7 @@ function generateManifest() {
 function generateApiManifest() {
   const manifest = {
     name: apiPluginInfo.name,
-    description: "API for other mods to work with the Nebula Multiplayer Mod",
+    description: "API for other mods to work with the Nebula Multiplayer Mod. (Does NOT require Nebula)",
     version_number: apiPluginInfo.version,
     dependencies: [
       BEPINEX_DEPENDENCY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+0.5.1:
+
+- Fixed cases where a multiplayer session could hang on the player joining screen.
+- Fixed issue where foundations built by clients would not sync to other clients.
+- Fixed issue where the user would not be informed if they were kicked due to a mod mismatch.
+- Enabled pausing in Multiplayer when no clients are connected. (thanks to @starfi5h)
+
 0.5.0:
 
 - Added API that enables other mods to sync over multiplayer! (Big thanks to @kremnev8!)

--- a/NebulaAPI/CHANGELOG.md
+++ b/NebulaAPI/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+1.0.1:
+
+- Edited description. (No changes to the actual API)
+
 1.0.0:
 
 - initial release on thunderstore

--- a/NebulaAPI/version.json
+++ b/NebulaAPI/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "assemblyVersion": {
     "precision": "build"
   },

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
0.5.1:

- Fixed cases where a multiplayer session could hang on the player joining screen.
- Fixed issue where foundations built by clients would not sync to other clients.
- Fixed issue where the user would not be informed if they were kicked due to a mod mismatch.
- Enabled pausing in Multiplayer when no clients are connected. (thanks to @starfi5h)
- Edited description of api for thunderstore. (No changes to the actual API)