### PR TITLE
Fix remote player animation

### DIFF
--- a/NebulaModel/Packets/Players/PlayerAnimationUpdate.cs
+++ b/NebulaModel/Packets/Players/PlayerAnimationUpdate.cs
@@ -18,6 +18,7 @@ namespace NebulaModel.Packets.Players
 
         public EMovementState MovementState { get; set; }
         public float HorzSpeed { get; set; }
+        public float VertSpeed { get; set; }
         public float Turning { get; set; }
         public float Altitude { get; set; }
 
@@ -35,7 +36,8 @@ namespace NebulaModel.Packets.Players
             MiningAnimIndex = animator.miningAnimIndex;
 
             MovementState = animator.movementState;
-            HorzSpeed = animator.horzSpeed;
+            HorzSpeed = animator.controller.horzSpeed;
+            VertSpeed = animator.controller.vertSpeed;
             Turning = animator.turning;
             Altitude = 1f;
             if (GameMain.localPlanet != null)

--- a/NebulaModel/Packets/Players/PlayerAnimationUpdate.cs
+++ b/NebulaModel/Packets/Players/PlayerAnimationUpdate.cs
@@ -1,5 +1,7 @@
 ﻿using NebulaAPI;
 using NebulaModel.DataStructures;
+using Unity;
+using UnityEngine;
 
 namespace NebulaModel.Packets.Players
 {
@@ -7,17 +9,17 @@ namespace NebulaModel.Packets.Players
     public class PlayerAnimationUpdate
     {
         public ushort PlayerId { get; set; }
-        public float RunWeight { get; set; }
-        public float DriftWeight { get; set; }
-        public float FlyWeight { get; set; }
-        public float SailWeight { get; set; }
         public float JumpWeight { get; set; }
         public float JumpNormalizedTime { get; set; }
         public int IdleAnimIndex { get; set; }
         public int SailAnimIndex { get; set; }
         public float MiningWeight { get; set; }
         public int MiningAnimIndex { get; set; }
-        public float[] SailAnimWeights { get; set; }
+
+        public EMovementState MovementState { get; set; }
+        public float HorzSpeed { get; set; }
+        public float Turning { get; set; }
+        public float Altitude { get; set; }
 
         public PlayerAnimationUpdate() { }
 
@@ -25,17 +27,21 @@ namespace NebulaModel.Packets.Players
         {
             PlayerId = playerId;
 
-            RunWeight = animator.runWeight;
-            DriftWeight = animator.driftWeight;
-            FlyWeight = animator.flyWeight;
-            SailWeight = animator.sailWeight;
             JumpWeight = animator.jumpWeight;
             JumpNormalizedTime = animator.jumpNormalizedTime;
             IdleAnimIndex = animator.idleAnimIndex;
             SailAnimIndex = animator.sailAnimIndex;
             MiningWeight = animator.miningWeight;
             MiningAnimIndex = animator.miningAnimIndex;
-            SailAnimWeights = animator.sailAnimWeights;
+
+            MovementState = animator.movementState;
+            HorzSpeed = animator.horzSpeed;
+            Turning = animator.turning;
+            Altitude = 1f;
+            if (GameMain.localPlanet != null)
+            {
+                Altitude = Mathf.Clamp01((animator.player.position.magnitude - GameMain.localPlanet.realRadius - 7f) * 0.15f);
+            }
         }
     }
 }

--- a/NebulaWorld/MonoBehaviours/Local/LocalPlayerAnimation.cs
+++ b/NebulaWorld/MonoBehaviours/Local/LocalPlayerAnimation.cs
@@ -23,15 +23,6 @@ namespace NebulaWorld.MonoBehaviours.Local
             if (time >= BROADCAST_INTERVAL)
             {
                 time = 0;
-
-                // TODO: UPGRADE 0.8.21 :: check if still needed after refactor
-                /*
-                PlayerController controller = playerAnimator.player.controller;
-                float vertSpeed = Vector3.Dot(base.transform.up, controller.velocity);
-                Vector3 horzVel = controller.velocity - vertSpeed * base.transform.up;
-                float horzSpeed = horzVel.magnitude;
-                */
-
                 Multiplayer.Session.Network.SendPacket(new PlayerAnimationUpdate(Multiplayer.Session.LocalPlayer.Id, playerAnimator));
             }
         }

--- a/NebulaWorld/MonoBehaviours/Remote/RemotePlayerAnimation.cs
+++ b/NebulaWorld/MonoBehaviours/Remote/RemotePlayerAnimation.cs
@@ -7,10 +7,13 @@ namespace NebulaWorld.MonoBehaviours.Remote
     public class RemotePlayerAnimation : MonoBehaviour
     {
         private PlayerAnimator playerAnimator;
+        private float altitude;
 
         private void Awake()
         {
-            playerAnimator = GetComponentInChildren<PlayerAnimator>();
+            playerAnimator = GetComponentInChildren<PlayerAnimator>();            
+            playerAnimator.Start();
+            playerAnimator.enabled = false;
         }
 
         public void UpdateState(PlayerAnimationUpdate packet)
@@ -18,17 +21,98 @@ namespace NebulaWorld.MonoBehaviours.Remote
             if (playerAnimator == null)
                 return;
 
-            playerAnimator.runWeight = packet.RunWeight;
-            playerAnimator.driftWeight = packet.DriftWeight;
-            playerAnimator.flyWeight = packet.FlyWeight;
-            playerAnimator.sailWeight = packet.SailWeight;
             playerAnimator.jumpWeight = packet.JumpWeight;
             playerAnimator.jumpNormalizedTime = packet.JumpNormalizedTime;
             playerAnimator.idleAnimIndex = packet.IdleAnimIndex;
             playerAnimator.sailAnimIndex = packet.SailAnimIndex;
             playerAnimator.miningWeight = packet.MiningWeight;
             playerAnimator.miningAnimIndex = packet.MiningAnimIndex;
-            playerAnimator.sailAnimWeights = packet.SailAnimWeights;
+
+            playerAnimator.movementState = packet.MovementState;
+            playerAnimator.horzSpeed = packet.HorzSpeed;
+            playerAnimator.turning = packet.Turning;
+            altitude = packet.Altitude;
+
+            float deltaTime = Time.deltaTime;
+            CalculateMovementStateWeights(playerAnimator, deltaTime);
+            CalculateDirectionWeights(playerAnimator, deltaTime);
+
+            playerAnimator.AnimateIdleState(deltaTime);
+            playerAnimator.AnimateRunState(deltaTime);
+            playerAnimator.AnimateDriftState(deltaTime);
+            AnimateFlyState(playerAnimator);
+            AnimateSailState(playerAnimator);
+
+            playerAnimator.AnimateJumpState(deltaTime);
+            playerAnimator.AnimateSkills(deltaTime);
+            //playerAnimator.AnimateRenderers(deltaTime);
+        }
+
+        private void CalculateMovementStateWeights(PlayerAnimator animator, float dt)
+        {
+            float target = (animator.horzSpeed > 0.15f) ? 1f : 0f;
+            float target2 = (animator.movementState >= EMovementState.Drift) ? 1f : 0f;
+            float num = (animator.movementState >= EMovementState.Fly) ? 1f : 0f;
+            float num2 = (animator.movementState >= EMovementState.Sail) ? 1f : 0f;
+            animator.runWeight = Mathf.MoveTowards(animator.runWeight, target, dt / 0.22f);
+            animator.driftWeight = Mathf.MoveTowards(animator.driftWeight, target2, dt / 0.2f);
+            animator.flyWeight = Mathf.MoveTowards(animator.flyWeight, num, dt / (((double)num > 0.5) ? 0.4f : 0.2f));
+            animator.sailWeight = Mathf.MoveTowards(animator.sailWeight, num2, dt / (((double)num2 > 0.5) ? 0.8f : 0.2f));
+            for (int i = 0; i < animator.sails.Length; i++)
+            {
+                animator.sailAnimWeights[i] = Mathf.MoveTowards(animator.sailAnimWeights[i], (i == animator.sailAnimIndex) ? 1f : 0f, dt / 0.3f);
+            }
+        }
+
+        private void CalculateDirectionWeights(PlayerAnimator animator, float dt)
+        {
+            animator.leftWeight = Mathf.InverseLerp(-animator.minTurningAngle, -animator.maxTurningAngle, animator.turning);
+            animator.rightWeight = Mathf.InverseLerp(animator.minTurningAngle, animator.maxTurningAngle, animator.turning);
+            animator.forwardWeight = Mathf.Clamp01(1f - animator.leftWeight - animator.rightWeight);
+            float num = Mathf.Clamp01((animator.horzSpeed - 0.01f) / ((animator.movementState == EMovementState.Drift) ? 5f : 12.5f));
+            animator.forwardWeight *= num;
+            animator.leftWeight *= num;
+            animator.rightWeight *= num;
+            animator.zeroWeight = 1f - animator.forwardWeight - animator.leftWeight - animator.rightWeight;
+        }
+
+        public void AnimateFlyState(PlayerAnimator animator)
+        {
+            bool flag = animator.flyWeight > 0.001f;
+            animator.fly_0.enabled = flag;
+            animator.fly_f.enabled = flag;
+            animator.fly_l.enabled = flag;
+            animator.fly_r.enabled = flag;
+            animator.fly_0.weight = altitude * animator.flyWeight * animator.zeroWeight;
+            animator.fly_f.weight = altitude * animator.flyWeight * animator.forwardWeight;
+            animator.fly_l.weight = altitude * animator.flyWeight * animator.leftWeight;
+            animator.fly_r.weight = altitude * animator.flyWeight * animator.rightWeight;
+            animator.fly_0.speed = 0.44f;
+            animator.fly_f.speed = 0.44f;
+            animator.fly_l.speed = 0.44f;
+            animator.fly_r.speed = 0.44f;
+            if (!flag)
+            {
+                animator.fly_0.normalizedTime = 0f;
+                animator.fly_f.normalizedTime = 0f;
+                animator.fly_l.normalizedTime = 0f;
+                animator.fly_r.normalizedTime = 0f;
+            }
+        }
+
+        public void AnimateSailState(PlayerAnimator animator)
+        {
+            bool flag = animator.sailWeight > 0.001f;
+            for (int i = 0; i < animator.sails.Length; i++)
+            {
+                animator.sails[i].weight = altitude * animator.sailWeight * animator.sailAnimWeights[i];
+                animator.sails[i].enabled = flag;
+                animator.sails[i].speed = 1f;
+                if (!flag)
+                {
+                    animator.sails[i].normalizedTime = 0f;
+                }
+            }
         }
     }
 }

--- a/NebulaWorld/MonoBehaviours/Remote/RemotePlayerAnimation.cs
+++ b/NebulaWorld/MonoBehaviours/Remote/RemotePlayerAnimation.cs
@@ -11,9 +11,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
 
         private void Awake()
         {
-            playerAnimator = GetComponentInChildren<PlayerAnimator>();            
-            playerAnimator.Start();
-            playerAnimator.enabled = false;
+            playerAnimator = GetComponentInChildren<PlayerAnimator>();
         }
 
         public void UpdateState(PlayerAnimationUpdate packet)

--- a/NebulaWorld/MonoBehaviours/Remote/RemotePlayerEffects.cs
+++ b/NebulaWorld/MonoBehaviours/Remote/RemotePlayerEffects.cs
@@ -5,9 +5,7 @@ using UnityEngine;
 namespace NebulaWorld.MonoBehaviours.Remote
 {
     public class RemoteWarpEffect : MonoBehaviour
-    {
-        // TODO: UPGRADE 0.8.21 need refactor
-        
+    {        
         private Transform rootTransform;
 
         private VFWarpEffect warpEffect = null;
@@ -212,8 +210,6 @@ namespace NebulaWorld.MonoBehaviours.Remote
 
     public class RemotePlayerEffects : MonoBehaviour
     {
-        // TODO: UPGRADE 0.8.21 need refactor
-        
         private PlayerAnimator rootAnimation;
         private Transform rootTransform;
         private Transform rootModelTransform;
@@ -684,7 +680,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
                             }
                         }
                         StopAllFlyAudio();
-                        /PlayFootsteps();
+                        PlayFootsteps();
                     }
                     for (int i = 0; i < psysr.Length; i++)
                     {

--- a/NebulaWorld/MonoBehaviours/Remote/RemotePlayerEffects.cs
+++ b/NebulaWorld/MonoBehaviours/Remote/RemotePlayerEffects.cs
@@ -1,11 +1,13 @@
-﻿using UnityEngine;
+﻿using NebulaModel.Packets.Players;
+using System;
+using UnityEngine;
 
 namespace NebulaWorld.MonoBehaviours.Remote
 {
     public class RemoteWarpEffect : MonoBehaviour
     {
         // TODO: UPGRADE 0.8.21 need refactor
-        /*
+        
         private Transform rootTransform;
 
         private VFWarpEffect warpEffect = null;
@@ -39,11 +41,11 @@ namespace NebulaWorld.MonoBehaviours.Remote
         Vector4[] warpRotations;
         Vector3 velocity;
 
-        RemotePlayerAnimation rootAnimation = null;
+        PlayerAnimator rootAnimation = null;
         public void Awake()
         {
             rootTransform = GetComponent<Transform>();
-            rootAnimation = GetComponent<RemotePlayerAnimation>();
+            rootAnimation = GetComponent<PlayerAnimator>();
 
             warpEffect = Instantiate(Configs.builtin.warpEffectPrefab, GetComponent<Transform>());
             warpEffect.enabled = false;
@@ -124,7 +126,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
 
         public void StartWarp()
         {
-            if (!rootAnimation.Sail.enabled || isWarping)
+            if (rootAnimation.sailWeight <= 0.001f || isWarping)
             {
                 return;
             }
@@ -134,7 +136,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
 
         public void StopWarp()
         {
-            if (!rootAnimation.Sail.enabled || !isWarping)
+            if (rootAnimation.sailWeight <= 0.001f || !isWarping)
             {
                 return;
             }
@@ -205,20 +207,19 @@ namespace NebulaWorld.MonoBehaviours.Remote
             astrosMat.SetFloat("_Multiplier", astrosMul * num2);
             nebulasMat.SetFloat("_Multiplier", nebulasMul * num2);
         }
-        */
+        
     }
 
     public class RemotePlayerEffects : MonoBehaviour
     {
         // TODO: UPGRADE 0.8.21 need refactor
-        /*
-        private RemotePlayerAnimation rootAnimation;
+        
+        private PlayerAnimator rootAnimation;
         private Transform rootTransform;
         private Transform rootModelTransform;
         private RemoteWarpEffect rootWarp;
 
         private ParticleSystem[] WaterEffect;
-        private ParticleSystem[][] FootSmokeEffect;
         private ParticleSystem[] FootSmallSmoke;
         private ParticleSystem[] FootLargeSmoke;
         private ParticleSystem[] FootEffect;
@@ -242,7 +243,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
 
         public void Awake()
         {
-            rootAnimation = GetComponent<RemotePlayerAnimation>();
+            rootAnimation = GetComponentInChildren<PlayerAnimator>();
             rootTransform = GetComponent<Transform>();
             rootModelTransform = rootTransform.Find("Model");
 
@@ -251,13 +252,11 @@ namespace NebulaWorld.MonoBehaviours.Remote
             torchEffect = rootModelTransform.Find("bip/pelvis/spine-1/spine-2/spine-3/r-clavicle/r-upper-arm/r-forearm/r-torch/vfx-torch/blast").GetComponent<ParticleSystem>();
             FootEffect = new ParticleSystem[2];
             WaterEffect = new ParticleSystem[2];
-            FootSmokeEffect = new ParticleSystem[2][];
-            FootSmokeEffect[0] = new ParticleSystem[2];
-            FootSmokeEffect[1] = new ParticleSystem[2];
             FootSmallSmoke = new ParticleSystem[2];
             FootLargeSmoke = new ParticleSystem[2];
 
-            Transform VFX = rootModelTransform.Find("bip/pelvis/spine-1/spine-2/spine-3/backpack/VFX").GetComponent<Transform>();
+            
+            Transform VFX = rootModelTransform.Find("bip/pelvis/spine-1/spine-2/spine-3/backpack/backpack_end/VFX").GetComponent<Transform>();
 
             psys[0] = VFX.GetChild(0).GetComponent<ParticleSystem>();
             psys[1] = VFX.GetChild(1).GetComponent<ParticleSystem>();
@@ -265,18 +264,15 @@ namespace NebulaWorld.MonoBehaviours.Remote
             psysr[0] = VFX.GetChild(0).Find("flames").GetComponent<ParticleSystemRenderer>();
             psysr[1] = VFX.GetChild(1).Find("flames").GetComponent<ParticleSystemRenderer>();
 
-            WaterEffect[0] = rootModelTransform.Find("bip/pelvis/l-thigh/l-calf/l-ankle/l-foot/vfx-footsteps/water").GetComponent<ParticleSystem>();
-            WaterEffect[1] = rootModelTransform.Find("bip/pelvis/r-thigh/r-calf/r-ankle/r-foot/vfx-footsteps/water").GetComponent<ParticleSystem>();
-            FootSmokeEffect[0][0] = rootModelTransform.Find("bip/pelvis/l-thigh/l-calf/l-ankle/l-foot/vfx-footsteps/smoke").GetComponent<ParticleSystem>();
-            FootSmokeEffect[0][1] = rootModelTransform.Find("bip/pelvis/l-thigh/l-calf/l-ankle/l-foot/vfx-footsteps/smoke-2").GetComponent<ParticleSystem>();
-            FootSmokeEffect[1][0] = rootModelTransform.Find("bip/pelvis/r-thigh/r-calf/r-ankle/r-foot/vfx-footsteps/smoke").GetComponent<ParticleSystem>();
-            FootSmokeEffect[1][1] = rootModelTransform.Find("bip/pelvis/r-thigh/r-calf/r-ankle/r-foot/vfx-footsteps/smoke-2").GetComponent<ParticleSystem>();
-            FootEffect[0] = rootModelTransform.Find("bip/pelvis/l-thigh/l-calf/l-ankle/l-foot/vfx-footsteps").GetComponent<ParticleSystem>();
-            FootEffect[1] = rootModelTransform.Find("bip/pelvis/r-thigh/r-calf/r-ankle/r-foot/vfx-footsteps").GetComponent<ParticleSystem>();
-            FootSmallSmoke[0] = rootModelTransform.Find("bip/pelvis/l-thigh/l-calf/l-ankle/l-foot/vfx-footsteps/smoke").GetComponent<ParticleSystem>();
-            FootSmallSmoke[1] = rootModelTransform.Find("bip/pelvis/r-thigh/r-calf/r-ankle/r-foot/vfx-footsteps/smoke").GetComponent<ParticleSystem>();
-            FootLargeSmoke[0] = rootModelTransform.Find("bip/pelvis/l-thigh/l-calf/l-ankle/l-foot/vfx-footsteps/smoke-2").GetComponent<ParticleSystem>();
-            FootLargeSmoke[1] = rootModelTransform.Find("bip/pelvis/r-thigh/r-calf/r-ankle/r-foot/vfx-footsteps/smoke-2").GetComponent<ParticleSystem>();
+
+            WaterEffect[0]    = rootModelTransform.Find("bip/pelvis/l-thigh/l-calf/l-ankle/l-foot/l-foot_end/vfx-footsteps/water").GetComponent<ParticleSystem>();
+            WaterEffect[1]    = rootModelTransform.Find("bip/pelvis/r-thigh/r-calf/r-ankle/r-foot/r-foot_end/vfx-footsteps/water").GetComponent<ParticleSystem>();
+            FootEffect[0]     = rootModelTransform.Find("bip/pelvis/l-thigh/l-calf/l-ankle/l-foot/l-foot_end/vfx-footsteps").GetComponent<ParticleSystem>();
+            FootEffect[1]     = rootModelTransform.Find("bip/pelvis/r-thigh/r-calf/r-ankle/r-foot/r-foot_end/vfx-footsteps").GetComponent<ParticleSystem>();
+            FootSmallSmoke[0] = rootModelTransform.Find("bip/pelvis/l-thigh/l-calf/l-ankle/l-foot/l-foot_end/vfx-footsteps/smoke").GetComponent<ParticleSystem>();
+            FootSmallSmoke[1] = rootModelTransform.Find("bip/pelvis/r-thigh/r-calf/r-ankle/r-foot/r-foot_end/vfx-footsteps/smoke").GetComponent<ParticleSystem>();
+            FootLargeSmoke[0] = rootModelTransform.Find("bip/pelvis/l-thigh/l-calf/l-ankle/l-foot/l-foot_end/vfx-footsteps/smoke-2").GetComponent<ParticleSystem>();
+            FootLargeSmoke[1] = rootModelTransform.Find("bip/pelvis/r-thigh/r-calf/r-ankle/r-foot/r-foot_end/vfx-footsteps/smoke-2").GetComponent<ParticleSystem>();
 
             solidSoundEvents[0] = "footsteps-0";
             solidSoundEvents[1] = "footsteps-1";
@@ -344,13 +340,13 @@ namespace NebulaWorld.MonoBehaviours.Remote
 
         private void PlayFootsteps()
         {
-            float moveWeight = Mathf.Max(1f, Mathf.Pow(rootAnimation.RunSlow.weight + rootAnimation.RunFast.weight, 2f));
-            bool trigger = (rootAnimation.RunSlow.enabled || rootAnimation.RunFast.enabled) && moveWeight > 0.15f;
+            float moveWeight = Mathf.Max(1f, Mathf.Pow(rootAnimation.run_slow.weight + rootAnimation.run_fast.weight, 2f));
+            bool trigger = (rootAnimation.run_slow.enabled || rootAnimation.run_fast.enabled) && moveWeight > 0.15f;
 
             if (trigger)
             {
-                int normalizedTime = Mathf.FloorToInt(rootAnimation.RunFast.normalizedTime * 2f - 0.02f);
-                float normalizedTimeDiff = (rootAnimation.RunFast.normalizedTime * 2f - 0.02f) - (float)normalizedTime;
+                int normalizedTime = Mathf.FloorToInt(rootAnimation.run_fast.normalizedTime * 2f - 0.02f);
+                float normalizedTimeDiff = (rootAnimation.run_fast.normalizedTime * 2f - 0.02f) - (float)normalizedTime;
                 bool timeIsEven = normalizedTime % 2 == 0;
 
                 if (lastTriggeredFood != normalizedTime)
@@ -443,7 +439,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
             }
 
             ParticleSystem waterParticle = (!lr) ? WaterEffect[0] : WaterEffect[1];
-            ParticleSystem[] smokeParticle = (!lr) ? FootSmokeEffect[0] : FootSmokeEffect[1];
+            ParticleSystem[] smokeParticle = (!lr) ? FootSmallSmoke : FootLargeSmoke;
             ParticleSystem footEffect = (!lr) ? FootEffect[0] : FootEffect[1];
             AmbientDesc ambientDesc = GameMain.galaxy.PlanetById(localPlanetId).ambientDesc;
             Color color = Color.clear;
@@ -592,7 +588,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
                     tmpMaxAltitude = 1000f;
                 }
 
-                if (rootAnimation.RunSlow.enabled || rootAnimation.RunFast.enabled || rootAnimation.Drift.enabled || rootAnimation.DriftF.enabled || rootAnimation.DriftR.enabled || rootAnimation.DriftL.enabled)
+                if (rootAnimation.runWeight > 0.001f || rootAnimation.driftWeight > 0.001f)
                 {
                     bool ground = IsGrounded();
 
@@ -626,7 +622,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
                 }
 
                 // NOTE: the pPhys can only be loaded if the player trying to load it has the planet actually loaded (meaning he is on the same planet or near it)
-                if (pPhys != null && pFactory != null && packet.horzSpeed > 5f)
+                if (pPhys != null && pFactory != null && packet.HorzSpeed > 5f)
                 {
                     int number = Physics.OverlapSphereNonAlloc(base.transform.localPosition, 1.8f, collider, 1024, QueryTriggerInteraction.Collide);
                     for (int i = 0; i < number; i++)
@@ -659,8 +655,8 @@ namespace NebulaWorld.MonoBehaviours.Remote
 
         public void UpdateState(PlayerAnimationUpdate packet)
         {
-            bool anyMovingAnimationActive = rootAnimation.RunSlow.enabled || rootAnimation.RunFast.enabled || rootAnimation.Fly.enabled || rootAnimation.Sail.enabled || rootAnimation.Drift.enabled || rootAnimation.DriftF.enabled || rootAnimation.DriftL.enabled || rootAnimation.DriftR.enabled || !IsGrounded();
-            bool anyDriftActive = rootAnimation.Drift.enabled || rootAnimation.DriftR.enabled || rootAnimation.DriftL.enabled || rootAnimation.DriftF.enabled;
+            bool anyMovingAnimationActive = rootAnimation.runWeight > 0.001f || rootAnimation.flyWeight > 0.001f || rootAnimation.sailWeight > 0.001f || rootAnimation.driftWeight > 0.001f || !IsGrounded();
+            bool anyDriftActive = rootAnimation.driftWeight > 0.001f;
             bool fireParticleOkay = psys != null && psysr != null && (psys[0] != null && psys[1] != null && psysr[0] != null && psysr[1] != null);
 
             if (anyMovingAnimationActive)
@@ -668,7 +664,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
                 UpdateExtraSoundEffects(packet);
                 if (fireParticleOkay)
                 {
-                    if ((!rootAnimation.RunSlow.enabled && !rootAnimation.RunFast.enabled) || anyDriftActive || rootAnimation.Sail.enabled)
+                    if ((!rootAnimation.run_slow.enabled && !rootAnimation.run_fast.enabled) || anyDriftActive || rootAnimation.sailWeight > 0.001f)
                     {
                         for (int i = 0; i < psys.Length; i++)
                         {
@@ -688,24 +684,24 @@ namespace NebulaWorld.MonoBehaviours.Remote
                             }
                         }
                         StopAllFlyAudio();
-                        PlayFootsteps();
+                        /PlayFootsteps();
                     }
                     for (int i = 0; i < psysr.Length; i++)
                     {
-                        if (rootAnimation.RunSlow.enabled || rootAnimation.RunFast.enabled)
+                        if (rootAnimation.run_slow.enabled || rootAnimation.run_fast.enabled)
                         {
-                            if (rootAnimation.RunFast.weight != 0)
+                            if (rootAnimation.run_fast.weight != 0)
                             {
                                 // when flying over the planet
-                                psysr[i].lengthScale = Mathf.Lerp(-3.5f, -8f, Mathf.Max(packet.horzSpeed, packet.vertSpeed) * 0.04f);
+                                psysr[i].lengthScale = Mathf.Lerp(-3.5f, -8f, Mathf.Max(packet.HorzSpeed, packet.VertSpeed) * 0.04f);
                             }
                             else
                             {
                                 // when "walking" over water and moving in air without button press or while "walking" over water
-                                psysr[i].lengthScale = Mathf.Lerp(-3.5f, -8f, Mathf.Max(packet.horzSpeed, packet.vertSpeed) * 0.03f);
+                                psysr[i].lengthScale = Mathf.Lerp(-3.5f, -8f, Mathf.Max(packet.HorzSpeed, packet.VertSpeed) * 0.03f);
                             }
                         }
-                        if (rootAnimation.Drift.enabled)
+                        if (rootAnimation.drift_0.enabled)
                         {
                             // when in air without pressing spacebar
                             psysr[i].lengthScale = -3.5f;
@@ -723,10 +719,10 @@ namespace NebulaWorld.MonoBehaviours.Remote
                                 driftAudio = null;
                             }
                         }
-                        if (rootAnimation.Fly.enabled)
+                        if (rootAnimation.fly_0.enabled)
                         {
                             // when pressing spacebar but also when landing (Drift is disabled when landing)
-                            psysr[i].lengthScale = Mathf.Lerp(-3.5f, -10f, Mathf.Max(packet.horzSpeed, packet.vertSpeed) * 0.03f);
+                            psysr[i].lengthScale = Mathf.Lerp(-3.5f, -10f, Mathf.Max(packet.HorzSpeed, packet.VertSpeed) * 0.03f);
                             if (flyAudio0 == null)
                             {
                                 flyAudio0 = VFAudio.Create("fly-atmos", base.transform, Vector3.zero, false);
@@ -741,9 +737,9 @@ namespace NebulaWorld.MonoBehaviours.Remote
                                 flyAudio0 = null;
                             }
                         }
-                        if (rootAnimation.Sail.enabled)
+                        if (rootAnimation.sailWeight > 0.001f)
                         {
-                            psysr[i].lengthScale = Mathf.Lerp(-3.5f, -10f, Mathf.Max(packet.horzSpeed, packet.vertSpeed) * 15f);
+                            psysr[i].lengthScale = Mathf.Lerp(-3.5f, -10f, Mathf.Max(packet.HorzSpeed, packet.VertSpeed) * 15f);
                             if (flyAudio1 == null)
                             {
                                 flyAudio1 = VFAudio.Create("fly-space", base.transform, Vector3.zero, false);
@@ -776,7 +772,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
                 }
             }
 
-            if (torchEffect != null && rootAnimation.Mining0.weight > 0.99f)
+            if (torchEffect != null && rootAnimation.miningWeight > 0.99f)
             {
                 if (!torchEffect.isPlaying && miningAudio == null)
                 {
@@ -785,7 +781,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
                     miningAudio?.Play();
                 }
             }
-            else if (torchEffect != null && rootAnimation.Mining0.weight <= 0.99f)
+            else if (torchEffect != null && rootAnimation.miningWeight <= 0.99f)
             {
                 if (torchEffect.isPlaying)
                 {
@@ -800,6 +796,6 @@ namespace NebulaWorld.MonoBehaviours.Remote
         {
             localPlanetId = localPlanet;
         }
-        */
+        
     }
 }

--- a/NebulaWorld/RemotePlayerModel.cs
+++ b/NebulaWorld/RemotePlayerModel.cs
@@ -35,7 +35,6 @@ namespace NebulaWorld
                 Object.Destroy(PlayerTransform.GetComponent<PlayerFootsteps>());
                 Object.Destroy(PlayerTransform.GetComponent<PlayerEffect>());
                 Object.Destroy(PlayerTransform.GetComponent<PlayerAudio>());
-                Object.Destroy(PlayerTransform.GetComponent<PlayerAnimator>());
                 Object.Destroy(PlayerTransform.GetComponent<PlayerController>());
                 PlayerTransform.GetComponent<Rigidbody>().isKinematic = true;
 

--- a/NebulaWorld/RemotePlayerModel.cs
+++ b/NebulaWorld/RemotePlayerModel.cs
@@ -42,6 +42,9 @@ namespace NebulaWorld
                 Movement = PlayerTransform.gameObject.AddComponent<RemotePlayerMovement>();
                 Animator = PlayerTransform.gameObject.AddComponent<RemotePlayerAnimation>();
                 Effects = PlayerTransform.gameObject.AddComponent<RemotePlayerEffects>();
+
+                PlayerTransform.GetComponent<PlayerAnimator>().Start();
+                PlayerTransform.GetComponent<PlayerAnimator>().enabled = false;
             }
 
             PlayerTransform.gameObject.name = $"Remote Player ({playerId})";

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -201,7 +201,6 @@ namespace NebulaWorld
                 {
                     player.Animator.UpdateState(packet);
 
-                    // TODO: UPGRADE 0.8.21
                     player.Effects.UpdateState(packet);
                 }
             }
@@ -214,8 +213,6 @@ namespace NebulaWorld
                 if (packet.PlayerId == 0) packet.PlayerId = 1; // host sends himself as PlayerId 0 but clients see him as id 1
                 if (remotePlayersModels.TryGetValue(packet.PlayerId, out RemotePlayerModel player))
                 {
-                    // TODO: UPGRADE 0.8.21
-                    /*
                     if (packet.WarpCommand)
                     {
                         player.Effects.StartWarp();
@@ -224,7 +221,6 @@ namespace NebulaWorld
                     {
                         player.Effects.StopWarp();
                     }
-                    */
                 }
             }
         }

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -202,7 +202,7 @@ namespace NebulaWorld
                     player.Animator.UpdateState(packet);
 
                     // TODO: UPGRADE 0.8.21
-                    // player.Effects.UpdateState(packet);
+                    player.Effects.UpdateState(packet);
                 }
             }
         }


### PR DESCRIPTION
Make RemotePlayerAnimation use the original playerAnimator, and disable playerAnimator to stop it from updating.
Call some of its functions to update animations when receiving a packet in RemotePlayerAnimation.UpdateState().