### PR TITLE
Add Sync Ups multiplayer option

### DIFF
--- a/NebulaModel/MultiplayerOptions.cs
+++ b/NebulaModel/MultiplayerOptions.cs
@@ -23,6 +23,9 @@ namespace NebulaModel
 
         public string LastIP { get; set; } = string.Empty;
 
+        [DisplayName("Sync Ups")]
+        public bool SyncUps { get; set; } = true;
+
         public string MechaColors { get; set; } = "209 151 76 255;184 90 72 255;94 92 92 255;123 234 255 255;229 155 94 255;255 243 235 255;255 248 245 255;255 255 255 255;";
 
         public Float4[] GetMechaColors()

--- a/NebulaModel/Packets/GameStates/GameStateUpdate.cs
+++ b/NebulaModel/Packets/GameStates/GameStateUpdate.cs
@@ -6,6 +6,16 @@ namespace NebulaModel.Packets.GameStates
     [HidePacketInDebugLogs]
     public class GameStateUpdate
     {
-        public GameState State { get; set; }
+        public long SentTime { get; set; }
+        public long GameTick { get; set; }
+        public float UnitsPerSecond { get; set; }
+
+        public GameStateUpdate() { }
+        public GameStateUpdate(long sentTime, long gameTick, float unitsPerSecond)
+        {
+            SentTime = sentTime;
+            GameTick = gameTick;
+            UnitsPerSecond = unitsPerSecond;
+        }
     }
 }

--- a/NebulaNetwork/Client.cs
+++ b/NebulaNetwork/Client.cs
@@ -18,6 +18,7 @@ namespace NebulaNetwork
 {
     public class Client : NetworkProvider
     {
+        private const float GAME_STATE_UPDATE_INTERVAL = 1f;
         private const int MECHA_SYNCHONIZATION_INTERVAL = 5;
 
         private readonly IPEndPoint serverEndpoint;
@@ -25,7 +26,7 @@ namespace NebulaNetwork
         private NebulaConnection serverConnection;
 
         private float mechaSynchonizationTimer = 0f;
-        private float pingTimer = 0f;
+        private float gameStateUpdateTimer = 0f;
 
         public Client(string url, int port)
             : this(new IPEndPoint(Dns.GetHostEntry(url).AddressList[0], port))
@@ -132,11 +133,11 @@ namespace NebulaNetwork
                     mechaSynchonizationTimer = 0f;
                 }
 
-                pingTimer += Time.deltaTime;
-                if (pingTimer >= 1f)
+                gameStateUpdateTimer += Time.deltaTime;
+                if (gameStateUpdateTimer >= GAME_STATE_UPDATE_INTERVAL)
                 {
                     SendPacket(new PingPacket());
-                    pingTimer = 0f;
+                    gameStateUpdateTimer = 0f;
                 }
             }
         }

--- a/NebulaNetwork/PacketProcessors/GameStates/GameStateUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/GameStates/GameStateUpdateProcessor.cs
@@ -17,6 +17,7 @@ namespace NebulaNetwork.PacketProcessors.GameStates
         private int averageRTT;
         private float avaerageUPS = 60f;
         private const float BUFFERING_TIME = 20f;
+        private bool hasChanged;
 
         public override void ProcessPacket(GameStateUpdate packet, NebulaConnection conn)
         {
@@ -39,7 +40,7 @@ namespace NebulaNetwork.PacketProcessors.GameStates
                     averageRTT = (int)rtt;
                     GameMain.gameTick = currentGameTick;
                 }
-                Log.Debug($"GameStateUpdate unstable. RTT:{rtt}(avg {averageRTT}) UPS:{packet.UnitsPerSecond:F2}(avg{avaerageUPS:F2})");
+                Log.Debug($"GameStateUpdate unstable. RTT:{rtt}(avg{averageRTT}) UPS:{packet.UnitsPerSecond:F2}(avg{avaerageUPS:F2})");
                 return;
             }
 
@@ -50,6 +51,12 @@ namespace NebulaNetwork.PacketProcessors.GameStates
                 {
                     Log.Info($"Game Tick got updated since it was desynced, was {GameMain.gameTick}, diff={diff}");
                     GameMain.gameTick = currentGameTick;
+                }
+                // Reset FixUPS when user turns off the option
+                if (hasChanged)
+                {
+                    FPSController.SetFixUPS(0);
+                    hasChanged = false;
                 }
                 return;
             }
@@ -81,6 +88,7 @@ namespace NebulaNetwork.PacketProcessors.GameStates
                 GameMain.gameTick += skipTick;
             }
             FPSController.SetFixUPS(UPS);
+            hasChanged = true;
         }
     }
 }

--- a/NebulaNetwork/PacketProcessors/GameStates/GameStateUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/GameStates/GameStateUpdateProcessor.cs
@@ -1,10 +1,12 @@
 ﻿using NebulaAPI;
+using NebulaModel;
 using NebulaModel.DataStructures;
 using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.GameStates;
-using NebulaModel.Utils;
+using NebulaWorld;
+using System;
 using UnityEngine;
 
 namespace NebulaNetwork.PacketProcessors.GameStates
@@ -12,21 +14,73 @@ namespace NebulaNetwork.PacketProcessors.GameStates
     [RegisterPacketProcessor]
     public class GameStateUpdateProcessor : PacketProcessor<GameStateUpdate>
     {
+        private int averageRTT;
+        private float avaerageUPS = 60f;
+        private const float BUFFERING_TIME = 20f;
+
         public override void ProcessPacket(GameStateUpdate packet, NebulaConnection conn)
         {
-            GameState state = packet.State;
+            long rtt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - packet.SentTime;
+            averageRTT = (int)(averageRTT * 0.8 + rtt * 0.2);
+            avaerageUPS = avaerageUPS * 0.8f + packet.UnitsPerSecond * 0.2f;
+            Multiplayer.Session.World.UpdatePingIndicator($"Ping: {averageRTT}ms");
 
             // We offset the tick received to account for the time it took to receive the packet
-            long timeOffset = TimeUtils.CurrentUnixTimestampMilliseconds() - packet.State.timestamp;
-            long tickOffsetSinceSent = (long)System.Math.Round(timeOffset / (GameMain.tickDeltaTime * 1000));
-            state.gameTick += tickOffsetSinceSent;
+            long tickOffsetSinceSent = (long)Math.Round(packet.UnitsPerSecond * rtt / 2 / 1000);
+            long currentGameTick = packet.GameTick + tickOffsetSinceSent;
+            long diff = currentGameTick - GameMain.gameTick;
 
-            // We allow for a small drift of 5 ticks since the tick offset using the ping is only an approximation
-            if (GameMain.gameTick > 0 && Mathf.Abs(state.gameTick - GameMain.gameTick) > 5)
+            // Discard abnormal packet (usually after host saving the file)
+            if (rtt > 2 * averageRTT || avaerageUPS - packet.UnitsPerSecond > 15)
             {
-                Log.Info($"Game Tick got updated since it was desynced, was {GameMain.gameTick}, received {state.gameTick}");
-                GameMain.gameTick = state.gameTick;
+                // Initial connetion
+                if (GameMain.gameTick < 1200L)
+                {
+                    averageRTT = (int)rtt;
+                    GameMain.gameTick = currentGameTick;
+                }
+                Log.Debug($"GameStateUpdate unstable. RTT:{rtt}(avg {averageRTT}) UPS:{packet.UnitsPerSecond:F2}(avg{avaerageUPS:F2})");
+                return;
             }
+
+            if (!Config.Options.SyncUps)
+            {
+                // We allow for a small drift of 5 ticks since the tick offset using the ping is only an approximation
+                if (GameMain.gameTick > 0 && Mathf.Abs(diff) > 5)
+                {
+                    Log.Info($"Game Tick got updated since it was desynced, was {GameMain.gameTick}, diff={diff}");
+                    GameMain.gameTick = currentGameTick;
+                }
+                return;
+            }
+
+            // Adjust client's UPS to match game tick with server, range 30~120 UPS
+            float UPS = diff / 1f + avaerageUPS;
+            long skipTick = 0;
+            if (UPS > 120f)
+            {
+                // Try to disturbute game tick difference into BUFFERING_TIME (seconds)
+                if (diff / BUFFERING_TIME + avaerageUPS > 120f)
+                {
+                    // The difference is too large, need to skip ticks to catch up
+                    skipTick = (long)(UPS - 120f);
+                }
+                UPS = 120f;
+            }
+            else if (UPS < 30f)
+            {
+                if (diff / BUFFERING_TIME + avaerageUPS < 30f)
+                {
+                    skipTick = (long)(UPS - 30f);
+                }
+                UPS = 30f;
+            }
+            if (skipTick != 0)
+            {
+                Log.Info($"Game Tick was desynced. skip={skipTick} diff={diff,2}, RTT={rtt}ms, UPS={packet.UnitsPerSecond:F2}");
+                GameMain.gameTick += skipTick;
+            }
+            FPSController.SetFixUPS(UPS);
         }
     }
 }

--- a/NebulaNetwork/PacketProcessors/Session/PingPacketProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Session/PingPacketProcessor.cs
@@ -1,28 +1,23 @@
 ﻿using NebulaAPI;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
+using NebulaModel.Packets.GameStates;
 using NebulaModel.Packets.Session;
-using NebulaWorld;
-using System;
 
 namespace NebulaNetwork.PacketProcessors.Session
 {
     [RegisterPacketProcessor]
     internal class PingPacketProcessor : PacketProcessor<PingPacket>
     {
-        private int averageRTT;
-
         public override void ProcessPacket(PingPacket packet, NebulaConnection conn)
         {
             if (IsHost)
             {
-                conn.SendPacket(packet);
+                conn.SendPacket(new GameStateUpdate(packet.SentTimestamp, GameMain.gameTick, (float)FPSController.currentUPS));
             }
             else
             {
-                int rtt = (int)(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - packet.SentTimestamp);
-                averageRTT = (int)(averageRTT * 0.7 + rtt * 0.3);
-                Multiplayer.Session.World.UpdatePingIndicator($"Ping: {averageRTT}ms");
+                conn.SendPacket(packet);
             }
         }
     }

--- a/NebulaNetwork/Server.cs
+++ b/NebulaNetwork/Server.cs
@@ -19,14 +19,12 @@ namespace NebulaNetwork
 {
     public class Server : NetworkProvider
     {
-        private const float GAME_STATE_UPDATE_INTERVAL = 1;
         private const float GAME_RESEARCH_UPDATE_INTERVAL = 2;
         private const float STATISTICS_UPDATE_INTERVAL = 1;
         private const float LAUNCH_UPDATE_INTERVAL = 2;
         private const float DYSONSPHERE_UPDATE_INTERVAL = 5;
         private const float WARNING_UPDATE_INTERVAL = 1;
 
-        private float gameStateUpdateTimer = 0;
         private float gameResearchHashUpdateTimer = 0;
         private float productionStatisticsUpdateTimer = 0;
         private float dysonLaunchUpateTimer = 1;
@@ -126,18 +124,11 @@ namespace NebulaNetwork
 
         public override void Update()
         {
-            gameStateUpdateTimer += Time.deltaTime;
             gameResearchHashUpdateTimer += Time.deltaTime;
             productionStatisticsUpdateTimer += Time.deltaTime;
             dysonLaunchUpateTimer += Time.deltaTime;
             dysonSphereUpdateTimer += Time.deltaTime;
             warningUpdateTimer += Time.deltaTime;
-
-            if (gameStateUpdateTimer > GAME_STATE_UPDATE_INTERVAL)
-            {
-                gameStateUpdateTimer = 0;
-                SendPacket(new GameStateUpdate() { State = new GameState(TimeUtils.CurrentUnixTimestampMilliseconds(), GameMain.gameTick) });
-            }
 
             if (gameResearchHashUpdateTimer > GAME_RESEARCH_UPDATE_INTERVAL)
             {


### PR DESCRIPTION
Try to adjust client's ups in the range of 30~120 to match with host when the option is enabled.  
The game tick difference of client and host is calculated by packet round-trip-time, host ``gameTick``, and host ``currentUPS``.  
The difference will be amortized over a period of time by increasing/decreasing client's ups, unless it exceeds the limit.  

Close #210 