### PR TITLE
Refactor DysonSphereManager (0.9.24)

### DIFF
--- a/NebulaModel/DataStructures/DysonLaunchData.cs
+++ b/NebulaModel/DataStructures/DysonLaunchData.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
-using System.IO;
+﻿using NebulaAPI;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace NebulaModel.DataStructures
 {
-    public class DysonLaunchData
+    [RegisterNestedType]
+    public class DysonLaunchData : INetSerializable
     {
         public struct Projectile
         {            
@@ -31,60 +32,56 @@ namespace NebulaModel.DataStructures
 
         public DysonLaunchData() : this(0) { }
 
-        public void Export(BinaryWriter bw)
+        public void Serialize(INetDataWriter writer)
         {
-            bw.Write(StarIndex);
-            bw.Write((ushort)BulletList.Count);
+            writer.Put(StarIndex);
+            writer.Put((ushort)BulletList.Count);
             for (ushort i = 0; i < (ushort)BulletList.Count; i++)
             {
                 Projectile data = BulletList[i];
-                bw.Write((byte)(data.PlanetId % 100));
-                bw.Write(data.Interval);
-                bw.Write(data.TargetId);
-                bw.Write(data.LocalPos.x);
-                bw.Write(data.LocalPos.y);
-                bw.Write(data.LocalPos.z);
+                writer.Put((byte)(data.PlanetId % 100));
+                writer.Put(data.Interval);
+                writer.Put(data.TargetId);
+                writer.Put(data.LocalPos.ToFloat3());
             }
-            bw.Write((ushort)RocketList.Count);
+            writer.Put((ushort)RocketList.Count);
             for (ushort i = 0; i < (ushort)RocketList.Count; i++)
             {
                 Projectile data = RocketList[i];
-                bw.Write((byte)(data.PlanetId % 100));
-                bw.Write(data.Interval);
-                bw.Write(data.TargetId);
-                bw.Write(data.LocalPos.x);
-                bw.Write(data.LocalPos.y);
-                bw.Write(data.LocalPos.z);
+                writer.Put((byte)(data.PlanetId % 100));
+                writer.Put(data.Interval);
+                writer.Put(data.TargetId);
+                writer.Put(data.LocalPos.ToFloat3());
             }
         }
 
-        public void Import(BinaryReader br)
+        public void Deserialize(INetDataReader reader)
         {
-            StarIndex = br.ReadInt32();
+            StarIndex = reader.GetInt();
             int starId = (StarIndex + 1) * 100;
-            int count = br.ReadUInt16();
+            int count = reader.GetUShort();
             BulletList = new List<Projectile>(count);
             for (int i = 0; i < count; i++)
             {
                 Projectile data = new Projectile
                 {
-                    PlanetId = br.ReadByte() + starId,
-                    Interval = br.ReadByte(),
-                    TargetId = br.ReadUInt16(),
-                    LocalPos = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle())
+                    PlanetId = reader.GetByte() + starId,
+                    Interval = reader.GetByte(),
+                    TargetId = reader.GetUShort(),
+                    LocalPos = reader.GetFloat3().ToVector3()
                 };
                 BulletList.Add(data);
             }
-            count = br.ReadUInt16();
+            count = reader.GetUShort();
             RocketList = new List<Projectile>(count);
             for (ushort i = 0; i < count; i++)
             {
                 Projectile data = new Projectile
                 {
-                    PlanetId = br.ReadByte() + starId,
-                    Interval = br.ReadByte(),
-                    TargetId = br.ReadUInt16(),
-                    LocalPos = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle())
+                    PlanetId = reader.GetByte() + starId,
+                    Interval = reader.GetByte(),
+                    TargetId = reader.GetUShort(),
+                    LocalPos = reader.GetFloat3().ToVector3()
                 };
                 RocketList.Add(data);
             }

--- a/NebulaModel/Packets/Universe/DysonBlueprintPacket.cs
+++ b/NebulaModel/Packets/Universe/DysonBlueprintPacket.cs
@@ -1,0 +1,19 @@
+﻿namespace NebulaModel.Packets.Universe
+{
+    public class DysonBlueprintPacket
+    {
+        public int StarIndex { get; set; }
+        public int LayerId { get; set; }
+        public EDysonBlueprintType BlueprintType {get; set; }
+        public string StringData { get; set; }
+
+        public DysonBlueprintPacket() { }
+        public DysonBlueprintPacket(int starIndex, int layerId, EDysonBlueprintType blueprintType, string stringData)
+        {
+            StarIndex = starIndex;
+            LayerId = layerId;
+            BlueprintType = blueprintType;
+            StringData = stringData;
+        }
+    }
+}

--- a/NebulaModel/Packets/Universe/DysonLaunchDataPacket.cs
+++ b/NebulaModel/Packets/Universe/DysonLaunchDataPacket.cs
@@ -1,18 +1,17 @@
 ﻿using NebulaAPI;
+using NebulaModel.DataStructures;
 
 namespace NebulaModel.Packets.Universe
 {
     [HidePacketInDebugLogs]
     public class DysonLaunchDataPacket
     {
-        public int Count { get; set; }
-        public byte[] BinaryData { get; set; }
+        public DysonLaunchData Data { get; set; }
 
         public DysonLaunchDataPacket() { }
-        public DysonLaunchDataPacket(int num, byte[] data)
+        public DysonLaunchDataPacket(DysonLaunchData data)
         {
-            Count = num;
-            BinaryData = data;
+            Data = data;
         }
     }
 }

--- a/NebulaModel/Packets/Universe/DysonSphereAddFramePacket.cs
+++ b/NebulaModel/Packets/Universe/DysonSphereAddFramePacket.cs
@@ -4,16 +4,18 @@
     {
         public int StarIndex { get; set; }
         public int LayerId { get; set; }
+        public int FrameId { get; set; }
         public int ProtoId { get; set; }
         public int NodeAId { get; set; }
         public int NodeBId { get; set; }
         public bool Euler { get; set; }
 
         public DysonSphereAddFramePacket() { }
-        public DysonSphereAddFramePacket(int starIndex, int layerId, int protoId, int nodeAId, int nodeBId, bool euler)
+        public DysonSphereAddFramePacket(int starIndex, int layerId, int frameId, int protoId, int nodeAId, int nodeBId, bool euler)
         {
             StarIndex = starIndex;
             LayerId = layerId;
+            FrameId = frameId;
             ProtoId = protoId;
             NodeAId = nodeAId;
             NodeBId = nodeBId;

--- a/NebulaModel/Packets/Universe/DysonSphereAddLayerPacket.cs
+++ b/NebulaModel/Packets/Universe/DysonSphereAddLayerPacket.cs
@@ -6,14 +6,16 @@ namespace NebulaModel.Packets.Universe
     public class DysonSphereAddLayerPacket
     {
         public int StarIndex { get; set; }
+        public int LayerId { get; set; }
         public float OrbitRadius { get; set; }
         public Float4 OrbitRotation { get; set; }
         public float OrbitAngularSpeed { get; set; }
 
         public DysonSphereAddLayerPacket() { }
-        public DysonSphereAddLayerPacket(int starIndex, float orbitRadius, Quaternion orbitRotation, float orbitAngularSpeed)
+        public DysonSphereAddLayerPacket(int starIndex, int layerId, float orbitRadius, Quaternion orbitRotation, float orbitAngularSpeed)
         {
             StarIndex = starIndex;
+            LayerId = layerId;
             OrbitRadius = orbitRadius;
             OrbitRotation = new Float4(orbitRotation);
             OrbitAngularSpeed = orbitAngularSpeed;

--- a/NebulaModel/Packets/Universe/DysonSphereAddNodePacket.cs
+++ b/NebulaModel/Packets/Universe/DysonSphereAddNodePacket.cs
@@ -6,14 +6,16 @@ namespace NebulaModel.Packets.Universe
     {
         public int StarIndex { get; set; }
         public int LayerId { get; set; }
+        public int NodeId { get; set; }
         public int NodeProtoId { get; set; }
         public Float3 Position { get; set; }
 
         public DysonSphereAddNodePacket() { }
-        public DysonSphereAddNodePacket(int starIndex, int layerId, int nodeProtoId, Float3 position)
+        public DysonSphereAddNodePacket(int starIndex, int layerId, int nodeId, int nodeProtoId, Float3 position)
         {
             StarIndex = starIndex;
             LayerId = layerId;
+            NodeId = nodeId;
             NodeProtoId = nodeProtoId;
             Position = position;
         }

--- a/NebulaModel/Packets/Universe/DysonSphereAddShellPacket.cs
+++ b/NebulaModel/Packets/Universe/DysonSphereAddShellPacket.cs
@@ -6,14 +6,16 @@ namespace NebulaModel.Packets.Universe
     {
         public int StarIndex { get; set; }
         public int LayerId { get; set; }
+        public int ShellId { get; set; }
         public int ProtoId { get; set; }
         public int[] NodeIds { get; set; }
 
         public DysonSphereAddShellPacket() { }
-        public DysonSphereAddShellPacket(int starIndex, int layerId, int protoId, List<int> nodeIds)
+        public DysonSphereAddShellPacket(int starIndex, int layerId, int shellId, int protoId, List<int> nodeIds)
         {
             StarIndex = starIndex;
             LayerId = layerId;
+            ShellId = shellId;
             ProtoId = protoId;
             NodeIds = nodeIds.ToArray();
         }

--- a/NebulaModel/Packets/Universe/DysonSphereData.cs
+++ b/NebulaModel/Packets/Universe/DysonSphereData.cs
@@ -4,12 +4,21 @@
     {
         public int StarIndex { get; set; }
         public byte[] BinaryData { get; set; }
+        public DysonSphereRespondEvent Event { get; set; }
 
         public DysonSphereData() { }
-        public DysonSphereData(int starIndex, byte[] data)
+        public DysonSphereData(int starIndex, byte[] data, DysonSphereRespondEvent respondEvent)
         {
             StarIndex = starIndex;
             BinaryData = data;
+            Event = respondEvent;
         }
+    }
+
+    public enum DysonSphereRespondEvent
+    {
+        List = 1,
+        Load = 2,        
+        Desync = 3
     }
 }

--- a/NebulaModel/Packets/Universe/DysonSphereEditLayerPacket.cs
+++ b/NebulaModel/Packets/Universe/DysonSphereEditLayerPacket.cs
@@ -1,0 +1,20 @@
+﻿using NebulaAPI;
+using UnityEngine;
+
+namespace NebulaModel.Packets.Universe
+{
+    public class DysonSphereEditLayerPacket
+    {
+        public int StarIndex { get; set; }
+        public int LayerId { get; set; }
+        public Float4 OrbitRotation { get; set; }
+
+        public DysonSphereEditLayerPacket() { }
+        public DysonSphereEditLayerPacket(int starIndex, int layerId, Quaternion orbitRotation)
+        {
+            StarIndex = starIndex;
+            LayerId = layerId;
+            OrbitRotation = new Float4(orbitRotation);
+        }
+    }
+}

--- a/NebulaModel/Packets/Universe/DysonSphereLoadRequest.cs
+++ b/NebulaModel/Packets/Universe/DysonSphereLoadRequest.cs
@@ -3,10 +3,20 @@
     public class DysonSphereLoadRequest
     {
         public int StarIndex { get; set; }
+        public DysonSphereRequestEvent Event { get; set; }
+
         public DysonSphereLoadRequest() { }
-        public DysonSphereLoadRequest(int starIndex)
+        public DysonSphereLoadRequest(int starIndex, DysonSphereRequestEvent requestEvent)
         {
             StarIndex = starIndex;
+            Event = requestEvent;
         }
+    }
+
+    public enum DysonSphereRequestEvent
+    {
+        List = 1,
+        Load = 2,        
+        Unload = 3
     }
 }

--- a/NebulaModel/Packets/Universe/DysonSwarmEditOrbit.cs
+++ b/NebulaModel/Packets/Universe/DysonSwarmEditOrbit.cs
@@ -3,15 +3,15 @@ using UnityEngine;
 
 namespace NebulaModel.Packets.Universe
 {
-    public class DysonSwarmAddOrbitPacket
+    public class DysonSwarmEditOrbitPacket
     {
         public int StarIndex { get; set; }
         public int OrbitId { get; set; }
         public float Radius { get; set; }
         public Float4 Rotation { get; set; }
 
-        public DysonSwarmAddOrbitPacket() { }
-        public DysonSwarmAddOrbitPacket(int starIndex, int orbitId, float radius, Quaternion rotation)
+        public DysonSwarmEditOrbitPacket() { }
+        public DysonSwarmEditOrbitPacket(int starIndex, int orbitId, float radius, Quaternion rotation)
         {
             StarIndex = starIndex;
             OrbitId = orbitId;

--- a/NebulaModel/Packets/Universe/DysonSwarmRemoveOrbitPacket.cs
+++ b/NebulaModel/Packets/Universe/DysonSwarmRemoveOrbitPacket.cs
@@ -4,12 +4,21 @@
     {
         public int StarIndex { get; set; }
         public int OrbitId { get; set; }
+        public SwarmRemoveOrbitEvent Event { get; set; }
 
         public DysonSwarmRemoveOrbitPacket() { }
-        public DysonSwarmRemoveOrbitPacket(int starIndex, int orbitId)
+        public DysonSwarmRemoveOrbitPacket(int starIndex, int orbitId, SwarmRemoveOrbitEvent removeEvent)
         {
             StarIndex = starIndex;
             OrbitId = orbitId;
+            Event = removeEvent;
         }
+    }
+
+    public enum SwarmRemoveOrbitEvent
+    {
+        Remove,
+        Disable,
+        Enable
     }
 }

--- a/NebulaNetwork/PacketProcessors/Universe/DysonSphereAddShellProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/DysonSphereAddShellProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using NebulaAPI;
+using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.Universe;
@@ -10,37 +11,27 @@ namespace NebulaNetwork.PacketProcessors.Universe
     [RegisterPacketProcessor]
     internal class DysonSphereAddShellProcessor : PacketProcessor<DysonSphereAddShellPacket>
     {
-        private readonly IPlayerManager playerManager;
-
-        public DysonSphereAddShellProcessor()
-        {
-            playerManager = Multiplayer.Session.Network.PlayerManager;
-        }
-
         public override void ProcessPacket(DysonSphereAddShellPacket packet, NebulaConnection conn)
         {
-            bool valid = true;
-            if (IsHost)
+            DysonSphereLayer layer = GameMain.data.dysonSpheres[packet.StarIndex]?.GetLayer(packet.LayerId);
+            if (layer == null)
             {
-                INebulaPlayer player = playerManager.GetPlayer(conn);
-                if (player != null)
+                return;
+            }
+            using (Multiplayer.Session.DysonSpheres.IsIncomingRequest.On())
+            {
+                int shellId = layer.shellRecycleCursor > 0 ? layer.shellRecycle[layer.shellRecycleCursor - 1] : layer.shellCursor;
+                if (shellId != packet.ShellId || layer.NewDysonShell(packet.ProtoId, new List<int>(packet.NodeIds)) == 0)
                 {
-                    playerManager.SendPacketToOtherPlayers(packet, player);
-                }
-                else
-                {
-                    valid = false;
+                    Log.Warn($"Cannnot add shell[{packet.ShellId}] on layer[{layer.id}], starIndex[{packet.StarIndex}]");
+                    Multiplayer.Session.DysonSpheres.HandleDesync(packet.StarIndex, conn);
+                    return;
                 }
             }
-
-            if (valid)
+            if (IsHost)
             {
-                using (Multiplayer.Session.DysonSpheres.IsIncomingRequest.On())
-                {
-                    GameMain.data.dysonSpheres[packet.StarIndex]?.GetLayer(packet.LayerId)?.NewDysonShell(packet.ProtoId, new List<int>(packet.NodeIds));
-                }
+                Multiplayer.Session.DysonSpheres.SendPacketToDysonSphereExcept(packet, packet.StarIndex, conn);
             }
         }
     }
 }
-

--- a/NebulaNetwork/PacketProcessors/Universe/DysonSphereDataProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/DysonSphereDataProcessor.cs
@@ -2,6 +2,9 @@
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.Universe;
+using NebulaWorld;
+using System.Collections.Generic;
+using System.IO;
 
 namespace NebulaNetwork.PacketProcessors.Universe
 {
@@ -15,23 +18,56 @@ namespace NebulaNetwork.PacketProcessors.Universe
                 return;
             }
 
-            //Failsafe, if client does not have instantiated sphere for the star, it will create dummy one that will be replaced during import
-            if (GameMain.data.dysonSpheres[packet.StarIndex] == null)
+            switch (packet.Event) 
             {
-                GameMain.data.dysonSpheres[packet.StarIndex] = new DysonSphere();
-                GameMain.data.statistics.production.Init(GameMain.data);
-                //Another failsafe, DysonSphere import requires initialized factory statistics
-                if (GameMain.data.statistics.production.factoryStatPool[0] == null)
-                {
-                    GameMain.data.statistics.production.factoryStatPool[0] = new FactoryProductionStat();
-                    GameMain.data.statistics.production.factoryStatPool[0].Init();
-                }
-                GameMain.data.dysonSpheres[packet.StarIndex].Init(GameMain.data, GameMain.data.galaxy.stars[packet.StarIndex]);
-            }
+                case DysonSphereRespondEvent.List:
+                    //Overwrite content assigned by UIDETopFunction.SetDysonComboBox()
+                    UIComboBox dysonBox = UIRoot.instance.uiGame.dysonEditor.controlPanel.topFunction.dysonBox;
+                    using (BinaryReader br = new BinaryUtils.Reader(packet.BinaryData).BinaryReader)
+                    {
+                        dysonBox.Items = new List<string>();
+                        dysonBox.ItemsData = new List<int>();
+                        int count = br.ReadInt32();
+                        for (int i = 0; i < count; i++)
+                        {
+                            int starIndex = br.ReadInt32();
+                            dysonBox.Items.Add(GameMain.galaxy.stars[starIndex].displayName);
+                            dysonBox.ItemsData.Add(starIndex);
+                        }
+                    }
+                    int index = dysonBox.ItemsData.FindIndex(x => x == UIRoot.instance.uiGame.dysonEditor.selection.viewStar?.index);
+                    dysonBox.itemIndex = index >= 0 ? index : 0;
+                    break;
 
-            using (BinaryUtils.Reader reader = new BinaryUtils.Reader(packet.BinaryData))
-            {
-                GameMain.data.dysonSpheres[packet.StarIndex].Import(reader.BinaryReader);
+                case DysonSphereRespondEvent.Load:
+                    //Failsafe, if client does not have instantiated sphere for the star, it will create dummy one that will be replaced during import
+                    if (GameMain.data.dysonSpheres[packet.StarIndex] == null)
+                    {
+                        GameMain.data.dysonSpheres[packet.StarIndex] = new DysonSphere();
+                        GameMain.data.statistics.production.Init(GameMain.data);
+                        //Another failsafe, DysonSphere import requires initialized factory statistics
+                        if (GameMain.data.statistics.production.factoryStatPool[0] == null)
+                        {
+                            GameMain.data.statistics.production.factoryStatPool[0] = new FactoryProductionStat();
+                            GameMain.data.statistics.production.factoryStatPool[0].Init();
+                        }
+                        GameMain.data.dysonSpheres[packet.StarIndex].Init(GameMain.data, GameMain.data.galaxy.stars[packet.StarIndex]);
+                    }
+
+                    using (BinaryUtils.Reader reader = new BinaryUtils.Reader(packet.BinaryData))
+                    {
+                        GameMain.data.dysonSpheres[packet.StarIndex].Import(reader.BinaryReader);
+                    }
+                    if (UIRoot.instance.uiGame.dysonEditor.active)
+                    {
+                        UIRoot.instance.uiGame.dysonEditor.selection.SetViewStar(GameMain.galaxy.stars[packet.StarIndex]);
+                    }
+                    Multiplayer.Session.DysonSpheres.IsNormal = true;
+                    break;
+
+                case DysonSphereRespondEvent.Desync:
+                    Multiplayer.Session.DysonSpheres.HandleDesync(packet.StarIndex, conn);
+                    break;
             }
         }
     }

--- a/NebulaNetwork/PacketProcessors/Universe/DysonSphereEditLayerProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/DysonSphereEditLayerProcessor.cs
@@ -7,23 +7,25 @@ using NebulaWorld;
 namespace NebulaNetwork.PacketProcessors.Universe
 {
     [RegisterPacketProcessor]
-    internal class DysonSwarmAddOrbitProcessor : PacketProcessor<DysonSwarmAddOrbitPacket>
+    public class DysonSphereEditLayerProcessor : PacketProcessor<DysonSphereEditLayerPacket>
     {
-        public override void ProcessPacket(DysonSwarmAddOrbitPacket packet, NebulaConnection conn)
+        public override void ProcessPacket(DysonSphereEditLayerPacket packet, NebulaConnection conn)
         {
             DysonSphere sphere = GameMain.data.dysonSpheres[packet.StarIndex];
             if (sphere == null)
             {
                 return;
             }
-            using (Multiplayer.Session.DysonSpheres.IncomingDysonSwarmPacket.On())
+            using (Multiplayer.Session.DysonSpheres.IsIncomingRequest.On())
             {
-                if (packet.OrbitId != NebulaWorld.Universe.DysonSphereManager.QueryOrbitId(sphere.swarm))
+                DysonSphereLayer layer = sphere.GetLayer(packet.LayerId);
+                if (layer == null)
                 {
                     Multiplayer.Session.DysonSpheres.HandleDesync(packet.StarIndex, conn);
                     return;
                 }
-                sphere.swarm.NewOrbit(packet.Radius, packet.Rotation.ToQuaternion());
+                layer.targetOrbitRotation = packet.OrbitRotation.ToQuaternion();
+                layer.InitOrbitRotation(layer.orbitRotation, layer.targetOrbitRotation);
             }
             if (IsHost)
             {

--- a/NebulaNetwork/PacketProcessors/Universe/DysonSphereRemoveFrameProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/DysonSphereRemoveFrameProcessor.cs
@@ -1,48 +1,78 @@
 ﻿using NebulaAPI;
+using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.Universe;
 using NebulaWorld;
+using System.Collections.Generic;
 
 namespace NebulaNetwork.PacketProcessors.Universe
 {
     [RegisterPacketProcessor]
     internal class DysonSphereRemoveFrameProcessor : PacketProcessor<DysonSphereRemoveFramePacket>
     {
-        private readonly IPlayerManager playerManager;
-
-        public DysonSphereRemoveFrameProcessor()
-        {
-            playerManager = Multiplayer.Session.Network.PlayerManager;
-        }
-
         public override void ProcessPacket(DysonSphereRemoveFramePacket packet, NebulaConnection conn)
         {
-            bool valid = true;
+            DysonSphereLayer layer = GameMain.data.dysonSpheres[packet.StarIndex]?.GetLayer(packet.LayerId);
+            if (layer == null)
+            {
+                return;
+            }
+            using (Multiplayer.Session.DysonSpheres.IsIncomingRequest.On())
+            {
+                if (!Check(layer, packet))
+                {
+                    Log.Warn($"Cannnot remove frame[{packet.FrameId}] on layer[{layer.id}], starIndex[{packet.StarIndex}]");
+                    Multiplayer.Session.DysonSpheres.HandleDesync(packet.StarIndex, conn);
+                    return;
+                }
+                //No need to remove if the frame is already null
+                if (layer.framePool[packet.FrameId] != null)
+                {
+                    layer.RemoveDysonFrame(packet.FrameId);
+                    NebulaWorld.Universe.DysonSphereManager.ClearSelection(packet.StarIndex, layer.id);
+                }
+            }
             if (IsHost)
             {
-                INebulaPlayer player = playerManager.GetPlayer(conn);
-                if (player != null)
-                {
-                    playerManager.SendPacketToOtherPlayers(packet, player);
-                }
-                else
-                {
-                    valid = false;
-                }
+                Multiplayer.Session.DysonSpheres.SendPacketToDysonSphereExcept(packet, packet.StarIndex, conn);
             }
+        }
 
-            if (valid)
+        private static bool Check(DysonSphereLayer layer, DysonSphereRemoveFramePacket packet)
+        {
+            if (packet.FrameId < 1 || packet.FrameId >= layer.frameCursor)
             {
-                using (Multiplayer.Session.DysonSpheres.IsIncomingRequest.On())
+                return false;
+            }
+            DysonFrame frame = layer.framePool[packet.FrameId];
+            if (frame == null)
+            {
+                //Sender and receiver are in the same state, so it's ok to pass
+                return true;
+            }
+            //Make sure that shells connected to the frame are removed first.
+            //UIDysonBrush_Remove.DeleteSelectedNode() remove frames first, so we need to remove shells here.
+            List<int> delShellList = new List<int>();
+            foreach (DysonShell shell in frame.nodeA.shells)
+            {
+                if (shell.frames.Contains(frame) && !delShellList.Contains(shell.id))
                 {
-                    DysonSphereLayer dsl = GameMain.data.dysonSpheres[packet.StarIndex]?.GetLayer(packet.LayerId);
-                    if (Multiplayer.Session.DysonSpheres.CanRemoveFrame(packet.FrameId, dsl))
-                    {
-                        dsl.RemoveDysonFrame(packet.FrameId);
-                    }
+                    delShellList.Add(shell.id);
                 }
             }
+            foreach (DysonShell shell in frame.nodeB.shells)
+            {
+                if (shell.frames.Contains(frame) && !delShellList.Contains(shell.id))
+                {
+                    delShellList.Add(shell.id);
+                }
+            }
+            foreach (int shellId in delShellList)
+            {
+                layer.RemoveDysonShell(shellId);
+            }
+            return true;
         }
     }
 }

--- a/NebulaNetwork/PacketProcessors/Universe/DysonSphereRemoveNodeProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/DysonSphereRemoveNodeProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using NebulaAPI;
+using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.Universe;
@@ -9,62 +10,52 @@ namespace NebulaNetwork.PacketProcessors.Universe
     [RegisterPacketProcessor]
     internal class DysonSphereRemoveNodeProcessor : PacketProcessor<DysonSphereRemoveNodePacket>
     {
-        private readonly IPlayerManager playerManager;
-
-        public DysonSphereRemoveNodeProcessor()
-        {
-            playerManager = Multiplayer.Session.Network.PlayerManager;
-        }
-
         public override void ProcessPacket(DysonSphereRemoveNodePacket packet, NebulaConnection conn)
         {
-            bool valid = true;
+            DysonSphereLayer layer = GameMain.data.dysonSpheres[packet.StarIndex]?.GetLayer(packet.LayerId);
+            if (layer == null)
+            {
+                return;
+            }
+            using (Multiplayer.Session.DysonSpheres.IsIncomingRequest.On())
+            {
+                if (!Check(layer, packet))
+                {
+                    Log.Warn($"Cannnot remove node[{packet.NodeId}] on layer[{layer.id}], starIndex[{packet.StarIndex}]");
+                    Multiplayer.Session.DysonSpheres.HandleDesync(packet.StarIndex, conn);
+                    return;
+                }
+                //No need to remove if the node is already null
+                if (layer.nodePool[packet.NodeId] != null)
+                {
+                    layer.RemoveDysonNode(packet.NodeId);
+                    NebulaWorld.Universe.DysonSphereManager.ClearSelection(packet.StarIndex, layer.id);
+                }
+            }
             if (IsHost)
             {
-                INebulaPlayer player = playerManager.GetPlayer(conn);
-                if (player != null)
-                {
-                    playerManager.SendPacketToOtherPlayers(packet, player);
-                }
-                else
-                {
-                    valid = false;
-                }
+                Multiplayer.Session.DysonSpheres.SendPacketToDysonSphereExcept(packet, packet.StarIndex, conn);
             }
+        }
 
-            if (valid)
+        private static bool Check(DysonSphereLayer layer, DysonSphereRemoveNodePacket packet)
+        {
+            if (packet.NodeId < 1 || packet.NodeId >= layer.nodeCursor)
             {
-                using (Multiplayer.Session.DysonSpheres.IsIncomingRequest.On())
-                {
-                    DysonSphereLayer dsl = GameMain.data.dysonSpheres[packet.StarIndex]?.GetLayer(packet.LayerId);
-                    if (dsl != null)
-                    {
-                        int num = 0;
-                        DysonNode dysonNode = dsl.nodePool[packet.NodeId];
-                        //Remove all frames that are part of the node
-                        while (dysonNode.frames.Count > 0)
-                        {
-                            dsl.RemoveDysonFrame(dysonNode.frames[0].id);
-                            if (num++ > 4096)
-                            {
-                                Assert.CannotBeReached();
-                                break;
-                            }
-                        }
-                        //Remove all shells that are part of the node
-                        while (dysonNode.shells.Count > 0)
-                        {
-                            dsl.RemoveDysonShell(dysonNode.shells[0].id);
-                            if (num++ > 4096)
-                            {
-                                Assert.CannotBeReached();
-                                break;
-                            }
-                        }
-                        dsl.RemoveDysonNode(packet.NodeId);
-                    }
-                }
+                return false;
             }
+            DysonNode node = layer.nodePool[packet.NodeId];
+            if (node == null)
+            {
+                //Sender and receiver are in the same state, so it's ok to pass
+                return true;
+            }
+            //Make sure that shells and frames connected to the node are removed first.
+            if (node.frames.Count > 0)
+            {
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/NebulaNetwork/PlayerManager.cs
+++ b/NebulaNetwork/PlayerManager.cs
@@ -285,7 +285,7 @@ namespace NebulaNetwork
                     availablePlayerIds.Enqueue(player.Id);
                 }
                 Multiplayer.Session.Statistics.UnRegisterPlayer(player.Id);
-                Multiplayer.Session.Launch.UnRegisterPlayer(conn);
+                Multiplayer.Session.DysonSpheres.UnRegisterPlayer(conn);
 
                 //Notify players about queued building plans for drones
                 int[] DronePlans = Multiplayer.Session.Drones.GetPlayerDronePlans(player.Id);

--- a/NebulaNetwork/Server.cs
+++ b/NebulaNetwork/Server.cs
@@ -21,8 +21,8 @@ namespace NebulaNetwork
     {
         private const float GAME_RESEARCH_UPDATE_INTERVAL = 2;
         private const float STATISTICS_UPDATE_INTERVAL = 1;
-        private const float LAUNCH_UPDATE_INTERVAL = 2;
-        private const float DYSONSPHERE_UPDATE_INTERVAL = 5;
+        private const float LAUNCH_UPDATE_INTERVAL = 4;
+        private const float DYSONSPHERE_UPDATE_INTERVAL = 2;
         private const float WARNING_UPDATE_INTERVAL = 1;
 
         private float gameResearchHashUpdateTimer = 0;
@@ -155,15 +155,7 @@ namespace NebulaNetwork
             if (dysonSphereUpdateTimer > DYSONSPHERE_UPDATE_INTERVAL)
             {
                 dysonSphereUpdateTimer = 0;
-                DysonSphere[] dysonSpheres = GameMain.data.dysonSpheres;
-                for (int i = 0; i < dysonSpheres.Length; i++)
-                {
-                    DysonSphere dysonSphere = dysonSpheres[i];
-                    if (dysonSphere != null && (dysonSphere.energyReqCurrentTick + dysonSphere.energyGenCurrentTick > 0))
-                    {
-                        SendPacketToStar(new DysonSphereStatusPacket(dysonSphere), dysonSphere.starData.id);
-                    }
-                }
+                Multiplayer.Session.DysonSpheres.UpdateSphereStatusIfNeeded();
             }
 
             if (warningUpdateTimer > WARNING_UPDATE_INTERVAL)

--- a/NebulaPatcher/Patches/Dynamic/DESelection_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/DESelection_Patch.cs
@@ -1,0 +1,64 @@
+﻿using HarmonyLib;
+using NebulaModel.Logger;
+using NebulaModel.Packets.Universe;
+using NebulaWorld;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(DESelection))]
+    internal class DESelection_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(DESelection.SetViewStar))]
+        public static bool SetViewStar_Prefix(DESelection __instance, ref StarData starData)
+        {
+            if (Multiplayer.IsActive && Multiplayer.Session.LocalPlayer.IsClient)
+            {
+                //UIDysonEditor._OnOpen()
+                if (!UIRoot.instance.uiGame.dysonEditor.sceneGroup.activeSelf)
+                {
+                    //Request the latest list of existing dyson spheres
+                    Multiplayer.Session.Network.SendPacket(new DysonSphereLoadRequest(0, DysonSphereRequestEvent.List));
+                    if (GameMain.localStar == null)
+                    {
+                        //In outer space, set initial viewStar to the one that has dyson sphere
+                        for (int i = 0; i < GameMain.data.dysonSpheres.Length; i++)
+                        {
+                            if (GameMain.data.dysonSpheres[i] != null)
+                            {
+                                starData = GameMain.data.dysonSpheres[i].starData;
+                                return true;
+                            }
+                        }
+                    }
+                }
+                if (starData != null && GameMain.data.dysonSpheres[starData.index] == null)
+                {
+                    Log.Info($"Requesting DysonSphere for system {starData.displayName} (Index: {starData.index})");
+                    Multiplayer.Session.Network.SendPacket(new DysonSphereLoadRequest(starData.index, DysonSphereRequestEvent.Load));
+                    //Set viewDysonSphere to null until requested dyson sphere data is arrived.
+                    __instance.ClearAllSelection();
+                    __instance.viewStar = starData;
+                    __instance.viewDysonSphere = null;
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(DESelection.ClearAllSelection))]
+        public static void ClearAllSelection_Postfix()
+        {
+            if (Multiplayer.IsActive && Multiplayer.Session.LocalPlayer.IsClient)
+            {
+                //UIDysonEditor._OnClose()
+                if (!UIRoot.instance.uiGame.dysonEditor.sceneGroup.activeSelf)
+                {
+                    //Unload remote dyson spheres
+                    Multiplayer.Session.DysonSpheres.UnloadRemoteDysonSpheres();
+                }
+            }            
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/DysonBlueprintData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/DysonBlueprintData_Patch.cs
@@ -1,0 +1,39 @@
+﻿using HarmonyLib;
+using NebulaAPI;
+using NebulaModel.Packets.Universe;
+using NebulaWorld;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(DysonBlueprintData))]
+    internal class DysonBlueprintData_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(DysonBlueprintData.ContentFromBase64String))]
+        public static void ContentFromBase64String_Prefix()
+        {
+            if (Multiplayer.IsActive)
+            {
+                Multiplayer.Session.DysonSpheres.InBlueprint = true;
+            }            
+        }
+
+#pragma warning disable Harmony003
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(DysonBlueprintData.ContentFromBase64String))]
+        public static void ContentFromBase64String_Postfix(DysonBlueprintDataIOError __result, string __0, EDysonBlueprintType __1, DysonSphere __2, DysonSphereLayer __3)
+        {
+            if (Multiplayer.IsActive)
+            {
+                Multiplayer.Session.DysonSpheres.InBlueprint = false;
+                if (!Multiplayer.Session.DysonSpheres.IsIncomingRequest && __result == DysonBlueprintDataIOError.OK)
+                {
+                    int starIndex = __2.starData.index;
+                    int layerId = __3?.id ?? -1;
+                    Multiplayer.Session.Network.SendPacket(new DysonBlueprintPacket(starIndex, layerId, __1, __0));
+                }
+            }
+        }
+#pragma warning restore Harmony003
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/DysonSphereLayer_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/DysonSphereLayer_Patch.cs
@@ -12,98 +12,79 @@ namespace NebulaPatcher.Patches.Dynamic
     {
         [HarmonyPrefix]
         [HarmonyPatch(nameof(DysonSphereLayer.NewDysonNode))]
-        public static bool NewDysonNode_Prefix(DysonSphereLayer __instance, int __result, int protoId, Vector3 pos)
+        public static void NewDysonNode_Prefix(DysonSphereLayer __instance, int protoId, Vector3 pos)
         {
-            if (!Multiplayer.IsActive)
+            if (Multiplayer.IsActive && !Multiplayer.Session.DysonSpheres.IsIncomingRequest)
             {
-                return true;
+                int nodeId = __instance.nodeRecycleCursor > 0 ? __instance.nodeRecycle[__instance.nodeRecycleCursor - 1] : __instance.nodeCursor;
+                Multiplayer.Session.Network.SendPacket(new DysonSphereAddNodePacket(__instance.starData.index, __instance.id, nodeId, protoId, new Float3(pos)));
             }
-            //Notify others that user added node to the dyson plan
-            if (!Multiplayer.Session.DysonSpheres.IsIncomingRequest)
-            {
-                Multiplayer.Session.Network.SendPacket(new DysonSphereAddNodePacket(__instance.starData.index, __instance.id, protoId, new Float3(pos)));
-            }
-            return true;
         }
 
         [HarmonyPrefix]
         [HarmonyPatch(nameof(DysonSphereLayer.NewDysonFrame))]
-        public static bool NewDysonFrame_Prefix(DysonSphereLayer __instance, int __result, int protoId, int nodeAId, int nodeBId, bool euler)
+        public static void NewDysonFrame_Prefix(DysonSphereLayer __instance, int protoId, int nodeAId, int nodeBId, bool euler)
         {
-            if (!Multiplayer.IsActive)
+            if (Multiplayer.IsActive && !Multiplayer.Session.DysonSpheres.IsIncomingRequest)
             {
-                return true;
+                int frameId = __instance.frameRecycleCursor > 0 ? __instance.frameRecycle[__instance.frameRecycleCursor - 1] : __instance.frameCursor;
+                Multiplayer.Session.Network.SendPacket(new DysonSphereAddFramePacket(__instance.starData.index, __instance.id, frameId, protoId, nodeAId, nodeBId, euler));
             }
-            //Notify others that user added frame to the dyson plan
-            if (!Multiplayer.Session.DysonSpheres.IsIncomingRequest)
-            {
-                Multiplayer.Session.Network.SendPacket(new DysonSphereAddFramePacket(__instance.starData.index, __instance.id, protoId, nodeAId, nodeBId, euler));
-            }
-            return true;
         }
 
         [HarmonyPrefix]
         [HarmonyPatch(nameof(DysonSphereLayer.RemoveDysonFrame))]
-        public static bool RemoveDysonFrame_Prefix(DysonSphereLayer __instance, int frameId)
+        public static void RemoveDysonFrame_Prefix(DysonSphereLayer __instance, int frameId)
         {
-            if (!Multiplayer.IsActive)
-            {
-                return true;
-            }
-            //Notify others that user removed frame from the dyson plan
-            if (!Multiplayer.Session.DysonSpheres.IsIncomingRequest)
+            if (Multiplayer.IsActive && !Multiplayer.Session.DysonSpheres.IsIncomingRequest)
             {
                 Multiplayer.Session.Network.SendPacket(new DysonSphereRemoveFramePacket(__instance.starData.index, __instance.id, frameId));
             }
-            return true;
         }
 
         [HarmonyPrefix]
         [HarmonyPatch(nameof(DysonSphereLayer.RemoveDysonNode))]
-        public static bool RemoveDysonNode_Prefix(DysonSphereLayer __instance, int nodeId)
+        public static void RemoveDysonNode_Prefix(DysonSphereLayer __instance, int nodeId)
         {
-            if (!Multiplayer.IsActive)
-            {
-                return true;
-            }
-            //Notify others that user removed node from the dyson plan
-            if (!Multiplayer.Session.DysonSpheres.IsIncomingRequest)
+            if (Multiplayer.IsActive && !Multiplayer.Session.DysonSpheres.IsIncomingRequest)
             {
                 Multiplayer.Session.Network.SendPacket(new DysonSphereRemoveNodePacket(__instance.starData.index, __instance.id, nodeId));
             }
-            return true;
         }
 
         [HarmonyPrefix]
         [HarmonyPatch(nameof(DysonSphereLayer.NewDysonShell))]
-        public static bool NewDysonShell_Prefix(DysonSphereLayer __instance, int protoId, List<int> nodeIds)
+        public static void NewDysonShell_Prefix(DysonSphereLayer __instance, int protoId, List<int> nodeIds)
         {
-            if (!Multiplayer.IsActive)
+            if (Multiplayer.IsActive && !Multiplayer.Session.DysonSpheres.IsIncomingRequest)
             {
-                return true;
+                int shellId = __instance.shellRecycleCursor > 0 ? __instance.shellRecycle[__instance.shellRecycleCursor - 1] : __instance.shellCursor;
+                Multiplayer.Session.Network.SendPacket(new DysonSphereAddShellPacket(__instance.starData.index, __instance.id, shellId, protoId, nodeIds));
             }
-            //Notify others that user removed node from the dyson plan
-            if (!Multiplayer.Session.DysonSpheres.IsIncomingRequest)
-            {
-                Multiplayer.Session.Network.SendPacket(new DysonSphereAddShellPacket(__instance.starData.index, __instance.id, protoId, nodeIds));
-            }
-            return true;
         }
 
         [HarmonyPrefix]
         [HarmonyPatch(nameof(DysonSphereLayer.RemoveDysonShell))]
-        public static bool RemoveDysonShell_Prefix(DysonSphereLayer __instance, int shellId)
+        public static void RemoveDysonShell_Prefix(DysonSphereLayer __instance, int shellId)
         {
-            if (!Multiplayer.IsActive)
-            {
-                return true;
-            }
-            //Notify others that user removed node from the dyson plan
-            if (!Multiplayer.Session.DysonSpheres.IsIncomingRequest)
+            if (Multiplayer.IsActive && !Multiplayer.Session.DysonSpheres.IsIncomingRequest)
             {
                 Multiplayer.Session.Network.SendPacket(new DysonSphereRemoveShellPacket(__instance.starData.index, __instance.id, shellId));
             }
-            return true;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(DysonSphereLayer.InitOrbitRotation))]
+        public static void InitOrbitRotation_Prefix(DysonSphereLayer __instance, Quaternion __1)
+        {
+            if (Multiplayer.IsActive && !Multiplayer.Session.DysonSpheres.IsIncomingRequest)
+            {
+                //Send only when it's trigger by UIDELayerInfo.OnEditConfirmClick()
+                if (UIRoot.instance.uiGame.dysonEditor.controlPanel.inspector.layerInfo.orbitEditMode)
+                {
+                    Multiplayer.Session.Network.SendPacket(new DysonSphereEditLayerPacket(__instance.starData.index, __instance.id, __1));
+                }
+            }
         }
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/DysonSwarm_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/DysonSwarm_Patch.cs
@@ -10,34 +10,58 @@ namespace NebulaPatcher.Patches.Dynamic
     {
         [HarmonyPrefix]
         [HarmonyPatch(nameof(DysonSwarm.NewOrbit))]
-        public static bool NewOrbit_Prefix(DysonSwarm __instance, int __result, float radius, Quaternion rotation)
+        public static void NewOrbit_Prefix(DysonSwarm __instance, float radius, Quaternion rotation)
         {
             if (!Multiplayer.IsActive)
             {
-                return true;
+                return;
             }
-            //Notify others that orbit for Dyson Swarm was created
-            if (!Multiplayer.Session.DysonSpheres.IncomingDysonSwarmPacket)
+            //If local is the author and not in the process of importing blueprint
+            if (!Multiplayer.Session.DysonSpheres.IncomingDysonSwarmPacket && !Multiplayer.Session.DysonSpheres.InBlueprint)
             {
-                Multiplayer.Session.Network.SendPacket(new DysonSwarmAddOrbitPacket(__instance.starData.index, radius, rotation));
+                int orbitId = NebulaWorld.Universe.DysonSphereManager.QueryOrbitId(__instance);
+                Multiplayer.Session.Network.SendPacket(new DysonSwarmAddOrbitPacket(__instance.starData.index, orbitId, radius, rotation));
             }
-            return true;
         }
 
         [HarmonyPrefix]
         [HarmonyPatch(nameof(DysonSwarm.RemoveOrbit))]
-        public static bool RemoveOrbit_Prefix(DysonSwarm __instance, int orbitId)
+        public static void RemoveOrbit_Prefix(DysonSwarm __instance, int orbitId)
         {
             if (!Multiplayer.IsActive)
             {
-                return true;
+                return;
             }
-            //Notify others that orbit for Dyson Swarm was deleted
+            //If local is the author and not in the process of importing blueprint
+            if (!Multiplayer.Session.DysonSpheres.IncomingDysonSwarmPacket && !Multiplayer.Session.DysonSpheres.InBlueprint)
+            {
+                Multiplayer.Session.Network.SendPacket(new DysonSwarmRemoveOrbitPacket(__instance.starData.index, orbitId, SwarmRemoveOrbitEvent.Remove));
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(DysonSwarm.SetOrbitEnable))]
+        public static void SetOrbitEnable_Prefix(DysonSwarm __instance, int orbitId, bool enabled)
+        {
+            if (!Multiplayer.IsActive)
+            {
+                return;
+            }
+            //Notify others that orbit for Dyson Swarm was enabled/disabled
             if (!Multiplayer.Session.DysonSpheres.IncomingDysonSwarmPacket)
             {
-                Multiplayer.Session.Network.SendPacket(new DysonSwarmRemoveOrbitPacket(__instance.starData.index, orbitId));
+                Multiplayer.Session.Network.SendPacket(new DysonSwarmRemoveOrbitPacket(__instance.starData.index, orbitId, enabled ? SwarmRemoveOrbitEvent.Enable : SwarmRemoveOrbitEvent.Disable));
             }
-            return true;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(DysonSwarm.EditOrbit))]
+        public static void EditOrbit_Prefix(DysonSwarm __instance, int orbitId, float radius, Quaternion rotation)
+        {
+            if (Multiplayer.IsActive && !Multiplayer.Session.DysonSpheres.IncomingDysonSwarmPacket)
+            {
+                Multiplayer.Session.Network.SendPacket(new DysonSwarmEditOrbitPacket(__instance.starData.index, orbitId, radius, rotation));
+            }
         }
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
@@ -87,11 +87,12 @@ namespace NebulaPatcher.Patches.Dynamic
 
             InternalLoadPlanetsRequestGenerator(star.planets);
 
+            Multiplayer.Session.DysonSpheres.UnloadRemoteDysonSpheres();
             // Request initial dysonSphere data
             if (GameMain.data.dysonSpheres[star.index] == null)
             {
                 Log.Info($"Requesting DysonSphere for system {star.displayName} (Index: {star.index})");
-                Multiplayer.Session.Network.SendPacket(new DysonSphereLoadRequest(star.index));
+                Multiplayer.Session.Network.SendPacket(new DysonSphereLoadRequest(star.index, DysonSphereRequestEvent.Load));
             }
 
             NebulaModAPI.OnStarLoadRequest?.Invoke(star.index);

--- a/NebulaPatcher/Patches/Dynamic/UIDESphereInfo_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIDESphereInfo_Patch.cs
@@ -1,0 +1,58 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(UIDESphereInfo))]
+    internal class UIDESphereInfo_Patch
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(UIDESphereInfo._OnInit))]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Original Function Name")]
+        public static void _OnInit_Postfix()
+        {
+            if (Multiplayer.IsActive)
+            {
+                UIRoot.instance.uiGame.dysonEditor.controlPanel.topFunction.pauseButton.button.interactable = false;
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(UIDESphereInfo.CalculateSailLifeDistribution))]
+        public static bool CalculateSailLifeDistribution_Prefix(UIDESphereInfo __instance, int division, out float maxCount, ref float[] __result)
+        {
+            maxCount = 0f;
+            if (!Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost)
+            {
+                return true;
+            }
+
+            if (division <= 1 || __instance.dysonSphere.swarm == null)
+            {
+                __result = null;
+                return false;
+            }
+            ExpiryOrder[] expiryOrder = __instance.dysonSphere.swarm.expiryOrder;
+            long gameTick = GameMain.gameTick;
+            float[] array = new float[division];
+            float gap = GameMain.history.solarSailLife * 60f / division;
+            for (int i = 0; i < expiryOrder.Length; i++)
+            {
+                if (expiryOrder[i].index != 0)
+                {
+                    // Make sure index is not out of array
+                    int index = (int)((expiryOrder[i].time - gameTick) / gap);
+                    index = index >= 0 ? index : 0;
+                    index = index < division ? index : division - 1;
+                    array[index] += 1f;
+                }
+            }
+            for (int k = 0; k < array.Length; k++)
+            {
+                maxCount = ((maxCount > array[k]) ? maxCount : array[k]);
+            }
+            __result = array;
+            return false;
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/UIDESwarmOrbitInfo.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIDESwarmOrbitInfo.cs
@@ -1,0 +1,47 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(UIDESwarmOrbitInfo))]
+    internal class UIDESwarmOrbitInfo_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(UIDESwarmOrbitInfo.CalculateSailLifeDistribution))]
+        public static bool CalculateSailLifeDistribution_Prefix(UIDESwarmOrbitInfo __instance, int division, out float maxCount, ref float[] __result)
+        {
+            maxCount = 0f;
+            if (!Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost)
+            {
+                return true;
+            }
+
+            if (division <= 1 || __instance.swarm == null)
+            {
+                __result = null;
+                return false;
+            }
+            ExpiryOrder[] expiryOrder = __instance.swarm.expiryOrder;
+            long gameTick = GameMain.gameTick;
+            float[] array = new float[division];
+            float gap = GameMain.history.solarSailLife * 60f / division;
+            for (int i = 0; i < expiryOrder.Length; i++)
+            {
+                if (expiryOrder[i].index != 0 && __instance.orbits.Contains((int)__instance.swarm.sailInfos[expiryOrder[i].index].orbit))
+                {
+                    // Make sure index is not out of array
+                    int index = (int)((expiryOrder[i].time - gameTick) / gap);
+                    index = index >= 0 ? index : 0;
+                    index = index < division ? index : division - 1;
+                    array[index] += 1f;
+                }
+            }
+            for (int k = 0; k < array.Length; k++)
+            {
+                maxCount = ((maxCount > array[k]) ? maxCount : array[k]);
+            }
+            __result = array;
+            return false;
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Transpilers/EjectorComponent_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/EjectorComponent_Transpiler.cs
@@ -35,7 +35,8 @@ namespace NebulaPatcher.Patches.Transpilers
                         new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(EjectorComponent), nameof(EjectorComponent.orbitId))),
                         HarmonyLib.Transpilers.EmitDelegate<Action<int, Vector3, int>>((planetId, localPos, orbitId) =>
                         {
-                            if (!Multiplayer.IsActive || !Multiplayer.Session.Launch.IsUpdateNeeded)
+                            // If the dyson sphere has no subscribers anymore, skip this data
+                            if (!Multiplayer.IsActive || !Multiplayer.Session.Launch.Snapshots.ContainsKey(planetId / 100 - 1))
                                 return;
 
                             // Assume orbitId < 65536

--- a/NebulaPatcher/Patches/Transpilers/SiloComponent_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/SiloComponent_Transpiler.cs
@@ -32,7 +32,8 @@ namespace NebulaPatcher.Patches.Transpilers
                         loadInstruction,
                         HarmonyLib.Transpilers.EmitDelegate<Action<int, Vector3, DysonNode>>((planetId, localPos, autoDysonNode) =>
                         {
-                            if (!Multiplayer.IsActive || !Multiplayer.Session.Launch.IsUpdateNeeded)
+                            // If the dyson sphere has no subscribers anymore, skip this data
+                            if (!Multiplayer.IsActive || !Multiplayer.Session.Launch.Snapshots.ContainsKey(planetId/100-1))
                                 return;
 
                             // Assume layerId < 16, nodeId < 4096

--- a/NebulaWorld/Universe/DysonSphereManager.cs
+++ b/NebulaWorld/Universe/DysonSphereManager.cs
@@ -1,4 +1,7 @@
-﻿using NebulaModel.DataStructures;
+﻿using NebulaAPI;
+using NebulaModel.DataStructures;
+using NebulaModel.Logger;
+using NebulaModel.Networking;
 using NebulaModel.Packets.Universe;
 using System;
 using System.Collections.Generic;
@@ -7,10 +10,22 @@ namespace NebulaWorld.Universe
 {
     public class DysonSphereManager : IDisposable
     {
+        private sealed class ThreadSafe
+        {
+            internal readonly Dictionary<int, List<INebulaConnection>> Subscribers = new Dictionary<int, List<INebulaConnection>>();
+        }
+        private readonly ThreadSafe threadSafe = new ThreadSafe();
+
+        public Locker GetSubscribers(out Dictionary<int, List<INebulaConnection>> subscribers)
+        {
+            return threadSafe.Subscribers.GetLocked(out subscribers);
+        }
+
         public readonly ToggleSwitch IsIncomingRequest = new ToggleSwitch();
         public readonly ToggleSwitch IncomingDysonSwarmPacket = new ToggleSwitch();
-
+        public bool IsNormal { get; set; } = true;
         public List<DysonSphereAddFramePacket> QueuedAddFramePackets = new List<DysonSphereAddFramePacket>();
+        private readonly List<DysonSphereStatusPacket> statusPackets = new List<DysonSphereStatusPacket>();
 
         public DysonSphereManager()
         {
@@ -20,6 +35,149 @@ namespace NebulaWorld.Universe
         public void Dispose()
         {
             QueuedAddFramePackets = null;
+        }
+
+        /// <summary>
+        /// Send packet to all Clients that subscribe to target Dyson Sphere 
+        /// </summary>
+        public void SendPacketToDysonSphere<T>(T packet, int starIndex) where T : class, new()
+        {
+            using (GetSubscribers(out Dictionary<int, List<INebulaConnection>> subscribers))
+            {
+                if (subscribers.ContainsKey(starIndex))
+                {
+                    foreach (INebulaConnection conn in subscribers[starIndex])
+                    {
+                        conn.SendPacket(packet);
+                    }
+                }
+            }
+        }
+
+        public void SendPacketToDysonSphereExcept<T>(T packet, int starIndex, INebulaConnection exception) where T : class, new()
+        {
+            using (GetSubscribers(out Dictionary<int, List<INebulaConnection>> subscribers))
+            {
+                if (subscribers.ContainsKey(starIndex))
+                {
+                    foreach (INebulaConnection conn in subscribers[starIndex])
+                    {
+                        //Cast to NebulaConnection so it can called the correct comparator
+                        if ((NebulaConnection)conn != (NebulaConnection)exception)
+                        {
+                            conn.SendPacket(packet);
+                        }
+                    }
+                }
+            }
+        }
+
+        public void RegisterPlayer(INebulaConnection conn, int starIndex)
+        {
+            using (GetSubscribers(out Dictionary<int, List<INebulaConnection>> subscribers))
+            {
+                if (!subscribers.ContainsKey(starIndex))
+                {
+                    subscribers.Add(starIndex, new List<INebulaConnection>());
+                    statusPackets.Add(new DysonSphereStatusPacket(GameMain.data.dysonSpheres[starIndex]));
+                    Multiplayer.Session.Launch.Register(starIndex);
+                }
+                if (!subscribers[starIndex].Contains(conn))
+                {
+                    subscribers[starIndex].Add(conn);
+                    conn.SendPacket(statusPackets.Find(x => x.StarIndex == starIndex));
+                }
+            }
+        }
+
+        public void UnRegisterPlayer(INebulaConnection conn, int starIndex)
+        {
+            using (GetSubscribers(out Dictionary<int, List<INebulaConnection>> subscribers))
+            {
+                if (subscribers.ContainsKey(starIndex))
+                {
+                    subscribers[starIndex].Remove(conn);
+                    if (subscribers[starIndex].Count == 0)
+                    {
+                        subscribers.Remove(starIndex);
+                        statusPackets.Remove(statusPackets.Find(x => x.StarIndex == starIndex));
+                        Multiplayer.Session.Launch.Unregister(starIndex);
+                    }
+                }
+            }
+        }
+
+        public void UnRegisterPlayer(INebulaConnection conn)
+        {
+            using (GetSubscribers(out Dictionary<int, List<INebulaConnection>> subscribers))
+            {
+                List<int> removals = new List<int>();
+                foreach (KeyValuePair<int, List<INebulaConnection>> item in subscribers)
+                {
+                    item.Value.Remove(conn);
+                    if (item.Value.Count == 0)
+                    {
+                        removals.Add(item.Key);
+                    }
+                }
+                foreach (int starIndex in removals)
+                {
+                    subscribers.Remove(starIndex);
+                    statusPackets.Remove(statusPackets.Find(x => x.StarIndex == starIndex));
+                    Multiplayer.Session.Launch.Unregister(starIndex);
+                }
+            }
+        }
+
+        public void UpdateSphereStatusIfNeeded()
+        {                            
+            foreach (DysonSphereStatusPacket packet in statusPackets)
+            {
+                DysonSphere dysonSphere = GameMain.data.dysonSpheres[packet.StarIndex];
+                //Update dyson sphere when the status changes
+                if (packet.GrossRadius != dysonSphere.grossRadius || packet.EnergyReqCurrentTick != dysonSphere.energyReqCurrentTick || packet.EnergyGenCurrentTick != dysonSphere.energyGenCurrentTick)
+                {
+                    packet.GrossRadius = dysonSphere.grossRadius;
+                    packet.EnergyReqCurrentTick = dysonSphere.energyReqCurrentTick;
+                    packet.EnergyGenCurrentTick = dysonSphere.energyGenCurrentTick;
+                    SendPacketToDysonSphere(packet, packet.StarIndex);
+                }
+            }
+        }
+
+        public void UnloadRemoteDysonSpheres()
+        {
+            //The editor will throw errors if there are no dyson spheres available
+            int currentId = GameMain.localStar?.index ?? UIRoot.instance.uiGame.dysonEditor.selection.viewStar?.index ?? -1;
+            for (int i = 0; i < GameMain.data.dysonSpheres.Length; i++)
+            {
+                if (GameMain.data.dysonSpheres[i] != null && i != currentId)
+                {
+                    Log.Info($"Unload DysonSphere at system {GameMain.galaxy.stars[i].displayName} (Index: {i})");
+                    Multiplayer.Session.Network.SendPacket(new DysonSphereLoadRequest(i, DysonSphereRequestEvent.Unload));
+                    GameMain.data.dysonSpheres[i] = null;
+                }
+            }
+            IsNormal = true;
+        }
+
+        public void HandleDesync(int starIndex, INebulaConnection conn)
+        {
+            if (Multiplayer.Session.LocalPlayer.IsHost)
+            {
+                //Notify packet author that its building request did not success
+                conn.SendPacket(new DysonSphereData(starIndex, Array.Empty<byte>(), DysonSphereRespondEvent.Desync));
+            }
+            else
+            {
+                //Notify client that desync happened
+                if (IsNormal)
+                {
+                    IsNormal = false;
+                    InGamePopup.ShowWarning("Desync", $"Dyson sphere id[{starIndex}] {GameMain.galaxy.stars[starIndex].displayName} is desynced.",
+                        "Reload", () => Multiplayer.Session.Network.SendPacket(new DysonSphereLoadRequest(starIndex, DysonSphereRequestEvent.Load)));
+                }
+            }
         }
 
         public bool CanCreateFrame(int node1, int node2, DysonSphereLayer dsl)


### PR DESCRIPTION
Update dyson sphere load/unload mechanism

- Request dyson sphere index list when opening the editor
- Load dyson sphere data when arriving at a new system or view star changes in the editor
- Unload remote dyson spheres when entering a new system or closing the editor
- When desync happens, client will request for whole dyson sphere data again

Manage dyson sphere subscribers in DysonSphereManager

- Refactor DysonSphereManager, LaunchManager
- Add new method ``SendPacketToDysonSphere()`` and ``SendPacketToDysonSphereExcept()`` in DysonSphereManager
- Add index checking in actions that add objects

Dyson sphere editor changes

- Disable the pause button
- Deselect components when the selected layer has components removed
- Deselect all when a layer or an orbit is removed
- Overwrite ``CalculateSailLifeDistribution()`` so its index will not go out of bound
