### PR TITLE
Change send and receive behaviors

### DIFF
--- a/.github/scripts/thunderstore_bundle.js
+++ b/.github/scripts/thunderstore_bundle.js
@@ -124,6 +124,7 @@ function generateManifest() {
       `nebula-${apiPluginInfo.name}-${apiPluginInfo.version}`,
       "PhantomGamers-IlLine-1.0.0",
       "CommonAPI-CommonAPI-1.2.2",
+      "starfi5h-BulletTime-1.2.0",
     ],
     website_url: "https://github.com/hubastard/nebula"
   };

--- a/NebulaModel/Logger/Log.cs
+++ b/NebulaModel/Logger/Log.cs
@@ -5,6 +5,8 @@ namespace NebulaModel.Logger
 {
     public static class Log
     {
+        public static string MessageInfo { get; private set; }
+
         private static ILogger logger;
 
         public static void Init(ILogger logger)
@@ -27,6 +29,7 @@ namespace NebulaModel.Logger
         public static void Info(string message)
         {
             logger.LogInfo(message);
+            MessageInfo = message;
         }
 
         public static void Info(object message)

--- a/NebulaModel/Networking/NebulaConnection.cs
+++ b/NebulaModel/Networking/NebulaConnection.cs
@@ -44,25 +44,24 @@ namespace NebulaModel.Networking
             }            
         }
 
-        public void ProcessPacketQueue()
+        private void ProcessPacketQueue()
         {
-            if (pendingPackets.Count == 0 || !enable)
+            if (enable && pendingPackets.Count > 0)
             {
-                return;
-            }
-            byte[] packet = pendingPackets.Dequeue();
-            if (peerSocket.ReadyState == WebSocketState.Open)
-            {
-                enable = false;
-                peerSocket.SendAsync(packet, res => OnSendCompleted());
-            }
-            else
-            {
-                Log.Warn($"Cannot send packet to a {peerSocket.ReadyState} connection {peerEndpoint.GetHashCode()}");
+                byte[] packet = pendingPackets.Dequeue();
+                if (peerSocket.ReadyState == WebSocketState.Open)
+                {
+                    peerSocket.SendAsync(packet, OnSendCompleted);
+                    enable = false;
+                }
+                else
+                {
+                    Log.Warn($"Cannot send packet to a {peerSocket.ReadyState} connection {peerEndpoint.GetHashCode()}");
+                }
             }
         }
 
-        public void OnSendCompleted()
+        private void OnSendCompleted(bool result)
         {
             lock (pendingPackets)
             {

--- a/NebulaModel/Networking/Serialization/NetPacketProcessor.cs
+++ b/NebulaModel/Networking/Serialization/NetPacketProcessor.cs
@@ -26,6 +26,7 @@ namespace NebulaModel.Networking.Serialization
         public bool SimulateLatency = false;
         public int SimulatedMinLatency = 20;
         public int SimulatedMaxLatency = 50;
+        public bool Enable { get; set; } = true;
 
         public NetPacketProcessor()
         {
@@ -70,7 +71,7 @@ namespace NebulaModel.Networking.Serialization
             {
                 ProcessDelayedPackets();
 
-                while (pendingPackets.Count > 0)
+                while (pendingPackets.Count > 0 && Enable)
                 {
                     PendingPacket packet = pendingPackets.Dequeue();
                     ReadPacket(new NetDataReader(packet.Data), packet.UserData);

--- a/NebulaModel/Packets/Session/HandshakeRequest.cs
+++ b/NebulaModel/Packets/Session/HandshakeRequest.cs
@@ -33,6 +33,17 @@ namespace NebulaModel.Packets.Session
                         writer.BinaryWriter.Write(mod.Version);
                         count++;
                     }
+                    else
+                    {
+                        foreach (BepInEx.BepInDependency dependency in pluginInfo.Value.Dependencies)
+                        {
+                            if (dependency.DependencyGUID == NebulaModAPI.API_GUID)
+                            {
+                                writer.BinaryWriter.Write(pluginInfo.Key);
+                                writer.BinaryWriter.Write(pluginInfo.Value.Metadata.Version.ToString());
+                            }
+                        }
+                    }
                 }
 
                 ModsVersion = writer.CloseAndGetBytes();

--- a/NebulaModel/Packets/Session/LobbyRequest.cs
+++ b/NebulaModel/Packets/Session/LobbyRequest.cs
@@ -28,6 +28,18 @@ namespace NebulaModel.Packets.Session
                         writer.BinaryWriter.Write(mod.Version);
                         count++;
                     }
+                    else
+                    {
+                        foreach (BepInEx.BepInDependency dependency in pluginInfo.Value.Dependencies)
+                        {
+                            if (dependency.DependencyGUID == NebulaModAPI.API_GUID)
+                            {
+                                writer.BinaryWriter.Write(pluginInfo.Key);
+                                writer.BinaryWriter.Write(pluginInfo.Value.Metadata.Version.ToString());
+                                count++;
+                            }
+                        }
+                    }
                 }
 
                 ModsVersion = writer.CloseAndGetBytes();

--- a/NebulaNetwork/Client.cs
+++ b/NebulaNetwork/Client.cs
@@ -140,7 +140,10 @@ namespace NebulaNetwork
                 gameStateUpdateTimer += Time.deltaTime;
                 if (gameStateUpdateTimer >= GAME_STATE_UPDATE_INTERVAL)
                 {
-                    SendPacket(new PingPacket());
+                    if (!GameMain.isFullscreenPaused)
+                    {
+                        SendPacket(new PingPacket());
+                    }
                     gameStateUpdateTimer = 0f;
                 }
             }

--- a/NebulaNetwork/PacketProcessors/Planet/FactoryDataProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Planet/FactoryDataProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using NebulaAPI;
+using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.Planet;
@@ -16,12 +17,17 @@ namespace NebulaNetwork.PacketProcessors.Planet
                 return;
             }
 
+            PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
             Multiplayer.Session.Planets.PendingFactories.Add(packet.PlanetId, packet.BinaryData);
+            Log.Info($"Parsing {packet.BinaryData.Length} bytes of data for PlanetFactory {planet.name} (ID: {planet.id})");
 
             lock (PlanetModelingManager.fctPlanetReqList)
             {
                 PlanetModelingManager.fctPlanetReqList.Enqueue(GameMain.galaxy.PlanetById(packet.PlanetId));
             }
+            // Stop packet processing until factory is imported
+            ((NebulaModel.NetworkProvider)Multiplayer.Session.Network).PacketProcessor.Enable = false;
+            Log.Info($"FactoryDataProcessor: Pause PacketProcessor");
         }
     }
 }

--- a/NebulaNetwork/PacketProcessors/Planet/FactoryDataProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Planet/FactoryDataProcessor.cs
@@ -16,18 +16,18 @@ namespace NebulaNetwork.PacketProcessors.Planet
             {
                 return;
             }
+            // Stop packet processing until factory is imported
+            ((NebulaModel.NetworkProvider)Multiplayer.Session.Network).PacketProcessor.Enable = false;
+            Log.Info($"FactoryDataProcessor: Pause PacketProcessor");
 
             PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
             Multiplayer.Session.Planets.PendingFactories.Add(packet.PlanetId, packet.BinaryData);
-            Log.Info($"Parsing {packet.BinaryData.Length} bytes of data for PlanetFactory {planet.name} (ID: {planet.id})");
+            Log.Info($"Parsing {packet.BinaryData.Length} bytes of data for factory {planet.name} (ID: {planet.id})");
 
             lock (PlanetModelingManager.fctPlanetReqList)
             {
                 PlanetModelingManager.fctPlanetReqList.Enqueue(GameMain.galaxy.PlanetById(packet.PlanetId));
             }
-            // Stop packet processing until factory is imported
-            ((NebulaModel.NetworkProvider)Multiplayer.Session.Network).PacketProcessor.Enable = false;
-            Log.Info($"FactoryDataProcessor: Pause PacketProcessor");
         }
     }
 }

--- a/NebulaNetwork/PacketProcessors/Planet/FactoryLoadRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Planet/FactoryLoadRequestProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using NebulaAPI;
+using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.Planet;
@@ -22,7 +23,9 @@ namespace NebulaNetwork.PacketProcessors.Planet
             using (BinaryUtils.Writer writer = new BinaryUtils.Writer())
             {
                 factory.Export(writer.BinaryWriter);
-                conn.SendPacket(new FactoryData(packet.PlanetID, writer.CloseAndGetBytes()));
+                byte[] data = writer.CloseAndGetBytes();
+                Log.Info($"Sent {data.Length} bytes of data for PlanetFactory {planet.name} (ID: {planet.id})");
+                conn.SendPacket(new FactoryData(packet.PlanetID, data));
             }
 
             // Add requesting client to connected player, so he can receive following update

--- a/NebulaNetwork/PacketProcessors/Session/LobbyRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Session/LobbyRequestProcessor.cs
@@ -91,6 +91,28 @@ namespace NebulaNetwork.PacketProcessors.Session
 
                         return;
                     }
+                    else
+                    {
+                        foreach (BepInEx.BepInDependency dependency in pluginInfo.Value.Dependencies)
+                        {
+                            if (dependency.DependencyGUID == NebulaModAPI.API_GUID)
+                            {
+                                string hostVersion = pluginInfo.Value.Metadata.Version.ToString();
+                                if (!clientMods.ContainsKey(pluginInfo.Key))
+                                {
+                                    conn.Disconnect(DisconnectionReason.ModIsMissing, pluginInfo.Key);
+                                    pendingPlayers.Remove(conn);
+                                    return;
+                                }
+                                if (clientMods[pluginInfo.Key] != hostVersion)
+                                {
+                                    conn.Disconnect(DisconnectionReason.ModVersionMismatch, $"{pluginInfo.Key};{clientMods[pluginInfo.Key]};{hostVersion}");
+                                    pendingPlayers.Remove(conn);
+                                    return;
+                                }
+                            }
+                        }
+                    }
                 }
 
                 if (packet.GameVersionSig != GameConfig.gameVersion.sig)

--- a/NebulaNetwork/PacketProcessors/Session/LobbyResponseProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Session/LobbyResponseProcessor.cs
@@ -26,6 +26,7 @@ namespace NebulaNetwork.PacketProcessors.Session
                 }
             }
             ((LocalPlayer)Multiplayer.Session.LocalPlayer).IsHost = false;
+            Multiplayer.Session.IsInLobby = true;
 
             UIRoot.instance.galaxySelect._Open();
             UIRoot.instance.uiMainMenu._Close();

--- a/NebulaNetwork/PacketProcessors/Session/PingPacketProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Session/PingPacketProcessor.cs
@@ -3,6 +3,7 @@ using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.GameStates;
 using NebulaModel.Packets.Session;
+using NebulaWorld.GameStates;
 
 namespace NebulaNetwork.PacketProcessors.Session
 {
@@ -13,7 +14,7 @@ namespace NebulaNetwork.PacketProcessors.Session
         {
             if (IsHost)
             {
-                conn.SendPacket(new GameStateUpdate(packet.SentTimestamp, GameMain.gameTick, (float)FPSController.currentUPS));
+                conn.SendPacket(new GameStateUpdate(packet.SentTimestamp, GameStatesManager.RealGameTick, GameStatesManager.RealUPS));
             }
             else
             {

--- a/NebulaNetwork/PacketProcessors/Session/SyncCompleteProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Session/SyncCompleteProcessor.cs
@@ -30,6 +30,7 @@ namespace NebulaNetwork.PacketProcessors.Session
                 if (player == null)
                 {
                     Log.Warn("Received a SyncComplete packet, but no player is joining.");
+                    Multiplayer.Session.World.OnAllPlayersSyncCompleted();
                     return;
                 }
 
@@ -54,7 +55,10 @@ namespace NebulaNetwork.PacketProcessors.Session
 
                 using (playerManager.GetConnectedPlayers(out System.Collections.Generic.Dictionary<INebulaConnection, INebulaPlayer> connectedPlayers))
                 {
-                    connectedPlayers.Add(player.Connection, player);
+                    if (!connectedPlayers.ContainsKey(player.Connection))
+                    {
+                        connectedPlayers.Add(player.Connection, player);
+                    }
                 }
 
                 // Load overriden Planet and Star names

--- a/NebulaNetwork/PacketProcessors/Universe/DysonSphereDataProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/DysonSphereDataProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using NebulaAPI;
+using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.Universe;
@@ -54,6 +55,8 @@ namespace NebulaNetwork.PacketProcessors.Universe
                         GameMain.data.dysonSpheres[packet.StarIndex].Init(GameMain.data, GameMain.data.galaxy.stars[packet.StarIndex]);
                     }
 
+                    StarData star = GameMain.galaxy.stars[packet.StarIndex];
+                    Log.Info($"Parsing {packet.BinaryData.Length} bytes of data for DysonSphere {star.name} (INDEX: {star.id})");
                     using (BinaryUtils.Reader reader = new BinaryUtils.Reader(packet.BinaryData))
                     {
                         GameMain.data.dysonSpheres[packet.StarIndex].Import(reader.BinaryReader);
@@ -64,8 +67,12 @@ namespace NebulaNetwork.PacketProcessors.Universe
                         UIComboBox dysonBox2 = UIRoot.instance.uiGame.dysonEditor.controlPanel.topFunction.dysonBox;
                         int index2 = dysonBox2.ItemsData.FindIndex(x => x == UIRoot.instance.uiGame.dysonEditor.selection.viewStar?.index);
                         dysonBox2.itemIndex = index2 >= 0 ? index2 : 0;
+                    }                    
+                    if (Multiplayer.Session.IsGameLoaded)
+                    {
+                        // Don't fade out when client is still joining
+                        InGamePopup.FadeOut();
                     }
-                    InGamePopup.FadeOut();
                     Multiplayer.Session.DysonSpheres.RequestingIndex = -1;
                     Multiplayer.Session.DysonSpheres.IsNormal = true;
                     break;

--- a/NebulaNetwork/PacketProcessors/Universe/DysonSphereRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/DysonSphereRequestProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using NebulaAPI;
+using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.Universe;
@@ -42,7 +43,9 @@ namespace NebulaNetwork.PacketProcessors.Universe
                     using (BinaryUtils.Writer writer = new BinaryUtils.Writer())
                     {
                         dysonSphere.Export(writer.BinaryWriter);
-                        conn.SendPacket(new DysonSphereData(packet.StarIndex, writer.CloseAndGetBytes(), DysonSphereRespondEvent.Load));
+                        byte[] data = writer.CloseAndGetBytes();
+                        Log.Info($"Sent {data.Length} bytes of data for DysonSphereData (INDEX: {packet.StarIndex})");
+                        conn.SendPacket(new DysonSphereData(packet.StarIndex, data, DysonSphereRespondEvent.Load));
                         Multiplayer.Session.DysonSpheres.RegisterPlayer(conn, packet.StarIndex);
                     }
                     break;

--- a/NebulaNetwork/PlayerManager.cs
+++ b/NebulaNetwork/PlayerManager.cs
@@ -266,25 +266,19 @@ namespace NebulaNetwork
 
             using (GetPendingPlayers(out Dictionary<INebulaConnection, INebulaPlayer> pendingPlayers))
             {
-                if (player == null)
+                if (pendingPlayers.TryGetValue(conn, out player))
                 {
-                    if (pendingPlayers.TryGetValue(conn, out player))
-                    {
-                        pendingPlayers.Remove(conn);
-                    }
+                    pendingPlayers.Remove(conn);
                 }
             }
 
             using (GetSyncingPlayers(out Dictionary<INebulaConnection, INebulaPlayer> syncingPlayers))
             {
-                if (player == null)
+                if (syncingPlayers.TryGetValue(conn, out player))
                 {
-                    if (syncingPlayers.TryGetValue(conn, out player))
-                    {
-                        syncingPlayers.Remove(conn);
-                        playerWasSyncing = true;
-                        syncCount = syncingPlayers.Count;
-                    }
+                    syncingPlayers.Remove(conn);
+                    playerWasSyncing = true;
+                    syncCount = syncingPlayers.Count;
                 }
             }
 

--- a/NebulaNetwork/PlayerManager.cs
+++ b/NebulaNetwork/PlayerManager.cs
@@ -252,30 +252,33 @@ namespace NebulaNetwork
 
         public void PlayerDisconnected(INebulaConnection conn)
         {
-            INebulaPlayer player;
+            INebulaPlayer player = null;
             bool playerWasSyncing = false;
             int syncCount = -1;
 
             using (GetConnectedPlayers(out Dictionary<INebulaConnection, INebulaPlayer> connectedPlayers))
             {
-                if (connectedPlayers.TryGetValue(conn, out player))
+                if (connectedPlayers.TryGetValue(conn, out INebulaPlayer removingPlayer))
                 {
+                    player = removingPlayer;
                     connectedPlayers.Remove(conn);
                 }
             }
 
             using (GetPendingPlayers(out Dictionary<INebulaConnection, INebulaPlayer> pendingPlayers))
             {
-                if (pendingPlayers.TryGetValue(conn, out player))
+                if (pendingPlayers.TryGetValue(conn, out INebulaPlayer removingPlayer))
                 {
+                    player = removingPlayer;
                     pendingPlayers.Remove(conn);
                 }
             }
 
             using (GetSyncingPlayers(out Dictionary<INebulaConnection, INebulaPlayer> syncingPlayers))
             {
-                if (syncingPlayers.TryGetValue(conn, out player))
+                if (syncingPlayers.TryGetValue(conn, out INebulaPlayer removingPlayer))
                 {
+                    player = removingPlayer;
                     syncingPlayers.Remove(conn);
                     playerWasSyncing = true;
                     syncCount = syncingPlayers.Count;

--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -77,8 +77,6 @@ namespace NebulaPatcher.Patches.Dynamic
             // Assign the factory to the result
             __result = __instance.factories[planet.factoryIndex];
 
-            NebulaModAPI.OnPlanetLoadFinished?.Invoke(planet.id);
-
             // Do not run the original method
             return false;
         }
@@ -142,6 +140,8 @@ namespace NebulaPatcher.Patches.Dynamic
                     ((NebulaModel.NetworkProvider)Multiplayer.Session.Network).PacketProcessor.Enable = true;
                     Log.Info($"OnActivePlanetLoaded: Resume PacketProcessor");
                 }
+
+                NebulaModAPI.OnPlanetLoadFinished?.Invoke(planet.id);
             }
 
             // call this here as it would not be called normally on the client, but its needed to set GameMain.data.galacticTransport.stationCursor

--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -28,7 +28,7 @@ namespace NebulaPatcher.Patches.Dynamic
 
         [HarmonyPrefix]
         [HarmonyPatch(nameof(GameData.GetOrCreateFactory))]
-        public static bool GetOrCreateFactory_Prefix(GameData __instance, PlanetFactory __result, PlanetData planet)
+        public static bool GetOrCreateFactory_Prefix(GameData __instance, ref PlanetFactory __result, PlanetData planet)
         {
             // We want the original method to run on the host client or in single player games
             if (!Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost)
@@ -135,6 +135,13 @@ namespace NebulaPatcher.Patches.Dynamic
                 planet.physics.raycastLogic.factory = planet.factory;
 
                 planet.onFactoryLoaded -= __instance.OnActivePlanetFactoryLoaded;
+
+                // If the game is still loading, we wait till the full loading is completed
+                if (Multiplayer.Session.IsGameLoaded)
+                {
+                    ((NebulaModel.NetworkProvider)Multiplayer.Session.Network).PacketProcessor.Enable = true;
+                    Log.Info($"OnActivePlanetLoaded: Resume PacketProcessor");
+                }
             }
 
             // call this here as it would not be called normally on the client, but its needed to set GameMain.data.galacticTransport.stationCursor

--- a/NebulaPatcher/Patches/Dynamic/GameLoader_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameLoader_Patch.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using NebulaModel.Logger;
 using NebulaWorld;
 
 namespace NebulaPatcher.Patches.Dynamic
@@ -10,6 +11,7 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPatch(nameof(GameLoader.FixedUpdate))]
         public static void FixedUpdate_Postfix(int ___frame)
         {
+            InGamePopup.UpdateMessage("Loading", "Loading state from server, please wait\n" + Log.MessageInfo);
             if (Multiplayer.IsActive && ___frame >= 11)
             {
                 Multiplayer.Session.OnGameLoadCompleted();

--- a/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
@@ -46,12 +46,11 @@ namespace NebulaPatcher.Patches.Dynamic
                 PlanetModelingManager.currentFactingStage = 0;
                 return false;
             }
+            NebulaModAPI.OnPlanetLoadRequest?.Invoke(planet.id);
 
             // Request factory
             Log.Info($"Requested factory for planet {planet.name} (ID: {planet.id}) from host");
-            Multiplayer.Session.Network.SendPacket(new FactoryLoadRequest(planet.id));
-
-            NebulaModAPI.OnPlanetLoadRequest?.Invoke(planet.id);
+            Multiplayer.Session.Network.SendPacket(new FactoryLoadRequest(planet.id));            
 
             // Skip running the actual method
             return false;

--- a/NebulaPatcher/Patches/Dynamic/UIMainMenu_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIMainMenu_Patch.cs
@@ -292,7 +292,6 @@ namespace NebulaPatcher.Patches.Dynamic
             if (isIP)
             {
                 Multiplayer.JoinGame(new Client(new IPEndPoint(IPAddress.Parse(connectionString), serverPort)));
-                Multiplayer.Session.IsInLobby = true;
                 return true;
             }
 
@@ -300,7 +299,6 @@ namespace NebulaPatcher.Patches.Dynamic
             if (System.Uri.TryCreate(connectionString, System.UriKind.RelativeOrAbsolute, out _))
             {
                 Multiplayer.JoinGame(new Client(connectionString, serverPort));
-                Multiplayer.Session.IsInLobby = true;
                 return true;
             }
 

--- a/NebulaWorld/GameStates/GameStatesManager.cs
+++ b/NebulaWorld/GameStates/GameStatesManager.cs
@@ -13,5 +13,12 @@ namespace NebulaWorld.GameStates
         public void Dispose()
         {
         }
+
+        public static long RealGameTick => GameMain.gameTick;
+        public static float RealUPS => (float)FPSController.currentUPS;
+
+        public static void NotifyTickDifference(float delta)
+        {
+        }
     }
 }

--- a/NebulaWorld/GameStates/GameStatesManager.cs
+++ b/NebulaWorld/GameStates/GameStatesManager.cs
@@ -1,0 +1,17 @@
+﻿using NebulaModel.Logger;
+using System;
+
+namespace NebulaWorld.GameStates
+{
+    public class GameStatesManager : IDisposable
+    {
+
+        public GameStatesManager()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/NebulaWorld/InGamePopup.cs
+++ b/NebulaWorld/InGamePopup.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEngine;
 
 namespace NebulaWorld
 {
@@ -10,6 +11,16 @@ namespace NebulaWorld
         {
             displayedMessage?.FadeOut();
             displayedMessage = null;
+        }
+
+        public static void UpdateMessage(in string title, string message)
+        {
+            if (displayedMessage != null && displayedMessage.m_TitleText.text == title)
+            {
+                displayedMessage.m_MessageText.horizontalOverflow = HorizontalWrapMode.Overflow;
+                displayedMessage.m_MessageText.verticalOverflow = VerticalWrapMode.Overflow;
+                displayedMessage.m_MessageText.text = message;
+            }
         }
 
         // Info

--- a/NebulaWorld/MultiplayerSession.cs
+++ b/NebulaWorld/MultiplayerSession.cs
@@ -3,6 +3,7 @@ using NebulaModel;
 using NebulaModel.Logger;
 using NebulaWorld.Factory;
 using NebulaWorld.GameDataHistory;
+using NebulaWorld.GameStates;
 using NebulaWorld.Logistics;
 using NebulaWorld.Planet;
 using NebulaWorld.Player;
@@ -26,6 +27,7 @@ namespace NebulaWorld
         public BuildToolManager BuildTools { get; private set; }
         public DroneManager Drones { get; private set; }
         public GameDataHistoryManager History { get; private set; }
+        public GameStatesManager State { get; private set; }
         public ILSShipManager Ships { get; private set; }
         public StationUIManager StationsUI { get; private set; }
         public PlanetManager Planets { get; private set; }
@@ -67,6 +69,7 @@ namespace NebulaWorld
             BuildTools = new BuildToolManager();
             Drones = new DroneManager();
             History = new GameDataHistoryManager();
+            State = new GameStatesManager();
             Ships = new ILSShipManager();
             StationsUI = new StationUIManager();
             Planets = new PlanetManager();
@@ -110,6 +113,9 @@ namespace NebulaWorld
 
             History?.Dispose();
             History = null;
+
+            State?.Dispose();
+            State = null;
 
             Ships?.Dispose();
             Ships = null;

--- a/NebulaWorld/MultiplayerSession.cs
+++ b/NebulaWorld/MultiplayerSession.cs
@@ -142,6 +142,8 @@ namespace NebulaWorld
             {
                 Log.Info("Game load completed");
                 IsGameLoaded = true;
+                ((NebulaModel.NetworkProvider)Multiplayer.Session.Network).PacketProcessor.Enable = true;
+                Log.Info($"OnGameLoadCompleted: Resume PacketProcessor");
 
                 if (Multiplayer.Session.LocalPlayer.IsHost)
                 {

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -306,7 +306,7 @@ namespace NebulaWorld
                 }
                 else
                 {
-                    Log.Error("Could not find the playerAnimator for player with ID " + playerId);
+                    Log.Warn("Could not find the playerAnimator for player with ID " + playerId);
                     return;
                 }
                 

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -157,7 +157,7 @@ namespace NebulaWorld
                 IsPlayerJoining = true;
                 Multiplayer.Session.CanPause = true;
                 GameMain.isFullscreenPaused = true;
-                InGamePopup.ShowInfo("Loading", Username + " joining the game, please wait", null);
+                InGamePopup.ShowInfo("Loading", Username + " joining the game, please wait\n(Use BulletTime mod to unfreeze the game)", null);
             }
         }
 


### PR DESCRIPTION
**NebulaConnection**

Switch to ``SendAsync`` and add sending packet queuing.

**NetPacketProcessor**

Add ``enable`` property, can pause or resume packet processor.  
It is used to pause packet processing when loading factory data.  

**PlayerManager**

Syncing player now will be added to ``connectedPlayers`` at the moment of requesting factory data, so he can receive the following factory update.
