### PR TITLE
Publish API releases to NuGet

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -114,5 +114,5 @@ jobs:
       - name: Publish to NuGet
         shell: bash
         run: |
-          dotnet pack .\NebulaAPI\NebulaAPI.csproj -c Release -o "." -p:OutDir="bin/net472/Release/"
+          dotnet pack .\NebulaAPI\NebulaAPI.csproj -c Release -o "." -p:OutDir="bin/net472/Release/" -p:PublicRelease=true
           dotnet nuget push *.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}} --skip-duplicate

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -98,6 +98,7 @@ jobs:
         with:
           name: nebula-api-thunderstore
           path: ${{ env.DIST_RELEASE_FOLDER }}nebula-NebulaMultiplayerModApi
+        continue-on-error: true
 
       # Create release
       - uses: hubastard/release-action@v1

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -109,3 +109,10 @@ jobs:
           tag: ${{ fromJson(steps.prepare-release.outputs.PREPARE_RELEASE_OUTPUT).NewBranch.Name }}
           commit: ${{ fromJson(steps.prepare-release.outputs.PREPARE_RELEASE_OUTPUT).NewBranch.Name }}
           token: ${{ secrets.GITHUB_TOKEN }}
+
+       # Publish to NuGet
+      - name: Publish to NuGet
+        shell: bash
+        run: |
+          dotnet pack .\NebulaAPI\NebulaAPI.csproj -c Release -o "." -p:OutDir="bin/net472/Release/"
+          dotnet nuget push *.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}} --skip-duplicate

--- a/NebulaAPI/NebulaAPI.csproj
+++ b/NebulaAPI/NebulaAPI.csproj
@@ -6,6 +6,7 @@
     <Authors>Nebula Mod Team</Authors>
     <Description>API for other mods to work with the Nebula Multiplayer Mod for Dyson Sphere Program.</Description>
     <PackageProjectUrl>https://github.com/hubastard/nebula</PackageProjectUrl>
+    <GitVersionBaseDirectory>$(MSBuildThisFileDirectory)</GitVersionBaseDirectory>
 </PropertyGroup>
 
 </Project>

--- a/NebulaAPI/NebulaAPI.csproj
+++ b/NebulaAPI/NebulaAPI.csproj
@@ -1,2 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk" />
+<Project Sdk="Microsoft.NET.Sdk">
+
+<PropertyGroup>
+    <PackageId>NebulaMultiplayerModApi</PackageId>
+    <Authors>Nebula Mod Team</Authors>
+    <Description>API for other mods to work with the Nebula Multiplayer Mod for Dyson Sphere Program.</Description>
+    <PackageProjectUrl>https://github.com/hubastard/nebula</PackageProjectUrl>
+</PropertyGroup>
+
+</Project>


### PR DESCRIPTION
- Requires a NUGET_API_KEY variable to be added to the repository secrets. @hubastard should make an organization for nebula on https://nuget.org (or do we maybe want to publish to the BepInEx nuget instead? https://nuget.bepinex.dev/)
- The initial release should be made manually, it can be done using the same command line that publish-release.yml uses.

Also just threw in here:
- Set the thunderstore upload step to continue on failure since thunderstore is prone to throw errors on upload even when the upload succeeds.

Closes #466 