### PR TITLE
Add WarningSystem syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+0.8.0:
+
+- @starfish: Added WarningSystem syncing
+- @PhantomGamers: Fixed case of NRE when arriving on another planet
+
 0.7.9:
 
 - @sp00ktober: gracefully tell older nebula versions that there is a mod version missmatch.

--- a/NebulaModel/Packets/Factory/EntityWarningSwitchPacket.cs
+++ b/NebulaModel/Packets/Factory/EntityWarningSwitchPacket.cs
@@ -1,0 +1,18 @@
+﻿namespace NebulaModel.Packets.Factory
+{
+    public class EntityWarningSwitchPacket
+    {
+        public int PlanetId { get; set; }
+        public int EntityId { get; set; }
+        public bool Enable { get; set; }
+
+        public EntityWarningSwitchPacket() { }
+
+        public EntityWarningSwitchPacket(int planetId, int entityId, bool enable)
+        {
+            PlanetId = planetId;
+            EntityId = entityId;
+            Enable = enable;
+        }
+    }
+}

--- a/NebulaModel/Packets/Factory/Monitor/MonitorSettingUpdatePacket.cs
+++ b/NebulaModel/Packets/Factory/Monitor/MonitorSettingUpdatePacket.cs
@@ -1,0 +1,37 @@
+﻿namespace NebulaModel.Packets.Factory.Monitor
+{
+    public class MonitorSettingUpdatePacket
+    {
+        public int PlanetId { get; set; }
+        public int MonitorId { get; set; }
+        public MonitorSettingEvent Event { get; set; }
+        public int Parameter1 { get; set; }
+        public int Parameter2 { get; set; }
+
+        public MonitorSettingUpdatePacket() { }
+        public MonitorSettingUpdatePacket(int planetId, int monitorId, MonitorSettingEvent settingEvent, int parameter1, int parameter2)
+        {
+            PlanetId = planetId;
+            MonitorId = monitorId;
+            Event = settingEvent;
+            Parameter1 = parameter1;
+            Parameter2 = parameter2;
+        }
+        public MonitorSettingUpdatePacket(int planetId, int monitorId, MonitorSettingEvent settingEvent, int parameter)
+            : this(planetId, monitorId, settingEvent, parameter, 0) { }
+    }
+
+    public enum MonitorSettingEvent
+    {
+        SetPassColorId = 0,
+        SetFailColorId = 1,
+        SetPassOperator = 2,
+        SetMonitorMode = 3,
+        SetSystemWarningMode = 4,
+        SetSystemWarningSignalId = 5,
+        SetCargoFilter = 6,
+        SetTargetCargoBytes = 7,
+        SetPeriodTickCount = 8,
+        SetTargetBelt = 9
+    }
+}

--- a/NebulaModel/Packets/Factory/Monitor/SpeakerSettingUpdatePacket.cs
+++ b/NebulaModel/Packets/Factory/Monitor/SpeakerSettingUpdatePacket.cs
@@ -1,0 +1,33 @@
+﻿namespace NebulaModel.Packets.Factory.Monitor
+{
+    public class SpeakerSettingUpdatePacket
+    {
+        public int PlanetId { get; set; }
+        public int SpeakerId { get; set; }
+        public SpeakerSettingEvent Event { get; set; }
+        public int Parameter1 { get; set; }
+        public int Parameter2 { get; set; }
+
+        public SpeakerSettingUpdatePacket() { }
+        public SpeakerSettingUpdatePacket(int planetId, int speakerId, SpeakerSettingEvent settingEvent, int parameter1, int parameter2)
+        {
+            PlanetId = planetId;
+            SpeakerId = speakerId;
+            Event = settingEvent;
+            Parameter1 = parameter1;
+            Parameter2 = parameter2;
+        }
+        public SpeakerSettingUpdatePacket(int planetId, int speakerId, SpeakerSettingEvent settingEvent, int parameter)
+            : this(planetId, speakerId, settingEvent, parameter, 0) { }
+    }
+
+    public enum SpeakerSettingEvent
+    {
+        SetTone = 0,
+        SetVolume = 1,
+        SetPitch = 2,
+        SetLength = 3,
+        SetRepeat = 4,
+        SetFalloffRadius = 5
+    }
+}

--- a/NebulaModel/Packets/Warning/WarningDataPacket.cs
+++ b/NebulaModel/Packets/Warning/WarningDataPacket.cs
@@ -1,0 +1,11 @@
+﻿namespace NebulaModel.Packets.Warning
+{
+    public class WarningDataPacket
+    {
+        public int ActiveWarningCount { get; set; }
+        public int Tick { get; set; }
+        public byte[] BinaryData { get; set; }
+
+        public WarningDataPacket() { }
+    }
+}

--- a/NebulaModel/Packets/Warning/WarningDataRequest.cs
+++ b/NebulaModel/Packets/Warning/WarningDataRequest.cs
@@ -1,0 +1,19 @@
+﻿namespace NebulaModel.Packets.Warning
+{
+    public class WarningDataRequest
+    {
+        public WarningRequestEvent Event { get; set; }
+
+        public WarningDataRequest() { }
+        public WarningDataRequest(WarningRequestEvent requestEvent)
+        {
+            Event = requestEvent;
+        }
+    }
+
+    public enum WarningRequestEvent
+    {
+        Signal = 0,
+        Data = 1
+    }
+}

--- a/NebulaModel/Packets/Warning/WarningSignalPacket.cs
+++ b/NebulaModel/Packets/Warning/WarningSignalPacket.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NebulaModel.Packets.Warning
+{
+    public class WarningSignalPacket
+    {
+        public int SignalCount { get; set; }
+        public int[] Signals { get; set; }
+        public int[] Counts { get; set; }
+        public int Tick { get; set; }
+
+        public WarningSignalPacket() { }
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Factory/Entity/EntityWarningSwitchProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Entity/EntityWarningSwitchProcessor.cs
@@ -1,0 +1,37 @@
+﻿using NebulaAPI;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Factory;
+
+namespace NebulaNetwork.PacketProcessors.Factory.Entity
+{
+    [RegisterPacketProcessor]
+    class EntityWarningSwitchProcessor : PacketProcessor<EntityWarningSwitchPacket>
+    {
+        public override void ProcessPacket(EntityWarningSwitchPacket packet, NebulaConnection conn)
+        {
+            PlanetFactory factory = GameMain.galaxy.PlanetById(packet.PlanetId)?.factory;
+            EntityData[] pool = factory?.entityPool;
+            if (pool != null && packet.EntityId > 0 && packet.EntityId < pool.Length && pool[packet.EntityId].id == packet.EntityId)
+            {
+                if (IsHost)
+                {
+                    if (packet.Enable && pool[packet.EntityId].warningId == 0)
+                    {
+                        GameMain.data.warningSystem.NewWarningData(factory.index, packet.EntityId, 0);
+                    }
+                    else if (!packet.Enable)
+                    {
+                        GameMain.data.warningSystem.RemoveWarningData(pool[packet.EntityId].warningId);
+                        pool[packet.EntityId].warningId = 0;
+                    }
+                }
+                else
+                {
+                    //Use dummy warningId on client side
+                    pool[packet.EntityId].warningId = packet.Enable ? 1 : 0;
+                }
+            }
+        }
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Factory/Monitor/MonitorSettingUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Monitor/MonitorSettingUpdateProcessor.cs
@@ -105,7 +105,7 @@ namespace NebulaNetwork.PacketProcessors.Factory.Monitor
                     }
                 }
             }
-            else
+            else if (pool != null)
             {
                 Log.Warn($"MonitorSettingUpdatePacket: Can't find monitor ({packet.PlanetId}, {packet.MonitorId})");
             }

--- a/NebulaNetwork/PacketProcessors/Factory/Monitor/MonitorSettingUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Monitor/MonitorSettingUpdateProcessor.cs
@@ -1,0 +1,114 @@
+﻿using NebulaAPI;
+using NebulaModel.Logger;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Factory.Monitor;
+using NebulaWorld;
+using NebulaWorld.Warning;
+using UnityEngine;
+
+namespace NebulaNetwork.PacketProcessors.Factory.Monitor
+{
+    [RegisterPacketProcessor]
+    internal class MonitorSettingUpdateProcessor : PacketProcessor<MonitorSettingUpdatePacket>
+    {
+        public override void ProcessPacket(MonitorSettingUpdatePacket packet, NebulaConnection conn)
+        {
+            MonitorComponent[] pool = GameMain.galaxy.PlanetById(packet.PlanetId)?.factory?.cargoTraffic?.monitorPool;
+            if (pool != null && packet.MonitorId > 0 && packet.MonitorId < pool.Length && pool[packet.MonitorId].id == packet.MonitorId)
+            {
+                using (Multiplayer.Session.Warning.IsIncomingMonitorPacket.On())
+                {
+                    
+                    switch (packet.Event)
+                    {
+                        case MonitorSettingEvent.SetPassColorId:
+                            pool[packet.MonitorId].SetPassColorId((byte)packet.Parameter1);
+                            break;
+
+                        case MonitorSettingEvent.SetFailColorId:
+                            pool[packet.MonitorId].SetFailColorId((byte)packet.Parameter1);
+                            break;
+
+                        case MonitorSettingEvent.SetPassOperator:
+                            pool[packet.MonitorId].SetPassOperator((byte)packet.Parameter1);
+                            break;
+
+                        case MonitorSettingEvent.SetMonitorMode:
+                            pool[packet.MonitorId].SetMonitorMode((byte)packet.Parameter1);
+                            break;
+
+                        case MonitorSettingEvent.SetSystemWarningMode:
+                            pool[packet.MonitorId].SetSystemWarningMode(packet.Parameter1);
+                            break;
+
+                        case MonitorSettingEvent.SetSystemWarningSignalId:
+                            pool[packet.MonitorId].SetSystemWarningSignalId(packet.Parameter1);
+                            break;
+
+                        case MonitorSettingEvent.SetCargoFilter:
+                            pool[packet.MonitorId].SetCargoFilter(packet.Parameter1);
+                            break;
+
+                        case MonitorSettingEvent.SetTargetCargoBytes:
+                            pool[packet.MonitorId].SetTargetCargoBytes(packet.Parameter1);
+                            break;
+
+                        case MonitorSettingEvent.SetPeriodTickCount:
+                            pool[packet.MonitorId].SetPeriodTickCount(packet.Parameter1);
+                            break;
+
+                        case MonitorSettingEvent.SetTargetBelt:
+                            pool[packet.MonitorId].SetTargetBelt(packet.Parameter1, packet.Parameter2);
+                            break;
+
+                        default:
+                            Log.Warn($"MonitorSettingUpdatePacket: Unkown MonitorSettingEvent {packet.Event}");
+                            break;
+                    }
+
+                    //Update UI Window too if it is viewing the current monitor
+                    UIMonitorWindow uIMonitor = UIRoot.instance.uiGame.monitorWindow;
+                    if (uIMonitor.monitorId == packet.MonitorId && uIMonitor.factory != null && uIMonitor.factory.planetId == packet.PlanetId)
+                    {
+                        switch (packet.Event)
+                        {
+                            case MonitorSettingEvent.SetMonitorMode:
+                                if (packet.Parameter1 == 0) 
+                                {
+                                    uIMonitor.TryCloseSpeakerPanel();
+                                }
+                                else
+                                {
+                                    uIMonitor.TryOpenSpeakerPanel();
+                                }
+                                break;
+
+                            case MonitorSettingEvent.SetSystemWarningSignalId:
+                                Sprite sprite = LDB.signals.IconSprite(packet.Parameter1);
+                                uIMonitor.iconTagImage.sprite = sprite ?? uIMonitor.tagNotSelectedSprite;
+                                break;
+
+                            case MonitorSettingEvent.SetCargoFilter:
+                                Sprite sprite2 = LDB.items.Select(packet.Parameter1)?.iconSprite;
+                                uIMonitor.cargoFilterImage.sprite = sprite2 ?? uIMonitor.cargoFilterNotSelectedSprite;
+                                break;
+
+                            case MonitorSettingEvent.SetPeriodTickCount:
+                                uIMonitor.updateTimestamp = 0L;
+                                break;
+
+                            default:
+                                break;
+                        }
+                        uIMonitor.RefreshMonitorWindow();
+                    }
+                }
+            }
+            else
+            {
+                Log.Warn($"MonitorSettingUpdatePacket: Can't find monitor ({packet.PlanetId}, {packet.MonitorId})");
+            }
+        }
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Factory/Monitor/SpeakerSettingUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Monitor/SpeakerSettingUpdateProcessor.cs
@@ -1,0 +1,89 @@
+﻿using NebulaAPI;
+using NebulaModel.Logger;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Factory.Monitor;
+using NebulaWorld;
+using System;
+
+namespace NebulaNetwork.PacketProcessors.Factory.Monitor
+{
+    [RegisterPacketProcessor]
+    internal class SpeakerSettingUpdateProcessor : PacketProcessor<SpeakerSettingUpdatePacket>
+    {
+        public override void ProcessPacket(SpeakerSettingUpdatePacket packet, NebulaConnection conn)
+        {
+            SpeakerComponent[] pool = GameMain.galaxy.PlanetById(packet.PlanetId)?.factory?.digitalSystem?.speakerPool;
+            if (pool != null && packet.SpeakerId > 0 && packet.SpeakerId < pool.Length && pool[packet.SpeakerId].id == packet.SpeakerId)
+            {
+                using (Multiplayer.Session.Warning.IsIncomingMonitorPacket.On())
+                {
+
+                    switch (packet.Event)
+                    {
+                        case SpeakerSettingEvent.SetTone:
+                            pool[packet.SpeakerId].SetTone(packet.Parameter1);
+                            break;
+
+                        case SpeakerSettingEvent.SetVolume:
+                            pool[packet.SpeakerId].SetVolume(packet.Parameter1);
+                            break;
+
+                        case SpeakerSettingEvent.SetPitch:
+                            pool[packet.SpeakerId].SetPitch(packet.Parameter1);
+                            break;
+
+                        case SpeakerSettingEvent.SetLength:
+                            float p0 = BitConverter.ToSingle(BitConverter.GetBytes(packet.Parameter1), 0);
+                            pool[packet.SpeakerId].SetLength(p0);
+                            break;
+
+                        case SpeakerSettingEvent.SetRepeat:
+                            pool[packet.SpeakerId].SetRepeat(packet.Parameter1 == 0 ? false : true);
+                            break;
+
+                        case SpeakerSettingEvent.SetFalloffRadius:
+                            float p1 = BitConverter.ToSingle(BitConverter.GetBytes(packet.Parameter1), 0);
+                            float p2 = BitConverter.ToSingle(BitConverter.GetBytes(packet.Parameter2), 0);
+                            pool[packet.SpeakerId].SetFalloffRadius(p1, p2);
+                            break;
+
+                        default:
+                            Log.Warn($"SpeakerSettingUpdatePacket: Unkown SpeakerSettingEvent {packet.Event}");
+                            break;
+                    }
+
+                    //Update UI Panel too if it is viewing the current speaker
+                    UISpeakerPanel uISpeaker = UIRoot.instance.uiGame.monitorWindow.speakerPanel;
+                    if (uISpeaker.speakerId == packet.SpeakerId && uISpeaker.factory != null && uISpeaker.factory.planetId == packet.PlanetId)
+                    {
+                        switch (packet.Event)
+                        {
+                            case SpeakerSettingEvent.SetRepeat:
+                            case SpeakerSettingEvent.SetPitch:
+                            case SpeakerSettingEvent.SetLength:
+                                uISpeaker.valueChangeCountDown = 0.5f;
+                                break;
+
+                            case SpeakerSettingEvent.SetFalloffRadius:
+                                if (uISpeaker.factory.entityPool != null)
+                                {
+                                    int audioId = uISpeaker.factory.entityPool[pool[packet.SpeakerId].entityId].audioId;
+                                    uISpeaker.factory.planet.audio?.ChangeAudioDataFalloff(audioId, pool[packet.SpeakerId].falloffRadius0, pool[packet.SpeakerId].falloffRadius1);
+                                }
+                                break;
+
+                            default:
+                                break;
+                        }
+                        uISpeaker.RefreshSpeakerPanel();
+                    }
+                }
+            }
+            else
+            {
+                Log.Warn($"SpeakerSettingUpdatePacket: Can't find speaker ({packet.PlanetId}, {packet.SpeakerId})");
+            }
+        }
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Factory/Monitor/SpeakerSettingUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Monitor/SpeakerSettingUpdateProcessor.cs
@@ -80,7 +80,7 @@ namespace NebulaNetwork.PacketProcessors.Factory.Monitor
                     }
                 }
             }
-            else
+            else if (pool != null)
             {
                 Log.Warn($"SpeakerSettingUpdatePacket: Can't find speaker ({packet.PlanetId}, {packet.SpeakerId})");
             }

--- a/NebulaNetwork/PacketProcessors/Warning/WarningDataProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Warning/WarningDataProcessor.cs
@@ -14,7 +14,7 @@ namespace NebulaNetwork.PacketProcessors.Warning
             Multiplayer.Session.Warning.TickData = packet.Tick;
             using (BinaryUtils.Reader reader = new BinaryUtils.Reader(packet.BinaryData))
             {
-                Multiplayer.Session.Warning.ImporBinaryData(reader.BinaryReader, packet.ActiveWarningCount);
+                Multiplayer.Session.Warning.ImportBinaryData(reader.BinaryReader, packet.ActiveWarningCount);
             }
         }
     }

--- a/NebulaNetwork/PacketProcessors/Warning/WarningDataProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Warning/WarningDataProcessor.cs
@@ -1,0 +1,21 @@
+﻿using NebulaAPI;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Warning;
+using NebulaWorld;
+
+namespace NebulaNetwork.PacketProcessors.Warning
+{
+    [RegisterPacketProcessor]
+    internal class WarningDataProcessor : PacketProcessor<WarningDataPacket>
+    {
+        public override void ProcessPacket(WarningDataPacket packet, NebulaConnection conn)
+        {
+            Multiplayer.Session.Warning.TickData = packet.Tick;
+            using (BinaryUtils.Reader reader = new BinaryUtils.Reader(packet.BinaryData))
+            {
+                Multiplayer.Session.Warning.ImporBinaryData(reader.BinaryReader, packet.ActiveWarningCount);
+            }
+        }
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Warning/WarningDataRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Warning/WarningDataRequestProcessor.cs
@@ -1,0 +1,17 @@
+﻿using NebulaAPI;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Warning;
+using NebulaWorld;
+
+namespace NebulaNetwork.PacketProcessors.Warning
+{
+    [RegisterPacketProcessor]
+    internal class WarningDataRequestProcessor : PacketProcessor<WarningDataRequest>
+    {
+        public override void ProcessPacket(WarningDataRequest packet, NebulaConnection conn)
+        {
+            Multiplayer.Session.Warning.HandleRequest(packet, conn);
+        }
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Warning/WarningSignalProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Warning/WarningSignalProcessor.cs
@@ -1,0 +1,30 @@
+﻿using NebulaAPI;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Warning;
+using NebulaWorld;
+using System;
+
+namespace NebulaNetwork.PacketProcessors.Warning
+{
+    [RegisterPacketProcessor]
+    internal class WarningSignalProcessor : PacketProcessor<WarningSignalPacket>
+    {
+        public override void ProcessPacket(WarningSignalPacket packet, NebulaConnection conn)
+        {
+            WarningSystem ws = GameMain.data.warningSystem;
+            Array.Clear(ws.warningCounts, 0, ws.warningCounts.Length);
+            Array.Clear(ws.warningSignals, 0, ws.warningSignalCount);
+
+            ws.warningSignalCount = packet.SignalCount;
+            for (int i = 0; i < packet.SignalCount; i++)
+            {
+                int signalId = packet.Signals[i];
+                ws.warningSignals[i] = signalId;
+                ws.warningCounts[signalId] = packet.Counts[i];
+            }
+
+            Multiplayer.Session.Warning.TickSignal = packet.Tick;
+        }
+    }
+}

--- a/NebulaNetwork/Server.cs
+++ b/NebulaNetwork/Server.cs
@@ -24,12 +24,14 @@ namespace NebulaNetwork
         private const float STATISTICS_UPDATE_INTERVAL = 1;
         private const float LAUNCH_UPDATE_INTERVAL = 2;
         private const float DYSONSPHERE_UPDATE_INTERVAL = 5;
+        private const float WARNING_UPDATE_INTERVAL = 1;
 
         private float gameStateUpdateTimer = 0;
         private float gameResearchHashUpdateTimer = 0;
         private float productionStatisticsUpdateTimer = 0;
         private float dysonLaunchUpateTimer = 1;
         private float dysonSphereUpdateTimer = 0;
+        private float warningUpdateTimer = 0;
 
         private WebSocketServer socket;
 
@@ -128,7 +130,8 @@ namespace NebulaNetwork
             gameResearchHashUpdateTimer += Time.deltaTime;
             productionStatisticsUpdateTimer += Time.deltaTime;
             dysonLaunchUpateTimer += Time.deltaTime;
-            dysonSphereUpdateTimer += Time.deltaTime;            
+            dysonSphereUpdateTimer += Time.deltaTime;
+            warningUpdateTimer += Time.deltaTime;
 
             if (gameStateUpdateTimer > GAME_STATE_UPDATE_INTERVAL)
             {
@@ -170,6 +173,12 @@ namespace NebulaNetwork
                         SendPacketToStar(new DysonSphereStatusPacket(dysonSphere), dysonSphere.starData.id);
                     }
                 }
+            }
+
+            if (warningUpdateTimer > WARNING_UPDATE_INTERVAL)
+            {
+                warningUpdateTimer = 0;
+                Multiplayer.Session.Warning.SendBroadcastIfNeeded();
             }
 
             PacketProcessor.ProcessPacketQueue();

--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -283,11 +283,6 @@ namespace NebulaPatcher.Patches.Dynamic
                             }
                         }
                     }
-                    // we need to reset the warning system to avoid nre for clients when they leave the solar system. this is related to the new traffic monitor
-                    // as we also free factory data this should be fine.
-                    // warnings should be triggered by some other syncing mechanic issued by the host (or find a better solution for this if you are not so tired as i am now)
-                    GameMain.data.warningSystem.Free();
-                    GameMain.data.warningSystem.Init(GameMain.data);
                 }
                 if (!Multiplayer.Session.IsInLobby)
                 {

--- a/NebulaPatcher/Patches/Dynamic/MonitorComponent_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/MonitorComponent_Patch.cs
@@ -1,0 +1,136 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+using NebulaModel.Packets.Factory.Monitor;
+using NebulaWorld.Warning;
+using UnityEngine;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+#pragma warning disable Harmony003 // Harmony non-ref patch parameters modified
+    [HarmonyPatch(typeof(MonitorComponent))]
+    internal class MonitorComponent_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(MonitorComponent.SetPassColorId))]
+        public static void SetPassColorId_Prefix(MonitorComponent __instance, byte __0)
+        {
+            if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
+            {
+                //Assume the monitor is on local planet
+                int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
+                Multiplayer.Session.Network.SendPacketToLocalStar(
+                    new MonitorSettingUpdatePacket(planetId, __instance.id, MonitorSettingEvent.SetPassColorId, __0));                
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(MonitorComponent.SetFailColorId))]
+        public static void SetFailColorId_Prefix(MonitorComponent __instance, int __0)
+        {
+            if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
+            {
+                int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
+                Multiplayer.Session.Network.SendPacketToLocalStar(
+                    new MonitorSettingUpdatePacket(planetId, __instance.id, MonitorSettingEvent.SetFailColorId, __0));
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(MonitorComponent.SetPassOperator))]
+        public static void SetPassOperator_Prefix(MonitorComponent __instance, int __0)
+        {
+            if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
+            {
+                int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
+                Multiplayer.Session.Network.SendPacketToLocalStar(
+                    new MonitorSettingUpdatePacket(planetId, __instance.id, MonitorSettingEvent.SetPassOperator, __0));
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(MonitorComponent.SetMonitorMode))]
+        public static void SetMonitorMode_Prefix(MonitorComponent __instance, int __0)
+        {
+            if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
+            {
+                int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
+                Multiplayer.Session.Network.SendPacketToLocalStar(
+                    new MonitorSettingUpdatePacket(planetId, __instance.id, MonitorSettingEvent.SetMonitorMode, __0));
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(MonitorComponent.SetSystemWarningMode))]
+        public static void SetSystemWarningMode_Prefix(MonitorComponent __instance, int __0)
+        {
+            if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
+            {
+                int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
+                Multiplayer.Session.Network.SendPacketToLocalStar(
+                    new MonitorSettingUpdatePacket(planetId, __instance.id, MonitorSettingEvent.SetSystemWarningMode, __0));
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(MonitorComponent.SetSystemWarningSignalId))]
+        public static void SetSystemWarningSignalId_Prefix(MonitorComponent __instance, int __0)
+        {
+            if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
+            {
+                int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
+                Multiplayer.Session.Network.SendPacketToLocalStar(
+                    new MonitorSettingUpdatePacket(planetId, __instance.id, MonitorSettingEvent.SetSystemWarningSignalId, __0));
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(MonitorComponent.SetCargoFilter))]
+        public static void SetCargoFilter_Prefix(MonitorComponent __instance, int __0)
+        {
+            if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
+            {
+                int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
+                Multiplayer.Session.Network.SendPacketToLocalStar(
+                    new MonitorSettingUpdatePacket(planetId, __instance.id, MonitorSettingEvent.SetCargoFilter, __0));
+            }
+        }        
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(MonitorComponent.SetTargetCargoBytes))]
+        public static void SSetTargetCargoBytes_Prefix(MonitorComponent __instance, int __0)
+        {
+            if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
+            {
+                int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
+                Multiplayer.Session.Network.SendPacketToLocalStar(
+                    new MonitorSettingUpdatePacket(planetId, __instance.id, MonitorSettingEvent.SetTargetCargoBytes, __0));
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(MonitorComponent.SetPeriodTickCount))]
+        public static void SetPeriodTickCount_Prefix(MonitorComponent __instance, int __0)
+        {
+            if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
+            {
+                int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
+                Multiplayer.Session.Network.SendPacketToLocalStar(
+                    new MonitorSettingUpdatePacket(planetId, __instance.id, MonitorSettingEvent.SetPeriodTickCount, __0));
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(MonitorComponent.SetTargetBelt))]
+        public static void SetTargetBelt_Prefix(MonitorComponent __instance, int __0, int __1)
+        {
+            //This is required for putting monitor over belt works properly
+            if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
+            {
+                int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
+                Multiplayer.Session.Network.SendPacketToLocalStar(
+                    new MonitorSettingUpdatePacket(planetId, __instance.id, MonitorSettingEvent.SetTargetBelt, __0, __1));
+            }
+        }
+    }
+#pragma warning restore Harmony003 // Harmony non-ref patch parameters modified
+}

--- a/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
@@ -172,5 +172,30 @@ namespace NebulaPatcher.Patches.Dynamic
                 }
             }
         }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(PlanetFactory.EnableEntityWarning))]
+        public static void EnableEntityWarning_Postfix(PlanetFactory __instance, int entityId)
+        {
+            if (Multiplayer.IsActive && entityId > 0 && __instance.entityPool[entityId].id == entityId)
+            {
+                if (Multiplayer.Session.LocalPlayer.IsClient)
+                {
+                    //Becasue WarningSystem.NewWarningData is blocked on client, we give it a dummy warningId
+                    __instance.entityPool[entityId].warningId = 1;
+                }
+                Multiplayer.Session.Network.SendPacketToLocalStar(new EntityWarningSwitchPacket(__instance.planetId, entityId, true));
+            }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(PlanetFactory.DisableEntityWarning))]
+        public static void DisableEntityWarning_Postfix(PlanetFactory __instance, int entityId)
+        {
+            if (Multiplayer.IsActive && entityId > 0 && __instance.entityPool[entityId].id == entityId)
+            {
+                Multiplayer.Session.Network.SendPacketToLocalStar(new EntityWarningSwitchPacket(__instance.planetId, entityId, false));
+            }
+        }
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/PowerSystem_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PowerSystem_Patch.cs
@@ -11,7 +11,10 @@ namespace NebulaPatcher.Patches.Dynamic
         public static void PowerSystem_GameTick_Prefix(long time, ref bool isActive)
         {
             //Enable signType update on remote planet every 64 tick
-            isActive |= (time & 63) == 0;
+            if ((time & 63) == 0 && Multiplayer.IsActive && Multiplayer.Session.LocalPlayer.IsHost)
+            {
+                isActive |= true;
+            }
         }
 
         [HarmonyPostfix]

--- a/NebulaPatcher/Patches/Dynamic/PowerSystem_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PowerSystem_Patch.cs
@@ -6,6 +6,14 @@ namespace NebulaPatcher.Patches.Dynamic
     [HarmonyPatch(typeof(PowerSystem))]
     internal class PowerSystem_Patch
     {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(PowerSystem.GameTick))]
+        public static void PowerSystem_GameTick_Prefix(long time, ref bool isActive)
+        {
+            //Enable signType update on remote planet every 64 tick
+            isActive |= (time & 63) == 0;
+        }
+
         [HarmonyPostfix]
         [HarmonyPatch(nameof(PowerSystem.GameTick))]
         public static void PowerSystem_GameTick_Postfix(PowerSystem __instance, long time, bool isActive, bool isMultithreadMode)

--- a/NebulaPatcher/Patches/Dynamic/SpeakerComponent_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/SpeakerComponent_Patch.cs
@@ -1,0 +1,92 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+using NebulaModel.Packets.Factory.Monitor;
+using NebulaModel.Logger;
+using System;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+#pragma warning disable Harmony003 // Harmony non-ref patch parameters modified
+    [HarmonyPatch(typeof(SpeakerComponent))]
+    internal class SpeakerComponent_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(SpeakerComponent.SetTone))]
+        public static void SetPassColorId_Prefix(MonitorComponent __instance, int __0)
+        {
+            if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
+            {
+                //Assume the monitor is on local planet
+                int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
+                Multiplayer.Session.Network.SendPacketToLocalStar(
+                    new SpeakerSettingUpdatePacket(planetId, __instance.id, SpeakerSettingEvent.SetTone, __0));
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(SpeakerComponent.SetVolume))]
+        public static void SetVolume_Prefix(MonitorComponent __instance, int __0)
+        {
+            if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
+            {
+                int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
+                Multiplayer.Session.Network.SendPacketToLocalStar(
+                    new SpeakerSettingUpdatePacket(planetId, __instance.id, SpeakerSettingEvent.SetVolume, __0));
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(SpeakerComponent.SetPitch))]
+        public static void SetPitch_Prefix(MonitorComponent __instance, int __0)
+        {
+            if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
+            {
+                int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
+                Multiplayer.Session.Network.SendPacketToLocalStar(
+                    new SpeakerSettingUpdatePacket(planetId, __instance.id, SpeakerSettingEvent.SetPitch, __0));
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(SpeakerComponent.SetLength))]
+        public static void SetLength_Prefix(MonitorComponent __instance, float __0)
+        {
+            Log.Info($"SetLength {__0} {Multiplayer.Session.Warning.IsIncomingMonitorPacket == true}");
+            if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
+            {
+                int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
+                int p1 = BitConverter.ToInt32(BitConverter.GetBytes(__0), 0);
+                Multiplayer.Session.Network.SendPacketToLocalStar(
+                    new SpeakerSettingUpdatePacket(planetId, __instance.id, SpeakerSettingEvent.SetLength, p1));                
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(SpeakerComponent.SetRepeat))]
+        public static void SetLength_Prefix(MonitorComponent __instance, bool __0)
+        {
+            if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
+            {
+                int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
+                Multiplayer.Session.Network.SendPacketToLocalStar(
+                    new SpeakerSettingUpdatePacket(planetId, __instance.id, SpeakerSettingEvent.SetRepeat, __0 ? 1 : 0));
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(SpeakerComponent.SetFalloffRadius))]
+        public static void SetFalloffRadius_Prefix(MonitorComponent __instance, float __0, float __1)
+        {
+            Log.Info($"SetFalloffRadius {__0} {__1} {Multiplayer.Session.Warning.IsIncomingMonitorPacket == true}");
+            if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
+            {
+                int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
+                int p1 = BitConverter.ToInt32(BitConverter.GetBytes(__0), 0);
+                int p2 = BitConverter.ToInt32(BitConverter.GetBytes(__1), 0);
+                Multiplayer.Session.Network.SendPacketToLocalStar(
+                    new SpeakerSettingUpdatePacket(planetId, __instance.id, SpeakerSettingEvent.SetFalloffRadius, p1, p2));
+            }
+        }
+    }
+#pragma warning restore Harmony003 // Harmony non-ref patch parameters modified
+}

--- a/NebulaPatcher/Patches/Dynamic/WarningSystem_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/WarningSystem_Patch.cs
@@ -1,22 +1,17 @@
 ﻿using HarmonyLib;
+using NebulaWorld;
 
 namespace NebulaPatcher.Patches.Dynamic
 {
     [HarmonyPatch(typeof(WarningSystem))]
     class WarningSystem_Patch
     {
-        /*
-         * Until we have a proper syncing of this system we avoid index out of bounds by skipping the method if needed.
-         */
         [HarmonyPrefix]
+        [HarmonyPatch(typeof(WarningSystem), nameof(WarningSystem.NewWarningData))]
         [HarmonyPatch(typeof(WarningSystem), nameof(WarningSystem.RemoveWarningData))]
-        public static bool RemoveWarningData_Prefix(WarningSystem __instance, int id)
+        public static bool AlterWarningData_Prefix()
         {
-            if(id > __instance.warningCursor)
-            {
-                return false;
-            }
-            return true;
+            return !Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost;
         }
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/WarningSystem_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/WarningSystem_Patch.cs
@@ -1,17 +1,38 @@
 ﻿using HarmonyLib;
+using NebulaModel.Packets.Warning;
 using NebulaWorld;
 
 namespace NebulaPatcher.Patches.Dynamic
 {
     [HarmonyPatch(typeof(WarningSystem))]
-    class WarningSystem_Patch
+    internal class WarningSystem_Patch
     {
         [HarmonyPrefix]
         [HarmonyPatch(typeof(WarningSystem), nameof(WarningSystem.NewWarningData))]
         [HarmonyPatch(typeof(WarningSystem), nameof(WarningSystem.RemoveWarningData))]
+        [HarmonyPatch(typeof(WarningSystem), nameof(WarningSystem.WarningLogic))]
         public static bool AlterWarningData_Prefix()
         {
+            //Let warningPool only be updated by packet
             return !Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(WarningSystem), nameof(WarningSystem.CalcFocusDetail))]
+        public static void CalcFocusDetail_Prefix(int __0)
+        {
+            if (__0 == 0 || !Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost)
+            {
+                return;
+            }
+            if (Multiplayer.Session.Warning.TickSignal != Multiplayer.Session.Warning.TickData)
+            {
+                if (GameMain.gameTick - Multiplayer.Session.Warning.LastRequestTime > 240)
+                {
+                    Multiplayer.Session.Network.SendPacket(new WarningDataRequest(WarningRequestEvent.Data));
+                    Multiplayer.Session.Warning.LastRequestTime = GameMain.gameTick;
+                }
+            }
         }
     }
 }

--- a/NebulaWorld/MultiplayerSession.cs
+++ b/NebulaWorld/MultiplayerSession.cs
@@ -9,6 +9,7 @@ using NebulaWorld.Player;
 using NebulaWorld.Statistics;
 using NebulaWorld.Trash;
 using NebulaWorld.Universe;
+using NebulaWorld.Warning;
 using System;
 
 namespace NebulaWorld
@@ -32,6 +33,7 @@ namespace NebulaWorld
         public TrashManager Trashes { get; private set; }
         public DysonSphereManager DysonSpheres { get; private set; }
         public LaunchManager Launch { get; private set; }
+        public WarningManager Warning { get; private set; }
 
         // Some Patch Flags
         public bool IsTankWindowPointerPress { get; set; }
@@ -71,6 +73,7 @@ namespace NebulaWorld
             Trashes = new TrashManager();
             DysonSpheres = new DysonSphereManager();
             Launch = new LaunchManager();
+            Warning = new WarningManager();
         }
 
         public void Dispose()
@@ -125,6 +128,9 @@ namespace NebulaWorld
 
             Launch?.Dispose();
             Launch = null;
+
+            Warning?.Dispose();
+            Warning = null;
         }
 
         public void OnGameLoadCompleted()

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -4,6 +4,7 @@ using NebulaModel.Logger;
 using NebulaModel.Packets.Players;
 using NebulaModel.Packets.Session;
 using NebulaModel.Packets.Trash;
+using NebulaModel.Packets.Warning;
 using NebulaModel.Utils;
 using NebulaWorld.MonoBehaviours;
 using NebulaWorld.MonoBehaviours.Local;
@@ -128,6 +129,9 @@ namespace NebulaWorld
 
                 // Subscribe for the local star events
                 Multiplayer.Session.Network.SendPacket(new PlayerUpdateLocalStarId(GameMain.data.localStar.id));
+
+                // Request latest warning signal
+                Multiplayer.Session.Network.SendPacket(new WarningDataRequest(WarningRequestEvent.Signal));
 
                 // Hide the "Joining Game" popup
                 InGamePopup.FadeOut();

--- a/NebulaWorld/Warning/WarningManager.cs
+++ b/NebulaWorld/Warning/WarningManager.cs
@@ -1,0 +1,164 @@
+﻿using NebulaModel.Networking;
+using NebulaModel.Packets.Warning;
+using System;
+using System.IO;
+using System.Collections.Concurrent;
+
+
+namespace NebulaWorld.Warning
+{
+    public class WarningManager : IDisposable
+    {
+        public int TickSignal { get; set; }
+        public int TickData { get; set; }
+        public long LastRequestTime { get; set; }
+
+        private ConcurrentBag<NebulaConnection> requesters;
+        private WarningSystem ws;
+        private WarningSignalPacket warningSignalPacket;
+        private WarningDataPacket warningDataPacket;
+        private int idleCycle;
+
+        public WarningManager()
+        {            
+            requesters = new ConcurrentBag<NebulaConnection>();
+            warningSignalPacket = new WarningSignalPacket();
+            warningSignalPacket.Signals = new int[8];
+            warningSignalPacket.Counts = new int[8];
+            warningDataPacket = new WarningDataPacket();
+        }
+
+        public void Dispose()
+        {
+            requesters = null;
+            warningSignalPacket = null;
+            warningDataPacket = null;
+        }
+
+        public void HandleRequest(WarningDataRequest packet, NebulaConnection conn)
+        {
+            if (packet.Event == WarningRequestEvent.Signal)
+            {
+                conn.SendPacket(warningSignalPacket);
+            }
+            else
+            {
+                if (warningSignalPacket.Tick == warningDataPacket.Tick)
+                {
+                    // warningDataPacket is latest, no need to update
+                    conn.SendPacket(warningDataPacket);
+                }
+                else
+                {
+                    // Send warningDataPacket after updating is done
+                    requesters.Add(conn);
+                }
+            }
+        }
+
+        public void SendBroadcastIfNeeded()
+        {
+            ws = GameMain.data.warningSystem;
+            bool hasChanged = CheckAndUpdateSignal();
+            if (hasChanged)
+            {                
+                warningSignalPacket.Tick = unchecked((int)GameMain.gameTick);
+                Multiplayer.Session.Network.SendPacket(warningSignalPacket);
+                idleCycle = 0;
+            }
+            else
+            {
+                if (++idleCycle > 60)
+                {
+                    // In case of warning content is changed but signal stays the same, force update
+                    warningSignalPacket.Tick = unchecked((int)GameMain.gameTick);
+                    Multiplayer.Session.Network.SendPacket(warningSignalPacket);
+                    idleCycle = 0;
+                }
+            }
+            if (!requesters.IsEmpty)
+            {
+                using (BinaryUtils.Writer writer = new BinaryUtils.Writer())
+                {
+                    warningDataPacket.ActiveWarningCount = ExportBinaryData(writer.BinaryWriter);
+                    warningDataPacket.BinaryData = writer.CloseAndGetBytes();
+                    warningDataPacket.Tick = warningSignalPacket.Tick;
+                }
+                while (requesters.TryTake(out NebulaConnection conn))
+                {
+                    conn.SendPacket(warningDataPacket);
+                }
+            }
+        }
+
+        public bool CheckAndUpdateSignal()
+        {
+            bool hasChanged = warningSignalPacket.SignalCount != ws.warningSignalCount;
+            warningSignalPacket.SignalCount = ws.warningSignalCount;
+            if (hasChanged)
+            {
+                warningSignalPacket.SignalCount = ws.warningSignalCount;
+                warningSignalPacket.Signals = new int[warningSignalPacket.SignalCount];
+                warningSignalPacket.Counts = new int[warningSignalPacket.SignalCount];
+            }
+            for (int i = 0; i < ws.warningSignalCount; i++)
+            {
+                int signalId = ws.warningSignals[i];
+                if (warningSignalPacket.Signals[i] != signalId || warningSignalPacket.Counts[i] != ws.warningCounts[signalId])
+                {
+                    warningSignalPacket.Signals[i] = signalId;
+                    warningSignalPacket.Counts[i] = ws.warningCounts[signalId];
+                    hasChanged = true;
+                }
+            }
+            
+            return hasChanged;
+        }
+
+        public int ExportBinaryData(BinaryWriter bw)
+        {
+            int activeWarningCount = 0;   
+            WarningData[] warningPool = ws.warningPool;
+            for (int i = 0; i < ws.warningCursor; i++)
+            {
+                WarningData data = warningPool[i];
+                if (data.id == i && data.state > 0)
+                {
+                    bw.Write(data.signalId);
+                    bw.Write(data.detailId);
+                    bw.Write(data.astroId);
+                    bw.Write(data.localPos.x);
+                    bw.Write(data.localPos.y);
+                    bw.Write(data.localPos.z);
+                    activeWarningCount++;
+                }                
+            }
+            return activeWarningCount;
+        }
+
+        public void ImporBinaryData(BinaryReader br, int activeWarningCount)
+        {
+            ws = GameMain.data.warningSystem;
+            while (activeWarningCount > ws.warningCapacity)
+			{
+                ws.warningCapacity *= 2;
+			}
+            ws.SetWarningCapacity(ws.warningCapacity);
+            ws.warningCursor = activeWarningCount;
+
+            //Import warning pool
+            WarningData[] warningPool = GameMain.data.warningSystem.warningPool;
+            for (int i = 0; i < activeWarningCount; i++)
+            {
+                warningPool[i].id = i;
+                warningPool[i].state = 1;
+                warningPool[i].signalId = br.ReadInt32();
+                warningPool[i].detailId = br.ReadInt32();
+                warningPool[i].astroId = br.ReadInt32();
+                warningPool[i].localPos.x = br.ReadSingle();
+                warningPool[i].localPos.y = br.ReadSingle();
+                warningPool[i].localPos.z = br.ReadSingle();
+            }
+        }
+    }
+}

--- a/NebulaWorld/Warning/WarningManager.cs
+++ b/NebulaWorld/Warning/WarningManager.cs
@@ -120,7 +120,8 @@ namespace NebulaWorld.Warning
         {
             int activeWarningCount = 0;   
             WarningData[] warningPool = ws.warningPool;
-            for (int i = 0; i < ws.warningCursor; i++)
+            //index start from 1 in warningPool
+            for (int i = 1; i < ws.warningCursor; i++)
             {
                 WarningData data = warningPool[i];
                 if (data.id == i && data.state > 0)
@@ -140,16 +141,20 @@ namespace NebulaWorld.Warning
         public void ImportBinaryData(BinaryReader br, int activeWarningCount)
         {
             ws = GameMain.data.warningSystem;
-            while (activeWarningCount > ws.warningCapacity)
+            int newCapacity = ws.warningCapacity;
+            while (activeWarningCount + 1 > newCapacity)
 			{
-                ws.warningCapacity *= 2;
+                newCapacity *= 2;
 			}
-            ws.SetWarningCapacity(ws.warningCapacity);
-            ws.warningCursor = activeWarningCount;
+            if (newCapacity > ws.warningCapacity)
+            {
+                ws.SetWarningCapacity(newCapacity);
+            }
+            ws.warningCursor = activeWarningCount + 1;
 
-            //Import warning pool
             WarningData[] warningPool = GameMain.data.warningSystem.warningPool;
-            for (int i = 0; i < activeWarningCount; i++)
+            //index start from 1 in warningPool
+            for (int i = 1; i <= activeWarningCount; i++)
             {
                 warningPool[i].id = i;
                 warningPool[i].state = 1;

--- a/NebulaWorld/Warning/WarningManager.cs
+++ b/NebulaWorld/Warning/WarningManager.cs
@@ -3,12 +3,13 @@ using NebulaModel.Packets.Warning;
 using System;
 using System.IO;
 using System.Collections.Concurrent;
-
+using NebulaModel.DataStructures;
 
 namespace NebulaWorld.Warning
 {
     public class WarningManager : IDisposable
     {
+        public readonly ToggleSwitch IsIncomingMonitorPacket = new ToggleSwitch();
         public int TickSignal { get; set; }
         public int TickData { get; set; }
         public long LastRequestTime { get; set; }

--- a/NebulaWorld/Warning/WarningManager.cs
+++ b/NebulaWorld/Warning/WarningManager.cs
@@ -137,7 +137,7 @@ namespace NebulaWorld.Warning
             return activeWarningCount;
         }
 
-        public void ImporBinaryData(BinaryReader br, int activeWarningCount)
+        public void ImportBinaryData(BinaryReader br, int activeWarningCount)
         {
             ws = GameMain.data.warningSystem;
             while (activeWarningCount > ws.warningCapacity)


### PR DESCRIPTION
- sync alarm switch on the building (PlanetFactory.EnableEnityWarning)
- sync traffic monitor (MonitorComponent & SpeakerComponent)
- host updates global alarm signals when it's necessary every 1s. (warningSignals, warningCounts)
- client sends requests when it needs detailed information. (warningPool)

~~Known issue: "No connection to the power grid", "No power supply to the power grid" can not show in host when client turn on alarm on a different planet.~~ Found the cause, the game set ``isActive`` to false on the remote planet so PowerSystem.GameTick() can't update signType.