### PR TITLE
Improve Build Performance

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -51,10 +51,6 @@ jobs:
       - name: Add remote build identifier
         run: New-Item -Name .remoteBuild -ItemType File -force
 
-      # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
-      - name: Setup MSBuild.exe
-        uses: microsoft/setup-msbuild@v1.0.2
-
       # Add dotnet to the PATH: https://github.com/actions/setup-dotnet
       - name: Setup dotnet.exe
         uses: actions/setup-dotnet@v1
@@ -63,10 +59,9 @@ jobs:
       - run: |
              dotnet tool install --tool-path . nbgv
 
-
       # Build it
       - name: Build the application
-        run: msbuild $env:SOLUTION_NAME /p:Configuration=Release /p:PublicRelease=true
+        run: dotnet build $env:SOLUTION_NAME /p:Configuration=Release /p:PublicRelease=true
 
       # Bundle
       - name: Bundle build for thunderstore and github

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,4 +51,8 @@
     <PackageReference Include="UnityEngine.Modules" Version="2018.4.12" IncludeAssets="compile" />
     <PackageReference Include="DysonSphereProgram.GameLibs" Version="*-*" IncludeAssets="compile" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
+  </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,6 +29,7 @@
 
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
+    <GitVersionBaseDirectory>$(MSBuildThisFileDirectory)</GitVersionBaseDirectory>
   </PropertyGroup>
 
   <PropertyGroup Label="API Properties" Condition=" '$(MSBuildProjectName)' == 'NebulaAPI' " >


### PR DESCRIPTION
For CI builds:

- Use dotnet build instead of msbuild, since we need dotnet for nbgv anyway.

For all builds:

- Sets GitVersionBaseDirectory to reduce GetBuildVersion invocations. See https://github.com/dotnet/Nerdbank.GitVersioning/blob/master/doc/msbuild.md#reducing-getbuildversion-invocations