### PR TITLE
fix for #467

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+0.7.2:
+
+- @sp00ktober: Fixed issue where the host would render buildings placed by players on other planets on his current planet.
+
 0.7.1:
 
 - @starfi5h: Fixed research desync issues

--- a/NebulaPatcher/Patches/Dynamic/GPUInstancingManager_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GPUInstancingManager_Patch.cs
@@ -41,7 +41,7 @@ namespace NebulaPatcher.Patches.Dynamic
         public static bool AddModel_Prefix(GPUInstancingManager __instance, ref int __result)
         {
             //Do not add model to the GPU queue if player is not on the same planet as building that was build
-            if (Multiplayer.IsActive && Multiplayer.Session.Factories.EventFactory != null && Multiplayer.Session.Factories.EventFactory.planet != __instance.activePlanet)
+            if (Multiplayer.IsActive && Multiplayer.Session.Factories.EventFactory != null && Multiplayer.Session.Factories.EventFactory.planet != GameMain.localPlanet)
             {
                 __result = 0;
                 return false;
@@ -54,7 +54,7 @@ namespace NebulaPatcher.Patches.Dynamic
         public static bool AddPrebuildModel_Prefix(GPUInstancingManager __instance, ref int __result)
         {
             //Do not add model to the GPU queue if player is not on the same planet as building that was build
-            if (Multiplayer.IsActive && Multiplayer.Session.Factories.EventFactory != null && Multiplayer.Session.Factories.EventFactory.planet != __instance.activePlanet)
+            if (Multiplayer.IsActive && Multiplayer.Session.Factories.EventFactory != null && Multiplayer.Session.Factories.EventFactory.planet != GameMain.localPlanet)
             {
                 __result = 0;
                 return false;

--- a/NebulaPatcher/Patches/Dynamic/GPUInstancingManager_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GPUInstancingManager_Patch.cs
@@ -3,39 +3,9 @@ using NebulaWorld;
 
 namespace NebulaPatcher.Patches.Dynamic
 {
-    // This is part of the weird planet movement fix
-    // as we delay setting localPlanet and planetId we need to be able to load FactoryData without them beeing set
-    // LoadingPlanetFactoryMain() -> factoryModel.gpuiManager.AddModel -> VegeRenderer::AddInst() -> base.manager.activeFactory -> GPUInstancingManager::get_activeFactory() -> get_activePlanet()
-    // which accesses GameMain.localPlanet which is null in that case which causes a NullReferenceException
-    // we need to return the right PlanetData in that case, luckily we make use of PlanetData.factoryLoading while loading the factory
     [HarmonyPatch(typeof(GPUInstancingManager))]
     internal class GPUInstancingManager_Patch
     {
-        [HarmonyPrefix]
-        [HarmonyPatch(nameof(GPUInstancingManager.activePlanet), MethodType.Getter)]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Original Function Name")]
-        public static bool get_activePlanet_Prefix(GPUInstancingManager __instance, ref PlanetData __result)
-        {
-            if (!Multiplayer.IsActive)
-            {
-                return true;
-            }
-
-            __result = __instance.specifyPlanet ?? GameMain.localPlanet;
-            if (__result == null && GameMain.localStar != null)
-            {
-                foreach (PlanetData p in GameMain.galaxy.StarById(GameMain.localStar.id).planets)
-                {
-                    if (p.factoryLoading)
-                    {
-                        __result = p;
-                        break;
-                    }
-                }
-            }
-            return false;
-        }
-
         [HarmonyPrefix]
         [HarmonyPatch(nameof(GPUInstancingManager.AddModel))]
         public static bool AddModel_Prefix(GPUInstancingManager __instance, ref int __result)

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
Should fix #467 which happened due to bypassing our own patch at https://github.com/hubastard/nebula/blob/master/NebulaPatcher/Patches/Dynamic/GPUInstancingManager_Patch.cs which relied on `activePlanet` which is now also set by us after #463 

Also removed an ancient patch we still had.