### PR TITLE
Quickfix for IndexOutOfBounds due to WarningSystem

### DIFF
--- a/NebulaPatcher/Patches/Dynamic/WarningSystem_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/WarningSystem_Patch.cs
@@ -1,0 +1,22 @@
+﻿using HarmonyLib;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(WarningSystem))]
+    class WarningSystem_Patch
+    {
+        /*
+         * Until we have a proper syncing of this system we avoid index out of bounds by skipping the method if needed.
+         */
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(WarningSystem), nameof(WarningSystem.RemoveWarningData))]
+        public static bool RemoveWarningData_Prefix(WarningSystem __instance, int id)
+        {
+            if(id > __instance.warningCursor)
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Avoid index out of bounds by skipping a method. This is a quickfix but needs to be replaced by a proper syncing of the warning system introduced in the latest game patches.

![grafik](https://user-images.githubusercontent.com/79335616/143307969-a550d6b6-68eb-4151-b8ec-218823be07e8.png)

`id` is not synced.