### PR TITLE
Refactor PlayerData serialization

### DIFF
--- a/NebulaModel/DataStructures/PlayerData.cs
+++ b/NebulaModel/DataStructures/PlayerData.cs
@@ -15,6 +15,7 @@ namespace NebulaModel.DataStructures
         public Float3 BodyRotation { get; set; }
         public IMechaData Mecha { get; set; }
         public int LocalStarId { get; set; }
+        public ushort DataRevision { get; set; } = 3;
 
         public PlayerData() { }
         public PlayerData(ushort playerId, int localPlanetId, Float4[] mechaColors, string username = null, Float3 localPlanetPosition = new Float3(), Double3 position = new Double3(), Float3 rotation = new Float3(), Float3 bodyRotation = new Float3())
@@ -32,14 +33,9 @@ namespace NebulaModel.DataStructures
 
         public void Serialize(INetDataWriter writer)
         {
-            writer.Put(Username);
-            writer.Put(PlayerId);
+            writer.Put("PDREV");
+            writer.Put(DataRevision);
             writer.Put(LocalPlanetId);
-            writer.Put(MechaColors?.Length ?? 0);
-            for (int i = 0; i < (MechaColors?.Length ?? 0); i++)
-            {
-                MechaColors[i].Serialize(writer);
-            }
             LocalPlanetPosition.Serialize(writer);
             UPosition.Serialize(writer);
             Rotation.Serialize(writer);
@@ -49,20 +45,29 @@ namespace NebulaModel.DataStructures
 
         public void Deserialize(INetDataReader reader)
         {
-            Username = reader.GetString();
-            PlayerId = reader.GetUShort();
-            LocalPlanetId = reader.GetInt();
-            MechaColors = new Float4[reader.GetInt()];
-            for (int i = 0; i < MechaColors.Length; i++)
+            try
             {
-                MechaColors[i] = reader.GetFloat4();
+                if (reader.GetString() != "PDREV")
+                {
+                    throw new System.Exception();
+                }
+
+                DataRevision = reader.GetUShort();
+
+                Logger.Log.Debug($"Deserializing PlayerData with Revision {DataRevision}");
+
+                LocalPlanetId = reader.GetInt();
+                LocalPlanetPosition = reader.GetFloat3();
+                UPosition = reader.GetDouble3();
+                Rotation = reader.GetFloat3();
+                BodyRotation = reader.GetFloat3();
+                Mecha = new MechaData();
+                Mecha.Deserialize(reader);
             }
-            LocalPlanetPosition = reader.GetFloat3();
-            UPosition = reader.GetDouble3();
-            Rotation = reader.GetFloat3();
-            BodyRotation = reader.GetFloat3();
-            Mecha = new MechaData();
-            Mecha.Deserialize(reader);
+            catch (System.Exception)
+            {
+                Logger.Log.Error("Tried to load invalid PlayerData. Data is either corrupt or from an unsupported Nebula version.");
+            }
         }
 
         public IPlayerData CreateCopyWithoutMechaData()


### PR DESCRIPTION
- adds revision information for versioning
- removes data that is set on connection (username, playerid, mechacolors)

This currently doesn't work as intended as when loading playerdata from 0.6.1
> ArgumentOutOfRangeException: Index and count must refer to a location within the buffer.

is thrown by https://github.com/hubastard/nebula/blob/8f3fadf49fc8e0de472f3559fe6e6a3acdca0d1f/NebulaNetwork/SaveManager.cs#L98 and I'm not quite sure why