### PR TITLE
Hotfix for error if one player is in space

### DIFF
--- a/NebulaPatcher/Patches/Dynamic/StorageComponent_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/StorageComponent_Patch.cs
@@ -50,7 +50,7 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPatch(nameof(StorageComponent.SetBans))]
         public static void SetBans_Postfix(StorageComponent __instance, int _bans)
         {
-            if (Multiplayer.IsActive && !Multiplayer.Session.Storage.IsIncomingRequest)
+            if (Multiplayer.IsActive && !Multiplayer.Session.Storage.IsIncomingRequest && GameMain.data.localPlanet != null)
             {
                 HandleUserInteraction(__instance, new StorageSyncSetBansPacket(__instance.id, GameMain.data.localPlanet.id, _bans));
             }


### PR DESCRIPTION
Sometimes if one player is in space, the others will also have localPlanet as null for some reason. 
Needs further investigation..

Feel free to request edits.

Edit: I am referring to this Stacktrace a user reported while one client was in space, other was putting stuff in chests:
![image](https://user-images.githubusercontent.com/30842467/144742087-f26c6c74-f6c8-4e7a-a94d-b6aea1905161.png)
Neither of them was a host. See the #bug-reports channel in the discord.