### PR TITLE
Fix ping indicator + other small changes

### DIFF
--- a/NebulaModel/Packets/Universe/DysonLaunchDataPacket.cs
+++ b/NebulaModel/Packets/Universe/DysonLaunchDataPacket.cs
@@ -1,5 +1,8 @@
-﻿namespace NebulaModel.Packets.Universe
+﻿using NebulaAPI;
+
+namespace NebulaModel.Packets.Universe
 {
+    [HidePacketInDebugLogs]
     public class DysonLaunchDataPacket
     {
         public int Count { get; set; }

--- a/NebulaModel/Packets/Universe/DysonSphereStatusPacket.cs
+++ b/NebulaModel/Packets/Universe/DysonSphereStatusPacket.cs
@@ -1,5 +1,8 @@
-﻿namespace NebulaModel.Packets.Universe
+﻿using NebulaAPI;
+
+namespace NebulaModel.Packets.Universe
 {
+    [HidePacketInDebugLogs]
     public class DysonSphereStatusPacket
     {
         public int StarIndex { get; set; }

--- a/NebulaNetwork/PacketProcessors/Session/PingPacketProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Session/PingPacketProcessor.cs
@@ -10,16 +10,19 @@ namespace NebulaNetwork.PacketProcessors.Session
     [RegisterPacketProcessor]
     internal class PingPacketProcessor : PacketProcessor<PingPacket>
     {
+        private int averageRTT;
+
         public override void ProcessPacket(PingPacket packet, NebulaConnection conn)
         {
             if (IsHost)
             {
-                conn.SendPacket(new PingPacket());
+                conn.SendPacket(packet);
             }
             else
             {
                 int rtt = (int)(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - packet.SentTimestamp);
-                Multiplayer.Session.World.UpdatePingIndicator($"Ping: {rtt}ms");
+                averageRTT = (int)(averageRTT * 0.7 + rtt * 0.3);
+                Multiplayer.Session.World.UpdatePingIndicator($"Ping: {averageRTT}ms");
             }
         }
     }

--- a/NebulaNetwork/Server.cs
+++ b/NebulaNetwork/Server.cs
@@ -167,7 +167,7 @@ namespace NebulaNetwork
                     DysonSphere dysonSphere = dysonSpheres[i];
                     if (dysonSphere != null && (dysonSphere.energyReqCurrentTick + dysonSphere.energyGenCurrentTick > 0))
                     {
-                        SendPacketToStar(new DysonSphereStatusPacket(dysonSpheres[i]), dysonSpheres[i].starData.id);
+                        SendPacketToStar(new DysonSphereStatusPacket(dysonSphere), dysonSphere.starData.id);
                     }
                 }
             }

--- a/NebulaNetwork/Server.cs
+++ b/NebulaNetwork/Server.cs
@@ -164,7 +164,8 @@ namespace NebulaNetwork
                 DysonSphere[] dysonSpheres = GameMain.data.dysonSpheres;
                 for (int i = 0; i < dysonSpheres.Length; i++)
                 {
-                    if (dysonSpheres[i] != null)
+                    DysonSphere dysonSphere = dysonSpheres[i];
+                    if (dysonSphere != null && (dysonSphere.energyReqCurrentTick + dysonSphere.energyGenCurrentTick > 0))
                     {
                         SendPacketToStar(new DysonSphereStatusPacket(dysonSpheres[i]), dysonSpheres[i].starData.id);
                     }

--- a/NebulaPatcher/Patches/Dynamic/GameHistoryData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameHistoryData_Patch.cs
@@ -154,6 +154,7 @@ namespace NebulaPatcher.Patches.Dynamic
         public static void RemoveTechInQueue_Prefix(int index, out int __state)
         {
             __state = GameMain.history.techQueue[index];
+            Log.Info($"RemoveTechInQueue: remove tech at index {index} with techId { __state}");
         }
     }
 }

--- a/NebulaWorld/MonoBehaviours/Remote/RemotePlayerAnimation.cs
+++ b/NebulaWorld/MonoBehaviours/Remote/RemotePlayerAnimation.cs
@@ -8,16 +8,27 @@ namespace NebulaWorld.MonoBehaviours.Remote
     {
         public PlayerAnimator PlayerAnimator;
         private RemotePlayerMovement rootMovement;
+        private RemotePlayerEffects remotePlayerEffects;
         private float altitudeFactor;
+        private readonly PlayerAnimationUpdate[] packetBuffer = new PlayerAnimationUpdate[3];
+
         private void Awake()
         {
             PlayerAnimator = GetComponent<PlayerAnimator>();
             rootMovement = GetComponent<RemotePlayerMovement>();
+            remotePlayerEffects = GetComponent<RemotePlayerEffects>();
         }
 
         public void UpdateState(PlayerAnimationUpdate packet)
         {
-            if (PlayerAnimator == null)
+            // Delay for 200 ms
+            for (int i = 0; i < packetBuffer.Length - 1; ++i)
+            {
+                packetBuffer[i] = packetBuffer[i + 1];
+            }
+            packetBuffer[packetBuffer.Length - 1] = packet;
+            packet = packetBuffer[0];
+            if (packet == null || PlayerAnimator == null)
             {
                 return;
             }
@@ -56,6 +67,8 @@ namespace NebulaWorld.MonoBehaviours.Remote
             PlayerAnimator.AnimateJumpState(deltaTime);
             PlayerAnimator.AnimateSkills(deltaTime);
             AnimateRenderers(PlayerAnimator);
+
+            remotePlayerEffects.UpdateState(packet);
         }
 
         private void CalculateMovementStateWeights(PlayerAnimator animator, float dt)

--- a/NebulaWorld/MonoBehaviours/Remote/RemotePlayerMovement.cs
+++ b/NebulaWorld/MonoBehaviours/Remote/RemotePlayerMovement.cs
@@ -1,7 +1,7 @@
 ﻿using NebulaAPI;
 using NebulaModel.Packets.Players;
-using NebulaModel.Utils;
 using NebulaWorld.MonoBehaviours.Local;
+using System;
 using UnityEngine;
 
 namespace NebulaWorld.MonoBehaviours.Remote
@@ -9,6 +9,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
     public class RemotePlayerMovement : MonoBehaviour
     {
         private const int BUFFERED_SNAPSHOT_COUNT = 4;
+        private const double INTERPOLATION_TIME = (1000 / (double)LocalPlayerMovement.SEND_RATE) * (BUFFERED_SNAPSHOT_COUNT - 1);
 
         public struct Snapshot
         {
@@ -67,9 +68,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
                 return;
             }
 
-            double past = (1000 / (double)LocalPlayerMovement.SEND_RATE) * (snapshotBuffer.Length - 1);
-            double now = TimeUtils.CurrentUnixTimestampMilliseconds();
-            double renderTime = now - past;
+            double renderTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - INTERPOLATION_TIME;
 
             for (int i = 0; i < snapshotBuffer.Length - 1; ++i)
             {
@@ -109,7 +108,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
 
             snapshotBuffer[snapshotBuffer.Length - 1] = new Snapshot()
             {
-                Timestamp = TimeUtils.CurrentUnixTimestampMilliseconds(),
+                Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                 LocalPlanetId = movement.LocalPlanetId,
                 LocalPlanetPosition = movement.LocalPlanetPosition,
                 UPosition = movement.UPosition,

--- a/NebulaWorld/RemotePlayerModel.cs
+++ b/NebulaWorld/RemotePlayerModel.cs
@@ -40,8 +40,8 @@ namespace NebulaWorld
 
                 // Add remote player components
                 Movement = PlayerTransform.gameObject.AddComponent<RemotePlayerMovement>();
-                Animator = PlayerTransform.gameObject.AddComponent<RemotePlayerAnimation>();
                 Effects = PlayerTransform.gameObject.AddComponent<RemotePlayerEffects>();
+                Animator = PlayerTransform.gameObject.AddComponent<RemotePlayerAnimation>();
 
                 PlayerTransform.GetComponent<PlayerAnimator>().Start();
                 PlayerTransform.GetComponent<PlayerAnimator>().enabled = false;

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -205,8 +205,6 @@ namespace NebulaWorld
                 if (remotePlayersModels.TryGetValue(packet.PlayerId, out RemotePlayerModel player))
                 {
                     player.Animator.UpdateState(packet);
-
-                    player.Effects.UpdateState(packet);
                 }
             }
         }


### PR DESCRIPTION
- Fix ping indicator so now it will show the average round trip time.
- Store PlayerAnimationUpdate in buffer to match the timing of movement update.
- Now host only send DysonSphereStatusPacket  if the sphere is not empty, or the system has power consumers(ray receivers).