### PR TITLE
Fix errors when trying to load saves from earlier Nebula version

### DIFF
--- a/NebulaModel/DataStructures/PlayerData.cs
+++ b/NebulaModel/DataStructures/PlayerData.cs
@@ -5,6 +5,7 @@ namespace NebulaModel.DataStructures
     [RegisterNestedType]
     public class PlayerData : IPlayerData
     {
+        public const ushort REVISION = 3;
         public string Username { get; set; }
         public ushort PlayerId { get; set; }
         public int LocalPlanetId { get; set; }
@@ -15,6 +16,7 @@ namespace NebulaModel.DataStructures
         public Float3 BodyRotation { get; set; }
         public IMechaData Mecha { get; set; }
         public int LocalStarId { get; set; }
+        public ushort Revision { get; set; } = REVISION;
 
         public PlayerData() { }
         public PlayerData(ushort playerId, int localPlanetId, Float4[] mechaColors, string username = null, Float3 localPlanetPosition = new Float3(), Double3 position = new Double3(), Float3 rotation = new Float3(), Float3 bodyRotation = new Float3())

--- a/NebulaNetwork/SaveManager.cs
+++ b/NebulaNetwork/SaveManager.cs
@@ -26,6 +26,7 @@ namespace NebulaNetwork
                 {
                     string hash = data.Key;
                     netDataWriter.Put(hash);
+                    netDataWriter.Put(PlayerData.REVISION);
                     data.Value.Serialize(netDataWriter);
                 }
             }
@@ -96,6 +97,21 @@ namespace NebulaNetwork
                 for (int i = 0; i < playerNum; i++)
                 {
                     string hash = netDataReader.GetString();
+
+                    try
+                    {
+                        ushort revision = netDataReader.GetUShort();
+                        if (revision != PlayerData.REVISION)
+                        {
+                            throw new System.Exception();
+                        }
+                    }
+                    catch (System.Exception)
+                    {
+                        NebulaModel.Logger.Log.Warn("Skipping PlayerData from unsupported Nebula version...");
+                        break;
+                    }
+
                     PlayerData playerData = netDataReader.Get<PlayerData>();
                     if (!savedPlayerData.ContainsKey(hash))
                     {


### PR DESCRIPTION
Fixes #445 by adding PlayerData revision number to save file, and skips loading PlayerData if the revision is not set or different from expected (if we have to change the revision, this can be used to seamlessly upgrade older data).