### PR TITLE
Use DysonSphereProgram.Modding namespace

### DIFF
--- a/NebulaAPI/NebulaAPI.csproj
+++ b/NebulaAPI/NebulaAPI.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 <PropertyGroup>
-    <PackageId>NebulaMultiplayerModApi</PackageId>
+    <PackageId>DysonSphereProgram.Modding.NebulaMultiplayerModApi</PackageId>
     <Authors>Nebula Mod Team</Authors>
     <Description>API for other mods to work with the Nebula Multiplayer Mod for Dyson Sphere Program.</Description>
     <PackageProjectUrl>https://github.com/hubastard/nebula</PackageProjectUrl>


### PR DESCRIPTION
@kremnev8 had already started uploading under the [DysonSphereProgram.Modding namespace on nuget.org](https://www.nuget.org/packages?q=+DysonSphereProgram.Modding) so we should probably use that too.

~~When this is merged I will deprecate [NebulaMultiplayerModApi](https://www.nuget.org/packages/NebulaMultiplayerModApi)~~ -- Actually I can do that before this gets merged 😅

E: Done: https://www.nuget.org/packages/DysonSphereProgram.Modding.NebulaMultiplayerModApi/