### PR TITLE
Another container bug

### DIFF
--- a/NebulaWorld/Logistics/ILSShipManager.cs
+++ b/NebulaWorld/Logistics/ILSShipManager.cs
@@ -268,6 +268,9 @@ namespace NebulaWorld.Logistics
                 UIStationStorage[] stationStorageUI = stationWindow.storageUIs;
                 if (stationStorageUI != null && stationStorageUI.Length > storageIndex)
                 {
+                    //Fixes a bug where the game thinks you're still in a container while exiting the planet, hopefully
+                    if (GameMain.localPlanet?.id == null) return;
+                    
                     stationStorageUI[storageIndex].RefreshValues();
                 }
             }


### PR DESCRIPTION
Another bug encountered with nebula and containers. The original error was thrown in stuff we don't modify, but we can prevent that function from getting called, when there is no planet around. At least I hope so, as its a hard to reproduce bug, again.
Screenshot: 
![image](https://user-images.githubusercontent.com/30842467/144910715-43a051da-5d3a-4ecc-988d-95f430f68aca.png)
