### PR TITLE
update tcli

### DIFF
--- a/.github/scripts/thunderstore_bundle.js
+++ b/.github/scripts/thunderstore_bundle.js
@@ -269,7 +269,7 @@ async function createGHArchive() {
 function uploadToTStore() {
   try {
     child_process.execSync(
-      `"${DIST_TSTORE_CLI_EXE_PATH}" publish --file "${TSTORE_API_ARCHIVE_PATH}""`
+      `"${DIST_TSTORE_CLI_EXE_PATH}" publish --file "${TSTORE_API_ARCHIVE_PATH}"`
     );
   } catch (error) {
     console.error(`Thunderstore upload failed for ${TSTORE_API_ARCHIVE_PATH} with error ${error}`);
@@ -277,7 +277,7 @@ function uploadToTStore() {
 
   try {
     child_process.execSync(
-      `"${DIST_TSTORE_CLI_EXE_PATH}" publish --file "${TSTORE_ARCHIVE_PATH}""`
+      `"${DIST_TSTORE_CLI_EXE_PATH}" publish --file "${TSTORE_ARCHIVE_PATH}"`
     );
   } catch (error) {
     console.error(`Thunderstore upload failed for ${TSTORE_ARCHIVE_PATH} with error ${error}`);

--- a/.github/scripts/thunderstore_bundle.js
+++ b/.github/scripts/thunderstore_bundle.js
@@ -269,7 +269,7 @@ async function createGHArchive() {
 function uploadToTStore() {
   try {
     child_process.execSync(
-      `"${DIST_TSTORE_CLI_EXE_PATH}" publish --file "${TSTORE_API_ARCHIVE_PATH}" --token "${process.env.TSTORE_TOKEN}" --use-session-auth`
+      `"${DIST_TSTORE_CLI_EXE_PATH}" publish --file "${TSTORE_API_ARCHIVE_PATH}""`
     );
   } catch (error) {
     console.error(`Thunderstore upload failed for ${TSTORE_API_ARCHIVE_PATH} with error ${error}`);
@@ -277,7 +277,7 @@ function uploadToTStore() {
 
   try {
     child_process.execSync(
-      `"${DIST_TSTORE_CLI_EXE_PATH}" publish --file "${TSTORE_ARCHIVE_PATH}" --token "${process.env.TSTORE_TOKEN}" --use-session-auth`
+      `"${DIST_TSTORE_CLI_EXE_PATH}" publish --file "${TSTORE_ARCHIVE_PATH}""`
     );
   } catch (error) {
     console.error(`Thunderstore upload failed for ${TSTORE_ARCHIVE_PATH} with error ${error}`);

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -71,7 +71,7 @@ jobs:
       # Bundle
       - name: Bundle build for thunderstore and github
         env:
-          TSTORE_TOKEN: ${{ secrets.TSTORE_TOKEN }}
+          TCLI_AUTH_TOKEN: ${{ secrets.TS_SERVICE_ACCOUNT_TOKEN }}
         run: node .github\scripts\thunderstore_bundle.js
 
       - name: Prepare Release


### PR DESCRIPTION
- update tcli to https://github.com/thunderstore-io/thunderstore-cli/commit/272503b7445eb1d65e87e2ff4111a19e199023b0
- use TCLI_AUTH_TOKEN for authentication

This should finally allow us to automatically release to Thunderstore 🤞