### PR TITLE
Remove dependencies from nuget package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -49,8 +49,8 @@
   <ItemGroup Label="Core">
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
     <PackageReference Include="BepInEx.Core" Version="5.*" PrivateAssets="all" />
-    <PackageReference Include="UnityEngine.Modules" Version="2018.4.12" IncludeAssets="compile" />
-    <PackageReference Include="DysonSphereProgram.GameLibs" Version="*-*" IncludeAssets="compile" />
+    <PackageReference Include="UnityEngine.Modules" Version="2018.4.12" IncludeAssets="compile" PrivateAssets="all" />
+    <PackageReference Include="DysonSphereProgram.GameLibs" Version="*-*" IncludeAssets="compile" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">

--- a/NebulaAPI/CHANGELOG.md
+++ b/NebulaAPI/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+1.1.2:
+
+- Bump version for nuget package.
+
 1.1.1:
 
 - Removed extraneous dll that was mistakenly included in the previous release

--- a/NebulaAPI/version.json
+++ b/NebulaAPI/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
Having these packages hardcoded as dependencies will prevent people who prefer to use local references over the nuget references.

This can especially impact people who use prepatchers and need to reference a local assembly-csharp.