### PR TITLE
Fix research desync

### DIFF
--- a/NebulaNetwork/PacketProcessors/GameHistory/GameHistoryResearchContributionProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/GameHistory/GameHistoryResearchContributionProcessor.cs
@@ -21,11 +21,14 @@ namespace NebulaNetwork.PacketProcessors.GameHistory
             //Check if client is contributing to the correct Tech Research
             if (packet.TechId == GameMain.history.currentTech)
             {
-                Log.Info($"ProcessPacket researchContribution: got package for same tech");
                 GameMain.history.AddTechHash(packet.Hashes);
                 IPlayerManager playerManager = Multiplayer.Session.Network.PlayerManager;
                 ((NebulaPlayer)playerManager.GetPlayer(conn)).UpdateResearchProgress(packet.TechId, packet.Hashes);
                 Log.Debug($"ProcessPacket researchContribution: playerid by: {playerManager.GetPlayer(conn).Id} - hashes {packet.Hashes}");
+            }
+            else
+            {
+                Log.Info($"ProcessPacket researchContribution: got package for different tech ({packet.TechId})");
             }
         }
     }

--- a/NebulaNetwork/PacketProcessors/GameHistory/GameHistoryResearchUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/GameHistory/GameHistoryResearchUpdateProcessor.cs
@@ -12,9 +12,11 @@ namespace NebulaNetwork.PacketProcessors.GameHistory
         {
             GameHistoryData data = GameMain.data.history;
             if (packet.TechId != data.currentTech)
-            {
-                //Wait for the authoritative packet to enqueue new tech first
-                return;
+            {                
+                NebulaModel.Logger.Log.Warn($"CurrentTech mismatch! Server:{packet.TechId} Local:{data.currentTech}");
+                //Replace currentTech to match with server
+                data.currentTech = packet.TechId;
+                data.techQueue[0] = packet.TechId;
             }
             TechState state = data.techStates[data.currentTech];
             state.hashUploaded = packet.HashUploaded;

--- a/NebulaNetwork/PacketProcessors/GameHistory/GameHistoryUnlockTechProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/GameHistory/GameHistoryUnlockTechProcessor.cs
@@ -15,9 +15,32 @@ namespace NebulaNetwork.PacketProcessors.GameHistory
             Log.Info($"Unlocking tech (ID: {packet.TechId})");
             using (Multiplayer.Session.History.IsIncomingRequest.On())
             {
-                GameMain.mainPlayer.mecha.lab.itemPoints.Clear();
-                GameMain.history.DequeueTech();
+                // Let the default method give back the items
+                GameMain.mainPlayer.mecha.lab.ManageTakeback();
+
+                // Update techState 
+                TechProto techProto = LDB.techs.Select(packet.TechId);
+                TechState techState = GameMain.history.techStates[packet.TechId];
+                if (techState.curLevel >= techState.maxLevel)
+                {
+                    techState.curLevel = techState.maxLevel;
+                    techState.hashUploaded = techState.hashNeeded;
+                    techState.unlocked = true;
+                }
+                else
+                {
+                    techState.curLevel++;
+                    techState.hashUploaded = 0L;
+                    techState.hashNeeded = techProto.GetHashNeeded(techState.curLevel);
+                }
+                // UnlockTech() unlocks tech to techState.maxLevel, so change it to curLevel temporarily
+                int maxLevl = techState.maxLevel;
+                techState.maxLevel = techState.curLevel;
+                GameMain.history.techStates[packet.TechId] = techState;
                 GameMain.history.UnlockTech(packet.TechId);
+                techState.maxLevel = maxLevl;
+                GameMain.history.techStates[packet.TechId] = techState;
+                GameMain.history.DequeueTech();                
             }
         }
     }

--- a/NebulaPatcher/Patches/Transpilers/LabComponent_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/LabComponent_Transpiler.cs
@@ -1,0 +1,44 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+
+namespace NebulaPatcher.Patches.Transpilers
+{
+    [HarmonyPatch(typeof(LabComponent))]
+    internal class LabComponent_Transpiler
+    {
+        [HarmonyTranspiler]
+        [HarmonyPatch(nameof(LabComponent.InternalUpdateResearch))]
+        static IEnumerable<CodeInstruction> InternalUpdateResearch_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            //Change: if (ts.hashUploaded >= ts.hashNeeded)
+            //To:     if (ts.hashUploaded >= ts.hashNeeded && (!Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost))
+            try
+            {
+                CodeMatcher matcher = new CodeMatcher(instructions)
+                    .MatchForward(true,
+                        new CodeMatch(i => i.IsLdarg()),
+                        new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(TechState), nameof(TechState.hashUploaded))),
+                        new CodeMatch(i => i.IsLdarg()),
+                        new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(TechState), nameof(TechState.hashNeeded))),
+                        new CodeMatch(OpCodes.Blt) //IL 339
+                    );
+                object label = matcher.Instruction.operand;
+                matcher.Advance(1)
+                    .InsertAndAdvance(HarmonyLib.Transpilers.EmitDelegate<Func<bool>>(() =>
+                    {
+                        return !Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost;
+                    }))
+                    .InsertAndAdvance(new CodeInstruction(OpCodes.Brfalse_S, label));
+                return matcher.InstructionEnumeration();
+            }
+            catch
+            {
+                NebulaModel.Logger.Log.Error("LabComponent.InternalUpdateResearch_Transpiler failed. Mod version not compatible with game version.");
+                return instructions;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Prevent client from unlocking tech itself.
- Force client's currentTech sync with server when receiving GameHistoryResearchUpdatePacket.
- Fix GameHistoryUnlockTechProcessor.

Fix #363:
GameHistoryData.VarifyTechQueue() check ``techQueue`` every tick, and it will remove the tech which ``techState`` is unlocked. LabComponent_Transpiler in this commit stop ``techState`` from unlocking so client will no longer drop tech in queue without GameHistoryUnlockTechPacket.
