### PR TITLE
Fix UpgradeEntityRequest, BuildToolManager

### DIFF
--- a/NebulaModel/Packets/Factory/UpgradeEntityRequest.cs
+++ b/NebulaModel/Packets/Factory/UpgradeEntityRequest.cs
@@ -5,20 +5,16 @@ namespace NebulaModel.Packets.Factory
     public class UpgradeEntityRequest
     {
         public int PlanetId { get; set; }
-        public Float3 pos { get; set; }
-        public Float4 rot { get; set; }
+        public int ObjId { get; set; }
         public int UpgradeProtoId { get; set; }
-        public bool IsPrebuild { get; set; }
         public int AuthorId { get; set; }
 
         public UpgradeEntityRequest() { }
-        public UpgradeEntityRequest(int planetId, Float3 pos, Float4 rot, int upgradeProtoId, bool isPrebuild, int authorId)
+        public UpgradeEntityRequest(int planetId, int objId, int upgradeProtoId, int authorId)
         {
             PlanetId = planetId;
-            this.pos = pos;
-            this.rot = rot;
+            ObjId = objId;
             UpgradeProtoId = upgradeProtoId;
-            IsPrebuild = isPrebuild;
             AuthorId = authorId;
         }
     }

--- a/NebulaPatcher/Patches/Dynamic/BuildTool_Common_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/BuildTool_Common_Patch.cs
@@ -44,7 +44,10 @@ namespace NebulaPatcher.Patches.Dynamic
             //If client builds, he need to first send request to the host and wait for reply
             if (!Multiplayer.Session.LocalPlayer.IsHost && !Multiplayer.Session.Factories.IsIncomingRequest.Value)
             {
-                Multiplayer.Session.Network.SendPacket(new CreatePrebuildsRequest(GameMain.localPlanet?.id ?? -1, previews, Multiplayer.Session.Factories.PacketAuthor == NebulaModAPI.AUTHOR_NONE ? Multiplayer.Session.LocalPlayer.Id : Multiplayer.Session.Factories.PacketAuthor, __instance.GetType().ToString()));
+                if (Multiplayer.Session.BuildTools.InitialCheck(previews[0].lpos))
+                {
+                    Multiplayer.Session.Network.SendPacket(new CreatePrebuildsRequest(GameMain.localPlanet?.id ?? -1, previews, Multiplayer.Session.Factories.PacketAuthor == NebulaModAPI.AUTHOR_NONE ? Multiplayer.Session.LocalPlayer.Id : Multiplayer.Session.Factories.PacketAuthor, __instance.GetType().ToString()));
+                }
                 return false;
             }
             return true;

--- a/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
@@ -79,27 +79,7 @@ namespace NebulaPatcher.Patches.Dynamic
 
             if (Multiplayer.Session.LocalPlayer.IsHost || !Multiplayer.Session.Factories.IsIncomingRequest.Value)
             {
-                bool isPrebuild = false;
-                Vector3 pos;
-                Quaternion rot;
-
-                if (objId > 0)
-                {
-                    // real entity
-                    EntityData eData = __instance.entityPool[objId];
-                    pos = eData.pos;
-                    rot = eData.rot;
-                }
-                else
-                {
-                    // blueprint build preview
-                    PrebuildData pData = __instance.prebuildPool[-objId];
-                    pos = pData.pos;
-                    rot = pData.rot;
-                    isPrebuild = true;
-                }
-
-                Multiplayer.Session.Network.SendPacket(new UpgradeEntityRequest(__instance.planetId, new Float3(pos.x, pos.y, pos.z), new Float4(rot.x, rot.y, rot.z, rot.w), replace_item_proto.ID, isPrebuild, Multiplayer.Session.Factories.PacketAuthor == -1 ? Multiplayer.Session.LocalPlayer.Id : Multiplayer.Session.Factories.PacketAuthor));
+                Multiplayer.Session.Network.SendPacket(new UpgradeEntityRequest(__instance.planetId, objId, replace_item_proto.ID, Multiplayer.Session.Factories.PacketAuthor == -1 ? Multiplayer.Session.LocalPlayer.Id : Multiplayer.Session.Factories.PacketAuthor));
             }
 
             return Multiplayer.Session.LocalPlayer.IsHost || Multiplayer.Session.Factories.IsIncomingRequest.Value;

--- a/NebulaPatcher/Patches/Dynamic/UIGame_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIGame_Patch.cs
@@ -20,5 +20,17 @@ namespace NebulaPatcher.Patches.Dynamic
             __instance.dfSpaceGuideOn = Config.Options.SpaceNavigationEnabled;
             __instance.dfVeinOn = Config.Options.VeinDistributionEnabled;
         }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(UIGame.StarmapChangingToMilkyWay))]
+        public static bool StarmapChangingToMilkyWay_Prefix(UIGame __instance)
+        {
+            if (Multiplayer.IsActive)
+            {
+                InGamePopup.ShowInfo("Access Denied", "Milky Way is disabled in multiplayer game.", "OK");
+                return false;
+            }
+            return true;
+        }
     }
 }

--- a/NebulaWorld/Factory/BuildToolManager.cs
+++ b/NebulaWorld/Factory/BuildToolManager.cs
@@ -9,6 +9,10 @@ namespace NebulaWorld.Factory
 {
     public class BuildToolManager : IDisposable
     {
+        public const long WAIT_TIME = 10000;
+        public Vector3 LastPosition;
+        public long LastCheckTime;
+
         public BuildToolManager()
         {
         }
@@ -61,9 +65,10 @@ namespace NebulaWorld.Factory
                     tmpNearcdLogic = buildTool.actionBuild.nearcdLogic;
                     tmpPlanetPhysics = buildTool.actionBuild.planetPhysics;
                     Multiplayer.Session.Factories.AddPlanetTimer(packet.PlanetId);
-                }
+                }                
 
                 bool incomingBlueprintEvent = packet.BuildToolType == typeof(BuildTool_BlueprintPaste).ToString();
+                Vector3 pos = Vector3.zero;
 
                 //Create Prebuilds from incoming packet and prepare new position
                 List<BuildPreview> tmpList = new List<BuildPreview>();
@@ -72,6 +77,7 @@ namespace NebulaWorld.Factory
                     tmpList.AddRange(buildTool.buildPreviews);
                     buildTool.buildPreviews.Clear();
                     buildTool.buildPreviews.AddRange(packet.GetBuildPreviews());
+                    pos = buildTool.buildPreviews[0].lpos;
                 }
 
                 Multiplayer.Session.Factories.EventFactory = planet.factory;
@@ -80,7 +86,7 @@ namespace NebulaWorld.Factory
                 buildTool.factory = planet.factory;
                 pab.factory = planet.factory;
                 pab.noneTool.factory = planet.factory;
-                if (Multiplayer.Session.Factories.IsIncomingRequest.Value)
+                if (Multiplayer.Session.LocalPlayer.IsHost)
                 {
                     // Only the server needs to set these
                     pab.planetPhysics = planet.physics;
@@ -89,13 +95,13 @@ namespace NebulaWorld.Factory
 
                 //Check if prebuilds can be build (collision check, height check, etc)
                 bool canBuild = false;
-                if (Multiplayer.Session.Factories.IsIncomingRequest.Value)
+                if (Multiplayer.Session.LocalPlayer.IsHost)
                 {
                     GameMain.mainPlayer.mecha.buildArea = float.MaxValue;
                     canBuild = CheckBuildingConnections(buildTool.buildPreviews, planet.factory.entityPool, planet.factory.prebuildPool);
                 }
 
-                if (canBuild || Multiplayer.Session.Factories.IsIncomingRequest.Value)
+                if (canBuild || Multiplayer.Session.LocalPlayer.IsClient)
                 {
                     if (Multiplayer.Session.Factories.IsIncomingRequest.Value)
                     {
@@ -132,6 +138,7 @@ namespace NebulaWorld.Factory
                         bpTool.bpCursor = incomingPreviews.Count;
                         bpTool.bpPool = incomingPreviews.ToArray();
                         bpTool.CreatePrebuilds();
+                        pos = incomingPreviews[0].lpos;
 
                         // Revert to previous data
                         bpTool.bpCursor = previousCursor;
@@ -160,6 +167,13 @@ namespace NebulaWorld.Factory
 
                 Multiplayer.Session.Factories.TargetPlanet = NebulaModAPI.PLANET_NONE;
                 Multiplayer.Session.Factories.PacketAuthor = NebulaModAPI.AUTHOR_NONE;
+
+                if (pos == LastPosition)
+                {
+                    //Reset check timer on client
+                    Log.Info($"Receive {LastPosition}");
+                    LastCheckTime = 0;
+                }
             }
         }
 
@@ -236,6 +250,19 @@ namespace NebulaWorld.Factory
                     }
                 }
             }
+            return true;
+        }
+        
+        public bool InitialCheck(Vector3 pos)
+        {
+            long now = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+            if ((now - LastCheckTime) < WAIT_TIME && LastPosition == pos)
+            {
+                //Stop client from sending prebuilds at the same position
+                return false;
+            }
+            LastCheckTime = now;
+            LastPosition = pos;
             return true;
         }
     }

--- a/NebulaWorld/Factory/FactoryManager.cs
+++ b/NebulaWorld/Factory/FactoryManager.cs
@@ -232,7 +232,8 @@ namespace NebulaWorld.Factory
 
         public void OnNewSetInserterPickTarget(int objId, int otherObjId, int inserterId, int offset, Vector3 pointPos)
         {
-            if (Multiplayer.IsActive && Multiplayer.Session.LocalPlayer.Id == PacketAuthor)
+            // 1. Client receives the build request from itself 2. Host sends the build request
+            if (Multiplayer.IsActive && (Multiplayer.Session.LocalPlayer.Id == PacketAuthor || (Multiplayer.Session.LocalPlayer.IsHost && PacketAuthor == NebulaModAPI.AUTHOR_NONE)))
             {
                 Multiplayer.Session.Network.SendPacketToLocalStar(new NewSetInserterPickTargetPacket(objId, otherObjId, inserterId, offset, pointPos, GameMain.localPlanet?.id ?? -1));
             }
@@ -240,7 +241,7 @@ namespace NebulaWorld.Factory
 
         public void OnNewSetInserterInsertTarget(int objId, int otherObjId, int inserterId, int offset, Vector3 pointPos)
         {
-            if (Multiplayer.IsActive && Multiplayer.Session.LocalPlayer.Id == PacketAuthor)
+            if (Multiplayer.IsActive && Multiplayer.Session.LocalPlayer.Id == PacketAuthor || (Multiplayer.Session.LocalPlayer.IsHost && PacketAuthor == NebulaModAPI.AUTHOR_NONE))
             {
                 Multiplayer.Session.Network.SendPacketToLocalStar(new NewSetInserterInsertTargetPacket(objId, otherObjId, inserterId, offset, pointPos, GameMain.localPlanet?.id ?? -1));
             }


### PR DESCRIPTION
Disable Milky Way accesses in MP sessions
- There was an issue that when the host zooms out to Milky Way, the ESC button won't load the menu anymore. Since Nebula doesn't upload the score to Milky Way, there is no need to view Milky Way in multiplayer.

Revert UpgradeEntityRequest to using objId
- Fix #499.
- Because #468 handle GPUInstancingManager.AddModel on remote planets, we can revert UpgradeEntityRequest changes in #463.

Fix BuildToolManager
- make ``canBuild`` check works properly. May fix #494
- prevent client from sending prebuild requests located at the same position. Partly fix #357 #365, client can still send duplicate prebuilds when time exceed ``WAIT_TIME``
