### PR TITLE
Bugfix and issue list for 0.8.0 pre-release

### DIFF
--- a/NebulaModel/DataStructures/PlayerData.cs
+++ b/NebulaModel/DataStructures/PlayerData.cs
@@ -96,6 +96,25 @@ namespace NebulaModel.DataStructures
             }
         }
 
+        // Old import method
+        public void DeserializeOld(INetDataReader reader, ushort revision)
+        {
+            Username = reader.GetString();
+            PlayerId = reader.GetUShort();
+            LocalPlanetId = reader.GetInt();
+            MechaColors = new Float4[reader.GetInt()];
+            for (int i = 0; i < MechaColors.Length; i++)
+            {
+                MechaColors[i] = reader.GetFloat4();
+            }
+            LocalPlanetPosition = reader.GetFloat3();
+            UPosition = reader.GetDouble3();
+            Rotation = reader.GetFloat3();
+            BodyRotation = reader.GetFloat3();
+            Mecha = new MechaData();
+            Mecha.Deserialize(reader);
+        }
+
         public IPlayerData CreateCopyWithoutMechaData()
         {
             return new PlayerData(PlayerId, LocalPlanetId, MechaColors, Username, LocalPlanetPosition, UPosition, Rotation, BodyRotation);

--- a/NebulaModel/Logger/Log.cs
+++ b/NebulaModel/Logger/Log.cs
@@ -47,6 +47,7 @@ namespace NebulaModel.Logger
         public static void Error(string message)
         {
             logger.LogError(message);
+            UIFatalErrorTip.instance.ShowError("[Nebula Error] " + message, "");
         }
 
         public static void Error(Exception ex)

--- a/NebulaModel/Packets/Factory/Belt/BeltSignalIconPacket.cs
+++ b/NebulaModel/Packets/Factory/Belt/BeltSignalIconPacket.cs
@@ -1,0 +1,17 @@
+﻿namespace NebulaModel.Packets.Factory.Belt
+{
+    public class BeltSignalIconPacket
+    {
+        public int EntityId { get; set; }
+        public int SignalId { get; set; }
+        public int PlanetId { get; set; }
+
+        public BeltSignalIconPacket() { }
+        public BeltSignalIconPacket(int entityId, int signalId, int planetId)
+        {
+            EntityId = entityId;
+            SignalId = signalId;
+            PlanetId = planetId;
+        }
+    }
+}

--- a/NebulaModel/Packets/Factory/Belt/BeltSignalNumberPacket.cs
+++ b/NebulaModel/Packets/Factory/Belt/BeltSignalNumberPacket.cs
@@ -1,0 +1,17 @@
+﻿namespace NebulaModel.Packets.Factory.Belt
+{
+    public class BeltSignalNumberPacket
+    {
+        public int EntityId { get; set; }
+        public float Number { get; set; }
+        public int PlanetId { get; set; }
+
+        public BeltSignalNumberPacket() { }
+        public BeltSignalNumberPacket(int entityId, float number, int planetId)
+        {
+            EntityId = entityId;
+            Number = number;
+            PlanetId = planetId;
+        }
+    }
+}

--- a/NebulaModel/Packets/Factory/Belt/BeltUpdatePickupItemsPacket.cs
+++ b/NebulaModel/Packets/Factory/Belt/BeltUpdatePickupItemsPacket.cs
@@ -1,6 +1,6 @@
 ﻿using NebulaAPI;
 
-namespace NebulaModel.Packets.Belt
+namespace NebulaModel.Packets.Factory.Belt
 {
     public class BeltUpdatePickupItemsPacket
     {

--- a/NebulaModel/Packets/Factory/Belt/BeltUpdatePutItemOnPacket.cs
+++ b/NebulaModel/Packets/Factory/Belt/BeltUpdatePutItemOnPacket.cs
@@ -1,4 +1,4 @@
-﻿namespace NebulaModel.Packets.Belt
+﻿namespace NebulaModel.Packets.Factory.Belt
 {
     public class BeltUpdatePutItemOnPacket
     {

--- a/NebulaModel/Packets/Factory/Belt/ConnectToMonitorPacket.cs
+++ b/NebulaModel/Packets/Factory/Belt/ConnectToMonitorPacket.cs
@@ -1,0 +1,19 @@
+﻿namespace NebulaModel.Packets.Factory.Belt
+{
+    public class ConnectToMonitorPacket
+    {
+        public int MonitorId { get; set; }
+        public int BeltId { get; set; }
+        public int Offset { get; set; }
+        public int PlanetId { get; set; }
+
+        public ConnectToMonitorPacket() { }
+        public ConnectToMonitorPacket(int monitorId, int beltId, int offset, int planetId)
+        {
+            MonitorId = monitorId;
+            BeltId = beltId;
+            Offset = offset;
+            PlanetId = planetId;
+        }
+    }
+}

--- a/NebulaModel/Packets/Factory/Belt/ConnectToSpraycoaterPacket.cs
+++ b/NebulaModel/Packets/Factory/Belt/ConnectToSpraycoaterPacket.cs
@@ -1,0 +1,19 @@
+﻿namespace NebulaModel.Packets.Factory.Belt
+{
+    public class ConnectToSpraycoaterPacket
+    {
+        public int SpraycoaterId { get; set; }
+        public int CargoBeltId { get; set; }
+        public int IncBeltId { get; set; }
+        public int PlanetId { get; set; }
+
+        public ConnectToSpraycoaterPacket() { }
+        public ConnectToSpraycoaterPacket(int spraycoaterId, int cargoBeltId, int incBeltId, int planetId)
+        {
+            SpraycoaterId = spraycoaterId;
+            CargoBeltId = cargoBeltId;
+            IncBeltId = incBeltId;
+            PlanetId = planetId;
+        }
+    }
+}

--- a/NebulaModel/Packets/Factory/BuildEntityRequest.cs
+++ b/NebulaModel/Packets/Factory/BuildEntityRequest.cs
@@ -5,13 +5,15 @@
         public int PlanetId { get; set; }
         public int PrebuildId { get; set; }
         public int AuthorId { get; set; }
+        public int EntityId { get; set; }
 
         public BuildEntityRequest() { }
-        public BuildEntityRequest(int planetId, int prebuildId, int authorId)
+        public BuildEntityRequest(int planetId, int prebuildId, int authorId, int entityId)
         {
             PlanetId = planetId;
             PrebuildId = prebuildId;
             AuthorId = authorId;
+            EntityId = entityId;
         }
     }
 }

--- a/NebulaModel/Packets/Factory/CreatePrebuildsRequest.cs
+++ b/NebulaModel/Packets/Factory/CreatePrebuildsRequest.cs
@@ -11,10 +11,11 @@ namespace NebulaModel.Packets.Factory
         public byte[] BuildPreviewData { get; set; }
         public int AuthorId { get; set; }
         public string BuildToolType { get; set; }
+        public int PrebuildId { get; set; }
 
         public CreatePrebuildsRequest() { }
 
-        public CreatePrebuildsRequest(int planetId, List<BuildPreview> buildPreviews, int playerId, string buildToolType)
+        public CreatePrebuildsRequest(int planetId, List<BuildPreview> buildPreviews, int playerId, string buildToolType, int prebuildId)
         {
             AuthorId = playerId;
             PlanetId = planetId;
@@ -28,6 +29,7 @@ namespace NebulaModel.Packets.Factory
                 }
                 BuildPreviewData = writer.CloseAndGetBytes();
             }
+            PrebuildId = prebuildId;
         }
 
         public List<BuildPreview> GetBuildPreviews()

--- a/NebulaModel/Packets/Session/SyncComplete.cs
+++ b/NebulaModel/Packets/Session/SyncComplete.cs
@@ -9,7 +9,11 @@ namespace NebulaModel.Packets.Session
         public PlayerData[] AllPlayers { get; set; }
         public byte[] ClientCert { get; set; }
 
-        public SyncComplete() { AllPlayers = new PlayerData[] { }; }
+        public SyncComplete()
+        {
+            AllPlayers = new PlayerData[] { };
+            ClientCert = new byte[] { };
+        }
         public SyncComplete(IPlayerData[] otherPlayers)
         {
             AllPlayers = otherPlayers.Select(data => (PlayerData)data).ToArray();

--- a/NebulaNetwork/PacketProcessors/Factory/Belt/BeltSignalIconProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Belt/BeltSignalIconProcessor.cs
@@ -1,0 +1,25 @@
+﻿using NebulaAPI;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Factory.Belt;
+using NebulaWorld;
+
+namespace NebulaNetwork.PacketProcessors.Factory.Belt
+{
+    [RegisterPacketProcessor]
+    internal class BeltSignalIconProcessor : PacketProcessor<BeltSignalIconPacket>
+    {
+        public override void ProcessPacket(BeltSignalIconPacket packet, NebulaConnection conn)
+        {
+            using (Multiplayer.Session.Factories.IsIncomingRequest.On())
+            {
+                CargoTraffic cargoTraffic = GameMain.galaxy.PlanetById(packet.PlanetId)?.factory?.cargoTraffic;
+                if (cargoTraffic == null)
+                {
+                    return;
+                }
+                cargoTraffic.SetBeltSignalIcon(packet.EntityId, packet.SignalId);
+            }
+        }
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Factory/Belt/BeltSignalNumberProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Belt/BeltSignalNumberProcessor.cs
@@ -1,0 +1,25 @@
+﻿using NebulaAPI;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Factory.Belt;
+using NebulaWorld;
+
+namespace NebulaNetwork.PacketProcessors.Factory.Belt
+{
+    [RegisterPacketProcessor]
+    internal class BeltSignalNumberProcessor : PacketProcessor<BeltSignalNumberPacket>
+    {
+        public override void ProcessPacket(BeltSignalNumberPacket packet, NebulaConnection conn)
+        {
+            using (Multiplayer.Session.Factories.IsIncomingRequest.On())
+            {
+                CargoTraffic cargoTraffic = GameMain.galaxy.PlanetById(packet.PlanetId)?.factory?.cargoTraffic;
+                if (cargoTraffic == null)
+                {
+                    return;
+                }
+                cargoTraffic.SetBeltSignalNumber(packet.EntityId, packet.Number);
+            }
+        }
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Factory/Belt/BeltUpdatePickupItemsProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Belt/BeltUpdatePickupItemsProcessor.cs
@@ -2,7 +2,7 @@
 using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
-using NebulaModel.Packets.Belt;
+using NebulaModel.Packets.Factory.Belt;
 
 namespace NebulaNetwork.PacketProcessors.Factory.Belt
 {

--- a/NebulaNetwork/PacketProcessors/Factory/Belt/ConnectToMonitorProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Belt/ConnectToMonitorProcessor.cs
@@ -1,5 +1,4 @@
 ﻿using NebulaAPI;
-using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.Factory.Belt;
@@ -8,9 +7,9 @@ using NebulaWorld;
 namespace NebulaNetwork.PacketProcessors.Factory.Belt
 {
     [RegisterPacketProcessor]
-    internal class BeltUpdatePutItemOnProcessor : PacketProcessor<BeltUpdatePutItemOnPacket>
+    internal class ConnectToMonitorProcessor : PacketProcessor<ConnectToMonitorPacket>
     {
-        public override void ProcessPacket(BeltUpdatePutItemOnPacket packet, NebulaConnection conn)
+        public override void ProcessPacket(ConnectToMonitorPacket packet, NebulaConnection conn)
         {
             using (Multiplayer.Session.Factories.IsIncomingRequest.On())
             {
@@ -19,10 +18,7 @@ namespace NebulaNetwork.PacketProcessors.Factory.Belt
                 {
                     return;
                 }
-                if (!cargoTraffic.PutItemOnBelt(packet.BeltId, packet.ItemId, packet.ItemInc))
-                {
-                    Log.Warn($"BeltUpdatePutItemOn: Cannot put item{packet.ItemId} on belt{packet.BeltId}, planet{packet.PlanetId}");
-                }
+                cargoTraffic.ConnectToMonitor(packet.MonitorId, packet.BeltId, packet.Offset);
             }
         }
     }

--- a/NebulaNetwork/PacketProcessors/Factory/Belt/ConnectToSpraycoaterProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Belt/ConnectToSpraycoaterProcessor.cs
@@ -1,5 +1,4 @@
 ﻿using NebulaAPI;
-using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.Factory.Belt;
@@ -8,9 +7,9 @@ using NebulaWorld;
 namespace NebulaNetwork.PacketProcessors.Factory.Belt
 {
     [RegisterPacketProcessor]
-    internal class BeltUpdatePutItemOnProcessor : PacketProcessor<BeltUpdatePutItemOnPacket>
+    internal class ConnectToSpraycoaterProcessor : PacketProcessor<ConnectToSpraycoaterPacket>
     {
-        public override void ProcessPacket(BeltUpdatePutItemOnPacket packet, NebulaConnection conn)
+        public override void ProcessPacket(ConnectToSpraycoaterPacket packet, NebulaConnection conn)
         {
             using (Multiplayer.Session.Factories.IsIncomingRequest.On())
             {
@@ -19,10 +18,7 @@ namespace NebulaNetwork.PacketProcessors.Factory.Belt
                 {
                     return;
                 }
-                if (!cargoTraffic.PutItemOnBelt(packet.BeltId, packet.ItemId, packet.ItemInc))
-                {
-                    Log.Warn($"BeltUpdatePutItemOn: Cannot put item{packet.ItemId} on belt{packet.BeltId}, planet{packet.PlanetId}");
-                }
+                cargoTraffic.ConnectToSpraycoater(packet.SpraycoaterId, packet.CargoBeltId, packet.IncBeltId);
             }
         }
     }

--- a/NebulaNetwork/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
@@ -39,6 +39,12 @@ namespace NebulaNetwork.PacketProcessors.Factory.Entity
                     PlanetData pData = GameMain.gpuiManager.specifyPlanet;
 
                     GameMain.gpuiManager.specifyPlanet = GameMain.galaxy.PlanetById(packet.PlanetId);
+                    if (packet.EntityId != -1 && packet.EntityId != NebulaWorld.Factory.FactoryManager.GetNextEntityId(planet.factory))
+                    {
+                        string warningText = $"EntityId mismatch {packet.EntityId} != {NebulaWorld.Factory.FactoryManager.GetNextEntityId(planet.factory)} on planet {planet.id}";
+                        Log.Warn(warningText);
+                        NebulaWorld.Warning.WarningManager.DisplayTemporaryWarning(warningText, 5000);
+                    }
                     planet.factory.BuildFinally(GameMain.mainPlayer, packet.PrebuildId);
                     GameMain.gpuiManager.specifyPlanet = pData;
 

--- a/NebulaNetwork/PacketProcessors/Factory/Inserter/NewSetInserterInsertTargetProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Inserter/NewSetInserterInsertTargetProcessor.cs
@@ -15,7 +15,7 @@ namespace NebulaNetwork.PacketProcessors.Factory.Inserter
             if (factory != null)
             {
                 Multiplayer.Session.Factories.TargetPlanet = factory.planetId;
-                factory.WriteObjectConn(packet.ObjId, 1, false, packet.OtherObjId, -1);
+                factory.WriteObjectConn(packet.ObjId, 0, true, packet.OtherObjId, -1);
 
                 // setting specifyPlanet here to avoid accessing a null object (see GPUInstancingManager activePlanet getter)
                 PlanetData pData = GameMain.gpuiManager.specifyPlanet;

--- a/NebulaNetwork/PacketProcessors/Factory/Laboratory/LaboratoryUpdateEventProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Laboratory/LaboratoryUpdateEventProcessor.cs
@@ -2,6 +2,7 @@
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.Factory.Laboratory;
+using NebulaWorld;
 
 namespace NebulaNetwork.PacketProcessors.Factory.Labratory
 {
@@ -14,34 +15,38 @@ namespace NebulaNetwork.PacketProcessors.Factory.Labratory
             LabComponent[] pool = factory?.factorySystem?.labPool;
             if (pool != null && packet.LabIndex != -1 && packet.LabIndex < pool.Length && pool[packet.LabIndex].id != -1)
             {
-                if (packet.ProductId == -4)
+                using (Multiplayer.Session.Factories.IsIncomingRequest.On())
                 {
-                    pool[packet.LabIndex].forceAccMode = !pool[packet.LabIndex].forceAccMode;
+                    Multiplayer.Session.Factories.PacketAuthor = NebulaModAPI.AUTHOR_NONE;
+                    if (packet.ProductId == -4)
+                    {
+                        pool[packet.LabIndex].forceAccMode = !pool[packet.LabIndex].forceAccMode;
+                    }
+                    else if (packet.ProductId == -3)
+                    {
+                        //Widthdraw produced cubes
+                        pool[packet.LabIndex].produced[0] = 0;
+                    }
+                    else if (packet.ProductId == -2)
+                    {
+                        //Research recipe reseted
+                        pool[packet.LabIndex].SetFunction(false, 0, 0, factory.entitySignPool);
+                    }
+                    else if (packet.ProductId == -1)
+                    {
+                        //Center chenged to research-mode
+                        pool[packet.LabIndex].SetFunction(true, 0, GameMain.data.history.currentTech, factory.entitySignPool);
+                    }
+                    else
+                    {
+                        //Cube Recipe changed
+                        int[] matrixIds = LabComponent.matrixIds;
+                        RecipeProto recipeProto = LDB.items.Select(matrixIds[packet.ProductId]).maincraft;
+                        pool[packet.LabIndex].SetFunction(false, (recipeProto == null) ? 0 : recipeProto.ID, 0, factory.entitySignPool);
+                    }
+                    factory.factorySystem?.SyncLabFunctions(GameMain.mainPlayer, packet.LabIndex);
+                    factory.factorySystem?.SyncLabForceAccMode(GameMain.mainPlayer, packet.LabIndex);
                 }
-                else if (packet.ProductId == -3)
-                {
-                    //Widthdraw produced cubes
-                    pool[packet.LabIndex].produced[0] = 0;
-                }
-                else if (packet.ProductId == -2)
-                {
-                    //Research recipe reseted
-                    pool[packet.LabIndex].SetFunction(false, 0, 0, factory.entitySignPool);
-                }
-                else if (packet.ProductId == -1)
-                {
-                    //Center chenged to research-mode
-                    pool[packet.LabIndex].SetFunction(true, 0, GameMain.data.history.currentTech, factory.entitySignPool);
-                }
-                else
-                {
-                    //Cube Recipe changed
-                    int[] matrixIds = LabComponent.matrixIds;
-                    RecipeProto recipeProto = LDB.items.Select(matrixIds[packet.ProductId]).maincraft;
-                    pool[packet.LabIndex].SetFunction(false, (recipeProto == null) ? 0 : recipeProto.ID, 0, factory.entitySignPool);
-                }
-                factory.factorySystem?.SyncLabFunctions(GameMain.mainPlayer, packet.LabIndex);
-                factory.factorySystem?.SyncLabForceAccMode(GameMain.mainPlayer, packet.LabIndex);
             }
         }
     }

--- a/NebulaNetwork/PacketProcessors/Logistics/ILSAddStationComponentProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Logistics/ILSAddStationComponentProcessor.cs
@@ -17,17 +17,16 @@ namespace NebulaNetwork.PacketProcessors.Logistics
             using (Multiplayer.Session.Ships.PatchLockILS.On())
             {
                 GalacticTransport galacticTransport = GameMain.data.galacticTransport;
-
-                if (packet.PlanetId == GameMain.localPlanet?.id)
+                StationComponent[] stationPool = GameMain.galaxy.PlanetById(packet.PlanetId).factory?.transport.stationPool;
+                if (stationPool != null)
                 {
-                    // If we're on the same planet as the new station was created on, should be able to find
-                    // it in our local PlanetTransport.stationPool
-                    StationComponent stationComponent = GameMain.localPlanet.factory.transport.stationPool[packet.StationId];
-                    galacticTransport.AddStationComponent(packet.PlanetId, stationComponent);
+                    // If we have loaded the factory where the new station was created on, should be able to find
+                    // it in our PlanetTransport.stationPool
+                    galacticTransport.AddStationComponent(packet.PlanetId, stationPool[packet.StationId]);
                 }
                 else
                 {
-                    // If we're not on the same planet as the new station was create on, we need to create a 
+                    // If we haven't loaded the factory the new station was create on, we need to create a 
                     // "fake" station that we can put into the GalacticTransport.stationPool instead of a real on
                     Multiplayer.Session.Ships.CreateFakeStationComponent(packet.StationGId, packet.PlanetId, packet.MaxShipCount);
                 }

--- a/NebulaNetwork/PacketProcessors/Players/RemoveDroneOrdersProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Players/RemoveDroneOrdersProcessor.cs
@@ -1,8 +1,10 @@
-﻿using NebulaModel.Networking;
+﻿using NebulaAPI;
+using NebulaModel.Networking;
 using NebulaModel.Packets;
 
 namespace NebulaNetwork.PacketProcessors.Players
 {
+    [RegisterPacketProcessor]
     internal class RemoveDroneOrdersProcessor : PacketProcessor<RemoveDroneOrdersPacket>
     {
         public override void ProcessPacket(RemoveDroneOrdersPacket packet, NebulaConnection conn)

--- a/NebulaNetwork/PacketProcessors/Session/LobbyRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Session/LobbyRequestProcessor.cs
@@ -128,6 +128,12 @@ namespace NebulaNetwork.PacketProcessors.Session
             // if user is known and host is ingame dont put him into lobby but let him join the game
             if (!isNewUser && Multiplayer.Session.IsGameLoaded)
             {
+                // Remove the new player from pending list
+                using (playerManager.GetPendingPlayers(out Dictionary<INebulaConnection, INebulaPlayer> pendingPlayers))
+                {
+                    pendingPlayers.Remove(conn);
+                }
+
                 // Add the new player to the list
                 using (playerManager.GetSyncingPlayers(out Dictionary<INebulaConnection, INebulaPlayer> syncingPlayers))
                 {

--- a/NebulaNetwork/PacketProcessors/Universe/DysonSphereDataProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/DysonSphereDataProcessor.cs
@@ -61,10 +61,14 @@ namespace NebulaNetwork.PacketProcessors.Universe
                     if (UIRoot.instance.uiGame.dysonEditor.active)
                     {
                         UIRoot.instance.uiGame.dysonEditor.selection.SetViewStar(GameMain.galaxy.stars[packet.StarIndex]);
+                        UIComboBox dysonBox2 = UIRoot.instance.uiGame.dysonEditor.controlPanel.topFunction.dysonBox;
+                        int index2 = dysonBox2.ItemsData.FindIndex(x => x == UIRoot.instance.uiGame.dysonEditor.selection.viewStar?.index);
+                        dysonBox2.itemIndex = index2 >= 0 ? index2 : 0;
                     }
+                    InGamePopup.FadeOut();
+                    Multiplayer.Session.DysonSpheres.RequestingIndex = -1;
                     Multiplayer.Session.DysonSpheres.IsNormal = true;
                     break;
-
                 case DysonSphereRespondEvent.Desync:
                     Multiplayer.Session.DysonSpheres.HandleDesync(packet.StarIndex, conn);
                     break;

--- a/NebulaNetwork/Server.cs
+++ b/NebulaNetwork/Server.cs
@@ -134,47 +134,50 @@ namespace NebulaNetwork
 
         public override void Update()
         {
-            gameResearchHashUpdateTimer += Time.deltaTime;
-            productionStatisticsUpdateTimer += Time.deltaTime;
-            dysonLaunchUpateTimer += Time.deltaTime;
-            dysonSphereUpdateTimer += Time.deltaTime;
-            warningUpdateTimer += Time.deltaTime;
-
-            if (gameResearchHashUpdateTimer > GAME_RESEARCH_UPDATE_INTERVAL)
-            {
-                gameResearchHashUpdateTimer = 0;
-                if (GameMain.data.history.currentTech != 0)
-                {
-                    TechState state = GameMain.data.history.techStates[GameMain.data.history.currentTech];
-                    SendPacket(new GameHistoryResearchUpdatePacket(GameMain.data.history.currentTech, state.hashUploaded, state.hashNeeded));
-                }
-            }
-
-            if (productionStatisticsUpdateTimer > STATISTICS_UPDATE_INTERVAL)
-            {
-                productionStatisticsUpdateTimer = 0;
-                Multiplayer.Session.Statistics.SendBroadcastIfNeeded();
-            }
-
-            if (dysonLaunchUpateTimer > LAUNCH_UPDATE_INTERVAL)
-            {
-                dysonLaunchUpateTimer = 0;
-                Multiplayer.Session.Launch.SendBroadcastIfNeeded();
-            }
-
-            if (dysonSphereUpdateTimer > DYSONSPHERE_UPDATE_INTERVAL)
-            {
-                dysonSphereUpdateTimer = 0;
-                Multiplayer.Session.DysonSpheres.UpdateSphereStatusIfNeeded();
-            }
-
-            if (warningUpdateTimer > WARNING_UPDATE_INTERVAL)
-            {
-                warningUpdateTimer = 0;
-                Multiplayer.Session.Warning.SendBroadcastIfNeeded();
-            }
-
             PacketProcessor.ProcessPacketQueue();
+
+            if (Multiplayer.Session.IsGameLoaded)
+            {
+                gameResearchHashUpdateTimer += Time.deltaTime;
+                productionStatisticsUpdateTimer += Time.deltaTime;
+                dysonLaunchUpateTimer += Time.deltaTime;
+                dysonSphereUpdateTimer += Time.deltaTime;
+                warningUpdateTimer += Time.deltaTime;
+
+                if (gameResearchHashUpdateTimer > GAME_RESEARCH_UPDATE_INTERVAL)
+                {
+                    gameResearchHashUpdateTimer = 0;
+                    if (GameMain.data.history.currentTech != 0)
+                    {
+                        TechState state = GameMain.data.history.techStates[GameMain.data.history.currentTech];
+                        SendPacket(new GameHistoryResearchUpdatePacket(GameMain.data.history.currentTech, state.hashUploaded, state.hashNeeded));
+                    }
+                }
+
+                if (productionStatisticsUpdateTimer > STATISTICS_UPDATE_INTERVAL)
+                {
+                    productionStatisticsUpdateTimer = 0;
+                    Multiplayer.Session.Statistics.SendBroadcastIfNeeded();
+                }
+
+                if (dysonLaunchUpateTimer > LAUNCH_UPDATE_INTERVAL)
+                {
+                    dysonLaunchUpateTimer = 0;
+                    Multiplayer.Session.Launch.SendBroadcastIfNeeded();
+                }
+
+                if (dysonSphereUpdateTimer > DYSONSPHERE_UPDATE_INTERVAL)
+                {
+                    dysonSphereUpdateTimer = 0;
+                    Multiplayer.Session.DysonSpheres.UpdateSphereStatusIfNeeded();
+                }
+
+                if (warningUpdateTimer > WARNING_UPDATE_INTERVAL)
+                {
+                    warningUpdateTimer = 0;
+                    Multiplayer.Session.Warning.SendBroadcastIfNeeded();
+                }
+            }            
         }
 
         private void DisableNagleAlgorithm(WebSocketServer socketServer)

--- a/NebulaPatcher/Patches/Dynamic/BuildTool_Common_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/BuildTool_Common_Patch.cs
@@ -31,6 +31,8 @@ namespace NebulaPatcher.Patches.Dynamic
             }
             if(__instance is BuildTool_PathAddon)
             {
+                // traffic monitors & sprayers cannot be drag build atm, so its always only one.
+                previews = new List<BuildPreview>();
                 previews.Add(((BuildTool_PathAddon)__instance).handbp);
             }
 

--- a/NebulaPatcher/Patches/Dynamic/BuildTool_Common_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/BuildTool_Common_Patch.cs
@@ -40,7 +40,9 @@ namespace NebulaPatcher.Patches.Dynamic
             if (Multiplayer.Session.LocalPlayer.IsHost)
             {
                 int planetId = Multiplayer.Session.Factories.EventFactory?.planetId ?? GameMain.localPlanet?.id ?? -1;
-                Multiplayer.Session.Network.SendPacketToStar(new CreatePrebuildsRequest(planetId, previews, Multiplayer.Session.Factories.PacketAuthor == NebulaModAPI.AUTHOR_NONE ? Multiplayer.Session.LocalPlayer.Id : Multiplayer.Session.Factories.PacketAuthor, __instance.GetType().ToString()), GameMain.galaxy.PlanetById(planetId).star.id);
+                int authorId = Multiplayer.Session.Factories.PacketAuthor == NebulaModAPI.AUTHOR_NONE ? Multiplayer.Session.LocalPlayer.Id : Multiplayer.Session.Factories.PacketAuthor;
+                int prebuildId = Multiplayer.Session.Factories.GetNextPrebuildId(planetId);
+                Multiplayer.Session.Network.SendPacketToStar(new CreatePrebuildsRequest(planetId, previews, authorId, __instance.GetType().ToString(), prebuildId), GameMain.galaxy.PlanetById(planetId).star.id);
             }
 
             //If client builds, he need to first send request to the host and wait for reply
@@ -48,7 +50,8 @@ namespace NebulaPatcher.Patches.Dynamic
             {
                 if (Multiplayer.Session.BuildTools.InitialCheck(previews[0].lpos))
                 {
-                    Multiplayer.Session.Network.SendPacket(new CreatePrebuildsRequest(GameMain.localPlanet?.id ?? -1, previews, Multiplayer.Session.Factories.PacketAuthor == NebulaModAPI.AUTHOR_NONE ? Multiplayer.Session.LocalPlayer.Id : Multiplayer.Session.Factories.PacketAuthor, __instance.GetType().ToString()));
+                    int authorId = Multiplayer.Session.Factories.PacketAuthor == NebulaModAPI.AUTHOR_NONE ? Multiplayer.Session.LocalPlayer.Id : Multiplayer.Session.Factories.PacketAuthor;
+                    Multiplayer.Session.Network.SendPacket(new CreatePrebuildsRequest(GameMain.localPlanet?.id ?? -1, previews, authorId, __instance.GetType().ToString(), -1));
                 }
                 return false;
             }

--- a/NebulaPatcher/Patches/Dynamic/CargoTraffic_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/CargoTraffic_Patch.cs
@@ -108,5 +108,26 @@ namespace NebulaPatcher.Patches.Dynamic
                 Multiplayer.Session.Network.SendPacketToLocalStar(new ConnectToSpraycoaterPacket(spraycoaterId, cargoBeltId, incBeltId, GameMain.data.localPlanet.id));
             }
         }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(CargoTraffic.SetBeltSignalIcon))]
+        public static void SetBeltSignalIcon_Postfix(int entityId, int signalId)
+        {
+            // Notify others about belt memo icon changes
+            if (Multiplayer.IsActive && !Multiplayer.Session.Factories.IsIncomingRequest.Value)
+            {
+                Multiplayer.Session.Network.SendPacketToLocalStar(new BeltSignalIconPacket(entityId, signalId, GameMain.data.localPlanet.id));
+            }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(CargoTraffic.SetBeltSignalNumber))]
+        public static void SetBeltSignalNumber_Postfix(int entityId, float number)
+        {
+            if (Multiplayer.IsActive && !Multiplayer.Session.Factories.IsIncomingRequest.Value)
+            {
+                Multiplayer.Session.Network.SendPacketToLocalStar(new BeltSignalNumberPacket(entityId, number, GameMain.data.localPlanet.id));
+            }
+        }
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetFactory_Patch.cs
@@ -52,7 +52,9 @@ namespace NebulaPatcher.Patches.Dynamic
 
             if (Multiplayer.Session.LocalPlayer.IsHost || !Multiplayer.Session.Factories.IsIncomingRequest.Value)
             {
-                Multiplayer.Session.Network.SendPacket(new BuildEntityRequest(__instance.planetId, prebuildId, Multiplayer.Session.Factories.PacketAuthor == NebulaModAPI.AUTHOR_NONE ? Multiplayer.Session.LocalPlayer.Id : Multiplayer.Session.Factories.PacketAuthor));
+                int author = Multiplayer.Session.Factories.PacketAuthor == NebulaModAPI.AUTHOR_NONE ? Multiplayer.Session.LocalPlayer.Id : Multiplayer.Session.Factories.PacketAuthor;
+                int entityId = Multiplayer.Session.LocalPlayer.IsHost ? NebulaWorld.Factory.FactoryManager.GetNextEntityId(__instance) : -1;
+                Multiplayer.Session.Network.SendPacket(new BuildEntityRequest(__instance.planetId, prebuildId, author, entityId));
             }
 
             if (!Multiplayer.Session.LocalPlayer.IsHost && !Multiplayer.Session.Factories.IsIncomingRequest.Value && !Multiplayer.Session.Drones.IsPendingBuildRequest(-prebuildId))

--- a/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
@@ -91,6 +91,7 @@ namespace NebulaPatcher.Patches.Dynamic
             // Request initial dysonSphere data
             if (GameMain.data.dysonSpheres[star.index] == null)
             {
+                Multiplayer.Session.DysonSpheres.RequestingIndex = star.index;
                 Log.Info($"Requesting DysonSphere for system {star.displayName} (Index: {star.index})");
                 Multiplayer.Session.Network.SendPacket(new DysonSphereLoadRequest(star.index, DysonSphereRequestEvent.Load));
             }

--- a/NebulaPatcher/Patches/Dynamic/SpeakerComponent_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/SpeakerComponent_Patch.cs
@@ -51,7 +51,6 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPatch(nameof(SpeakerComponent.SetLength))]
         public static void SetLength_Prefix(MonitorComponent __instance, float __0)
         {
-            Log.Info($"SetLength {__0} {Multiplayer.Session.Warning.IsIncomingMonitorPacket == true}");
             if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
             {
                 int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;
@@ -77,7 +76,6 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPatch(nameof(SpeakerComponent.SetFalloffRadius))]
         public static void SetFalloffRadius_Prefix(MonitorComponent __instance, float __0, float __1)
         {
-            Log.Info($"SetFalloffRadius {__0} {__1} {Multiplayer.Session.Warning.IsIncomingMonitorPacket == true}");
             if (Multiplayer.IsActive && !Multiplayer.Session.Warning.IsIncomingMonitorPacket)
             {
                 int planetId = GameMain.data.localPlanet == null ? -1 : GameMain.data.localPlanet.id;

--- a/NebulaPatcher/Patches/Dynamic/UIFatalErrorTip_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIFatalErrorTip_Patch.cs
@@ -1,0 +1,77 @@
+﻿using BepInEx;
+using BepInEx.Bootstrap;
+using HarmonyLib;
+using NebulaModel.Logger;
+using System;
+using System.Text;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(UIFatalErrorTip))]
+    internal class UIFatalErrorTip_Patch
+    {
+        static GameObject button;
+
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(UIFatalErrorTip._OnOpen))]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Original Function Name")]
+        public static void _OnOpen_Postfix()
+        {
+            try
+            {
+                if (button == null)
+                {
+                    button = GameObject.Find("UI Root/Overlay Canvas/In Game/Windows/Dyson Sphere Editor/Dyson Editor Control Panel/hierarchy/layers/blueprint-group/blueprint-2/copy-button");
+                    GameObject errorPanel = GameObject.Find("UI Root/Overlay Canvas/Fatal Error/errored-panel/");
+                    errorPanel.transform.Find("tip-text-1").GetComponent<Text>().text = Title();
+                    GameObject.Destroy(errorPanel.transform.Find("tip-text-1").GetComponent<Localizer>());
+                    button = GameObject.Instantiate(button, errorPanel.transform);
+                    button.name = "Copy & Close button";
+                    button.transform.localPosition = errorPanel.transform.Find("icon").localPosition + new Vector3(30, -35, 0); //-885 -30 //-855 -60
+                    button.GetComponent<Image>().color = new Color(0.3113f, 0f, 0.0097f, 0.6f);
+                    button.GetComponent<UIButton>().BindOnClickSafe(OnClick);
+                    button.GetComponent<UIButton>().tips = new UIButton.TipSettings();
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Warn($"UIFatalErrorTip button did not patch! {e}");
+            }
+        }
+
+        private static string Title()
+        {
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.Append("This game has occured an error! Game version ");
+            stringBuilder.Append(GameConfig.gameVersion.ToString());
+            stringBuilder.Append('.');
+            stringBuilder.Append(GameConfig.gameVersion.Build);
+            stringBuilder.AppendLine();
+            stringBuilder.Append("Mods use: ");
+            foreach (BepInEx.PluginInfo pluginInfo in Chainloader.PluginInfos.Values)
+            {
+                stringBuilder.Append('[');
+                stringBuilder.Append(pluginInfo.Metadata.Name);
+                stringBuilder.Append(pluginInfo.Metadata.Version);
+                stringBuilder.Append("] ");
+            }
+            return stringBuilder.ToString();
+        }
+
+        private static void OnClick(int id)
+        {
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine("```");
+            stringBuilder.AppendLine(Title());
+            stringBuilder.Append(UIFatalErrorTip.instance.errorLogText.text);
+            stringBuilder.AppendLine("```");
+            // Copy string to clipboard
+            GUIUtility.systemCopyBuffer = stringBuilder.ToString();
+            UIFatalErrorTip.ClearError();
+            GameObject.Destroy(button);
+            button = null;
+        }
+    }
+}

--- a/NebulaWorld/Factory/BeltManager.cs
+++ b/NebulaWorld/Factory/BeltManager.cs
@@ -1,4 +1,4 @@
-﻿using NebulaModel.Packets.Belt;
+﻿using NebulaModel.Packets.Factory.Belt;
 using System;
 using System.Collections.Generic;
 

--- a/NebulaWorld/Factory/BuildToolManager.cs
+++ b/NebulaWorld/Factory/BuildToolManager.cs
@@ -258,6 +258,7 @@ namespace NebulaWorld.Factory
             if ((now - LastCheckTime) < WAIT_TIME && LastPosition == pos)
             {
                 //Stop client from sending prebuilds at the same position
+                UIRealtimeTip.Popup("Please wait for server respond");
                 return false;
             }
             LastCheckTime = now;

--- a/NebulaWorld/Factory/BuildToolManager.cs
+++ b/NebulaWorld/Factory/BuildToolManager.cs
@@ -99,6 +99,10 @@ namespace NebulaWorld.Factory
                 {
                     GameMain.mainPlayer.mecha.buildArea = float.MaxValue;
                     canBuild = CheckBuildingConnections(buildTool.buildPreviews, planet.factory.entityPool, planet.factory.prebuildPool);
+                    if (!canBuild)
+                    {
+                        Log.Warn($"CreatePrebuildsRequest: request do not pass connections test on planet {planet.id}");
+                    }
                 }
 
                 if (canBuild || Multiplayer.Session.LocalPlayer.IsClient)
@@ -106,6 +110,15 @@ namespace NebulaWorld.Factory
                     if (Multiplayer.Session.Factories.IsIncomingRequest.Value)
                     {
                         CheckAndFixConnections(buildTool, planet);
+                    }
+                    if (Multiplayer.Session.LocalPlayer.IsClient)
+                    {
+                        if (packet.PrebuildId != Multiplayer.Session.Factories.GetNextPrebuildId(packet.PlanetId))
+                        {
+                            string warningText = $"PrebuildId mismatch on {packet.PlanetId} planet: {packet.PrebuildId} != {Multiplayer.Session.Factories.GetNextPrebuildId(planet.factory)}";
+                            Log.Warn(warningText);
+                            NebulaWorld.Warning.WarningManager.DisplayTemporaryWarning(warningText, 5000);
+                        }
                     }
 
                     if (packet.BuildToolType == typeof(BuildTool_Click).ToString())
@@ -201,6 +214,7 @@ namespace NebulaWorld.Factory
                         // `entity.pos == tmpVector` does not work in every cases (rounding errors?).
                         if ((entity.pos - tmpVector).sqrMagnitude < 0.1f)
                         {
+                            Log.Info($"CheckAndFixConnections: {entity.pos} {tmpVector}");
                             preview.coverObjId = entity.id;
                             break;
                         }

--- a/NebulaWorld/Factory/FactoryManager.cs
+++ b/NebulaWorld/Factory/FactoryManager.cs
@@ -233,10 +233,20 @@ namespace NebulaWorld.Factory
             return prebuildRecycleCursor <= 0 ? factory.prebuildCursor + 1 : prebuildRecycle[prebuildRecycleCursor - 1];
         }
 
+        public static int GetNextEntityId(PlanetFactory factory)
+        {
+            if (factory == null)
+            {
+                return -1;
+            }
+
+            return factory.entityRecycleCursor <= 0 ? factory.entityCursor : factory.entityRecycle[factory.entityRecycleCursor - 1];
+        }
+
         public void OnNewSetInserterPickTarget(int objId, int otherObjId, int inserterId, int offset, Vector3 pointPos)
         {
             // 1. Client receives the build request from itself 2. Host sends the build request
-            if (Multiplayer.IsActive && (Multiplayer.Session.LocalPlayer.Id == PacketAuthor || (Multiplayer.Session.LocalPlayer.IsHost && PacketAuthor == NebulaModAPI.AUTHOR_NONE)))
+            if (Multiplayer.IsActive && (Multiplayer.Session.LocalPlayer.Id == PacketAuthor || (Multiplayer.Session.LocalPlayer.IsHost && !IsIncomingRequest.Value)))
             {
                 Multiplayer.Session.Network.SendPacketToLocalStar(new NewSetInserterPickTargetPacket(objId, otherObjId, inserterId, offset, pointPos, GameMain.localPlanet?.id ?? -1));
             }
@@ -244,7 +254,7 @@ namespace NebulaWorld.Factory
 
         public void OnNewSetInserterInsertTarget(int objId, int otherObjId, int inserterId, int offset, Vector3 pointPos)
         {
-            if (Multiplayer.IsActive && Multiplayer.Session.LocalPlayer.Id == PacketAuthor || (Multiplayer.Session.LocalPlayer.IsHost && PacketAuthor == NebulaModAPI.AUTHOR_NONE))
+            if (Multiplayer.IsActive && (Multiplayer.Session.LocalPlayer.Id == PacketAuthor || (Multiplayer.Session.LocalPlayer.IsHost && !IsIncomingRequest.Value)))
             {
                 Multiplayer.Session.Network.SendPacketToLocalStar(new NewSetInserterInsertTargetPacket(objId, otherObjId, inserterId, offset, pointPos, GameMain.localPlanet?.id ?? -1));
             }

--- a/NebulaWorld/Logistics/StationUIManager.cs
+++ b/NebulaWorld/Logistics/StationUIManager.cs
@@ -90,8 +90,16 @@ namespace NebulaWorld.Logistics
                 case StationUI.EUISettings.SetDroneCount:
                 {
                     // Check if new setting is acceptable
-                    int totalCount = Math.Min((int)packet.SettingValue, stationComponent.workDroneDatas.Length);
+                    int maxDroneCount = stationComponent.workDroneDatas?.Length ?? 0;
+                    if (maxDroneCount == 0)
+                    {
+                        PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
+                        ItemProto itemProto = LDB.items.Select(planet.factory.entityPool[stationComponent.entityId].protoId);
+                        maxDroneCount = itemProto?.prefabDesc.stationMaxDroneCount ?? 10;
+                    }
+                    int totalCount = Math.Min((int)packet.SettingValue, maxDroneCount);
                     stationComponent.idleDroneCount = Math.Max(totalCount - stationComponent.workDroneCount, 0);
+                    totalCount = stationComponent.idleDroneCount + stationComponent.workDroneCount;
                     if (totalCount < (int)packet.SettingValue && packet.ShouldRefund)
                     {
                         // The result is less than original setting, refund extra drones to author
@@ -104,8 +112,16 @@ namespace NebulaWorld.Logistics
                 case StationUI.EUISettings.SetShipCount:
                 {
                     // Check if new setting is acceptable
-                    int totalCount = Math.Min((int)packet.SettingValue, stationComponent.workShipDatas.Length);
+                    int maxShipCount = stationComponent.workShipDatas?.Length ?? 0;
+                    if (maxShipCount == 0)
+                    {
+                        PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
+                        ItemProto itemProto = LDB.items.Select(planet.factory.entityPool[stationComponent.entityId].protoId);
+                        maxShipCount = itemProto?.prefabDesc.stationMaxShipCount ?? 10;
+                    }
+                    int totalCount = Math.Min((int)packet.SettingValue, maxShipCount);
                     stationComponent.idleShipCount = Math.Max(totalCount - stationComponent.workShipCount, 0);
+                    totalCount = stationComponent.idleShipCount + stationComponent.workShipCount;
                     if (totalCount < (int)packet.SettingValue && packet.ShouldRefund)
                     {
                         // The result is less than original setting, refund extra ships to author
@@ -228,7 +244,7 @@ namespace NebulaWorld.Logistics
          */
         private StationComponent GetStation(int planetId, int stationId, int stationGid)
         {
-            PlanetData planet = GameMain.galaxy?.PlanetById(planetId);
+            PlanetData planet = GameMain.galaxy.PlanetById(planetId);
 
             // If we can't find planet or the factory for said planet, we can just skip this
             if (planet?.factory?.transport == null)

--- a/NebulaWorld/Logistics/StationUIManager.cs
+++ b/NebulaWorld/Logistics/StationUIManager.cs
@@ -77,7 +77,7 @@ namespace NebulaWorld.Logistics
                 case StationUI.EUISettings.MaxChargePower:
                 {
                     PlanetData planet = GameMain.galaxy.PlanetById(packet.PlanetId);
-                    if (planet.factory?.powerSystem != null)
+                    if (planet?.factory?.powerSystem?.consumerPool != null)
                     {
                         PowerConsumerComponent[] consumerPool = planet.factory.powerSystem.consumerPool;
                         if (consumerPool.Length > stationComponent.pcId)
@@ -205,13 +205,16 @@ namespace NebulaWorld.Logistics
                 }
                 case StationUI.EUISettings.MaxMiningSpeed:
                 {                       
-                    PlanetFactory factory = GameMain.galaxy.PlanetById(packet.PlanetId).factory;
+                    PlanetFactory factory = GameMain.galaxy.PlanetById(packet.PlanetId)?.factory;
                     if (factory != null)
                     {
                         int speed = 10000 + (int)(packet.SettingValue + 0.5f) * 1000;
-                        long workEnergyPrefab = LDB.items.Select(factory.entityPool[stationComponent.entityId].protoId).prefabDesc.workEnergyPerTick;
-                        factory.factorySystem.minerPool[stationComponent.minerId].speed = speed;
-                        factory.powerSystem.consumerPool[stationComponent.pcId].workEnergyPerTick = (long)(workEnergyPrefab * (speed / 10000f) * (speed / 10000f));
+                        PrefabDesc workEnergyPrefab = LDB.items.Select(factory.entityPool[stationComponent.entityId].protoId)?.prefabDesc;
+                        if (workEnergyPrefab != null && factory.factorySystem?.minerPool != null && factory.powerSystem?.consumerPool != null)
+                        {
+                            factory.factorySystem.minerPool[stationComponent.minerId].speed = speed;
+                            factory.powerSystem.consumerPool[stationComponent.pcId].workEnergyPerTick = (long)(workEnergyPrefab.workEnergyPerTick * (speed / 10000f) * (speed / 10000f));
+                        }
                     }
                     break;
                 }

--- a/NebulaWorld/Universe/DysonSphereManager.cs
+++ b/NebulaWorld/Universe/DysonSphereManager.cs
@@ -25,6 +25,7 @@ namespace NebulaWorld.Universe
         public readonly ToggleSwitch IncomingDysonSwarmPacket = new ToggleSwitch();
         public bool IsNormal { get; set; } = true; //Client side: is the spheres data normal or desynced
         public bool InBlueprint { get; set; } = false; //In the processing of importing blueprint
+        public int RequestingIndex { get; set; } = -1; //StarIndex of the dyson sphere requesting
 
         private readonly List<DysonSphereStatusPacket> statusPackets = new List<DysonSphereStatusPacket>(); //Server side
 
@@ -197,7 +198,7 @@ namespace NebulaWorld.Universe
         public static void ClearSelection(int starIndex, int layerId = -1)
         {
             DESelection selection = UIRoot.instance.uiGame.dysonEditor.selection;
-            if (starIndex == selection.viewStar.index)
+            if (selection.viewStar!= null && selection.viewStar.index == starIndex)
             {
                 if (layerId == -1)
                 {

--- a/NebulaWorld/Warning/WarningManager.cs
+++ b/NebulaWorld/Warning/WarningManager.cs
@@ -1,8 +1,10 @@
-﻿using NebulaModel.Networking;
+﻿using BepInEx;
+using NebulaModel.Networking;
 using NebulaModel.Packets.Warning;
 using System;
 using System.IO;
 using System.Collections.Concurrent;
+using System.Threading;
 using NebulaModel.DataStructures;
 
 namespace NebulaWorld.Warning
@@ -165,6 +167,19 @@ namespace NebulaWorld.Warning
                 warningPool[i].localPos.y = br.ReadSingle();
                 warningPool[i].localPos.z = br.ReadSingle();
             }
+        }
+
+        public static void DisplayTemporaryWarning(string warningText, int millisecond)
+        {
+            DisplayCriticalWarning(warningText);
+            ThreadingHelper.Instance.StartAsyncInvoke(() =>
+            {
+                Thread.Sleep(millisecond);
+                return (() =>
+                {
+                    RemoveCriticalWarning();
+                });
+            });
         }
 
         public static void DisplayCriticalWarning(string warningText)


### PR DESCRIPTION
A list of issues solved/unsolved in 0.8.0 pre-release version

Resolved, will be fixed in the next update:
-------------

- Sprayer and monitor are not connected to belt when client builds on a different planet.

> (Self note: watch out ``OnBeltBuilt()`` and ``OnAddonBuilt()``, they use ``planet.physics.nearColliderLogic`` which is not synced, so it is needed to sync the result of these functions)

- On client, sprayer and monitor will build to the wrong place when there are multiple prebuilds.

- Other players get items refunds too when a player changes the recipe of a lab with matrix in it.

- Other clients will receive an undefined packet when a client leaves.

- When a player disconnects during loading, the host will get NRE or the whole game pause.

- If a loaded remote planet has ILS built by other players, the ILS will not sync on this player and may cause errors when they change its storage.

- Player color can show differently on other players ([fix in the main branch](https://github.com/hubastard/nebula/commit/40b2408aa2c9eada7f88978ea5cecb84d8564aad) by sp00ktober)

- Clients lose their inventory when loading an old .server file
=> Now support backward compatibility to revision 4 (current: 5)

- When a client opens dyson editor without any dyson spheres loaded, it will get an error.
=> Now dyson spheres only unload when arriving a new system

- When clients connect sorters output by placing belts under the sorters, the sorters will stop working after host reload the game.  

Known issues:
-------------

- When client land on a heavily built-upon planet, it may trigger NRE on renderer
> NRE: CargoTraffic.AlterBeltRenderer (IL_0350)

Unknown cause, can't reproduce yet:
-------------
- Sometimes when host deletes an ILS on a different planet in the same system, client will get an error.
![unknown](https://user-images.githubusercontent.com/50672801/153281708-5ee36cfc-a536-41d8-80c0-842c61c1c3c6.png)

- Belts connect randomly on client, fix after reconnection.
![DSPGAME_2022-02-07_18-41-30](https://user-images.githubusercontent.com/50672801/153282066-f017f0b6-3c68-4d30-afbd-dddb32fff031.png)

- Sometimes sorters will stop working. The animation is still running but no cargo is moved.  Fix after replacement.
- Sometimes the splitter filter is randomly set to the wrong item and can't be changed. Have to replace the splitter.
- Sometimes clients can't see the profiler functioning in factories. They don't see the blue bonus bar.


Other changes:
-------------
![copy](https://user-images.githubusercontent.com/50672801/153118396-d7f9f6f1-177e-4ba5-a467-0ab0b35c15da.png)
Add a button to copy and close the error message. Special thanks to Therzok's WhatTheBreak and crecheng's CloseError
 