### PR TITLE
Improve error log and bugfix

### DIFF
--- a/NebulaModel/Packets/Universe/DysonBlueprintPacket.cs
+++ b/NebulaModel/Packets/Universe/DysonBlueprintPacket.cs
@@ -5,7 +5,7 @@
         public int StarIndex { get; set; }
         public int LayerId { get; set; }
         public EDysonBlueprintType BlueprintType {get; set; }
-        public string StringData { get; set; }
+        public char[] CharsData { get; set; }
 
         public DysonBlueprintPacket() { }
         public DysonBlueprintPacket(int starIndex, int layerId, EDysonBlueprintType blueprintType, string stringData)
@@ -13,7 +13,8 @@
             StarIndex = starIndex;
             LayerId = layerId;
             BlueprintType = blueprintType;
-            StringData = stringData;
+            // because string leangth may exceed maxStringLength in NetSerializer, convert to char array here
+            CharsData = stringData.ToCharArray();
         }
     }
 }

--- a/NebulaModel/Packets/Universe/DysonBlueprintPacket.cs
+++ b/NebulaModel/Packets/Universe/DysonBlueprintPacket.cs
@@ -13,7 +13,7 @@
             StarIndex = starIndex;
             LayerId = layerId;
             BlueprintType = blueprintType;
-            // because string leangth may exceed maxStringLength in NetSerializer, convert to char array here
+            // because string length may exceed maxStringLength in NetSerializer, convert to char array here
             CharsData = stringData.ToCharArray();
         }
     }

--- a/NebulaNetwork/PacketProcessors/Logistics/StationUIInitialSyncProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Logistics/StationUIInitialSyncProcessor.cs
@@ -17,15 +17,18 @@ namespace NebulaNetwork.PacketProcessors.Logistics
         public override void ProcessPacket(StationUIInitialSync packet, NebulaConnection conn)
         {
             StationComponent stationComponent = null;
-            StationComponent[] gStationPool = GameMain.data.galacticTransport.stationPool;
             StationComponent[] stationPool = GameMain.data.galaxy.PlanetById(packet.PlanetId).factory.transport.stationPool;
-
-            stationComponent = packet.StationGId > 0 ? gStationPool[packet.StationGId] : stationPool?[packet.StationId];
+            // Assume the requesting station is on a loaded planet
+            stationComponent = stationPool?[packet.StationId];
 
             if (stationComponent == null)
             {
                 Log.Error($"StationUIInitialSyncProcessor: Unable to find requested station on planet {packet.PlanetId} with id {packet.StationId} and gid of {packet.StationGId}");
                 return;
+            }
+            if (stationComponent.gid > 0 && stationComponent.gid != packet.StationGId)
+            {
+                Log.Error($"StationGid desync! Host:{packet.StationGId} Local:{stationComponent.gid}");
             }
 
             stationComponent.tripRangeDrones = packet.TripRangeDrones;

--- a/NebulaNetwork/PacketProcessors/Logistics/StationUIInitialSyncRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Logistics/StationUIInitialSyncRequestProcessor.cs
@@ -21,14 +21,13 @@ namespace NebulaNetwork.PacketProcessors.Logistics
             }
 
             StationComponent stationComponent;
-            StationComponent[] gStationPool = GameMain.data.galacticTransport.stationPool;
             StationComponent[] stationPool = GameMain.data.galaxy?.PlanetById(packet.PlanetId)?.factory?.transport?.stationPool;
 
-            stationComponent = packet.StationGId > 0 ? gStationPool[packet.StationGId] : stationPool?[packet.StationId];
+            stationComponent = stationPool?[packet.StationId];
 
             if (stationComponent == null)
             {
-                Log.Error($"StationUIInitialSyncRequestProcessor: Unable to find requested station on planet {packet.PlanetId} with id {packet.StationId} and gid of {packet.StationGId}");
+                Log.Error($"StationUIInitialSyncRequestProcessor: Unable to find requested station on planet {packet.PlanetId} with id {packet.StationId} and gid {packet.StationGId}");
                 return;
             }
 

--- a/NebulaNetwork/PacketProcessors/Logistics/StationUIProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Logistics/StationUIProcessor.cs
@@ -23,9 +23,9 @@ namespace NebulaNetwork.PacketProcessors.Logistics
                 packet.ShouldRefund = false;
                 Multiplayer.Session.StationsUI.UpdateStation(ref packet);
 
-                // broadcast to every clients that may have the station loaded.
-                int starId = GameMain.galaxy.PlanetById(packet.PlanetId)?.star.id ?? -1;
-                playerManager.SendPacketToStarExcept(packet, starId, conn);
+                // broadcast to other clients 
+                INebulaPlayer player = playerManager.GetPlayer(conn);
+                playerManager.SendPacketToOtherPlayers(packet, player);
 
                 // as we block the normal method for the client he must run it once he receives this packet.
                 // but only the one issued the request should get items refund

--- a/NebulaNetwork/PacketProcessors/Logistics/StorageUIProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Logistics/StorageUIProcessor.cs
@@ -23,9 +23,9 @@ namespace NebulaNetwork.PacketProcessors.Logistics
                 packet.ShouldRefund = false;
                 Multiplayer.Session.StationsUI.UpdateStorage(packet);
 
-                // broadcast to every clients that may have the station loaded.
-                int starId = GameMain.galaxy.PlanetById(packet.PlanetId)?.star.id ?? -1;
-                playerManager.SendPacketToStarExcept(packet, starId, conn);
+                // broadcast to other clients 
+                INebulaPlayer player = playerManager.GetPlayer(conn);
+                playerManager.SendPacketToOtherPlayers(packet, player);
 
                 // as we block some methods for the client he must run it once he receives this packet.
                 // but only the one issued the request should get items refund

--- a/NebulaNetwork/PacketProcessors/Planet/PlanetDataRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Planet/PlanetDataRequestProcessor.cs
@@ -1,4 +1,5 @@
-﻿using NebulaAPI;
+﻿using BepInEx;
+using NebulaAPI;
 using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
@@ -21,50 +22,74 @@ namespace NebulaNetwork.PacketProcessors.Planet
 
             foreach (int planetId in packet.PlanetIDs)
             {
-                PlanetData planet = GameMain.galaxy.PlanetById(planetId);
-                Log.Info($"Returning terrain for {planet.name}");
-
-                // NOTE: The following has been picked-n-mixed from "PlanetModelingManager.PlanetComputeThreadMain()"
-                // This method is **costly** - do not run it more than is required!
-                // It generates the planet on the host and then sends it to the client
-
-                PlanetAlgorithm planetAlgorithm = PlanetModelingManager.Algorithm(planet);
-
-                if (planet.data == null)
+                ThreadingHelper.Instance.StartAsyncInvoke(() =>
                 {
-                    planet.data = new PlanetRawData(planet.precision);
-                    planet.modData = planet.data.InitModData(planet.modData);
-                    planet.data.CalcVerts();
-                    planet.aux = new PlanetAuxData(planet);
-                    planetAlgorithm.GenerateTerrain(planet.mod_x, planet.mod_y);
-                    planetAlgorithm.CalcWaterPercent();
-
-                    //Load planet meshes and register callback to unload unneccessary stuff
-                    planet.wanted = true;
-                    planet.onLoaded += OnActivePlanetLoaded;
-                    PlanetModelingManager.modPlanetReqList.Enqueue(planet);
-
-                    if (planet.type != EPlanetType.Gas)
-                    {
-                        planetAlgorithm.GenerateVegetables();
-                        planetAlgorithm.GenerateVeins(false);
-                    }
-                }
-
-                using (BinaryUtils.Writer writer = new BinaryUtils.Writer())
-                {
-                    planet.ExportRuntime(writer.BinaryWriter);
-                    planetDataToReturn.Add(planetId, writer.CloseAndGetBytes());
-                }
-            }
-
-            conn.SendPacket(new PlanetDataResponse(planetDataToReturn));
+                    PlanetCompute(planetId, planetDataToReturn);
+                    return () => Callback(conn, planetDataToReturn, packet.PlanetIDs.Length);
+                });
+            }            
         }
 
-        public void OnActivePlanetLoaded(PlanetData planet)
+        public static void OnActivePlanetLoaded(PlanetData planet)
         {
             planet.Unload();
             planet.onLoaded -= OnActivePlanetLoaded;
+        }
+
+        private static void PlanetCompute(int planetId, Dictionary<int, byte[]> planetDataToReturn) 
+        {
+            PlanetData planet = GameMain.galaxy.PlanetById(planetId);
+            HighStopwatch highStopwatch = new HighStopwatch();
+            highStopwatch.Begin();
+
+            // NOTE: The following has been picked-n-mixed from "PlanetModelingManager.PlanetComputeThreadMain()"
+            // This method is **costly** - do not run it more than is required!
+            // It generates the planet on the host and then sends it to the client
+
+            PlanetAlgorithm planetAlgorithm = PlanetModelingManager.Algorithm(planet);
+
+            if (planet.data == null)
+            {
+                planet.data = new PlanetRawData(planet.precision);
+                planet.modData = planet.data.InitModData(planet.modData);
+                planet.data.CalcVerts();
+                planet.aux = new PlanetAuxData(planet);
+                planetAlgorithm.GenerateTerrain(planet.mod_x, planet.mod_y);
+                planetAlgorithm.CalcWaterPercent();
+
+                //Load planet meshes and register callback to unload unneccessary stuff
+                planet.wanted = true;
+                planet.onLoaded += OnActivePlanetLoaded;
+                PlanetModelingManager.modPlanetReqList.Enqueue(planet);
+
+                if (planet.type != EPlanetType.Gas)
+                {
+                    planetAlgorithm.GenerateVegetables();
+                    planetAlgorithm.GenerateVeins(false);
+                }
+            }
+
+            using (BinaryUtils.Writer writer = new BinaryUtils.Writer())
+            {
+                planet.ExportRuntime(writer.BinaryWriter);
+                lock (planetDataToReturn)
+                {
+                    planetDataToReturn.Add(planetId, writer.CloseAndGetBytes());
+                }
+            }
+            Log.Info($"Returning terrain for {planet.name}, time:{highStopwatch.duration:F5} s");
+        }
+
+        private static void Callback(NebulaConnection conn, Dictionary<int, byte[]> planetDataToReturn, int count)
+        {
+            lock (planetDataToReturn)
+            {
+                if (planetDataToReturn.Count == count)
+                {
+                    conn.SendPacket(new PlanetDataResponse(planetDataToReturn));
+                    planetDataToReturn.Clear();
+                }
+            }
         }
     }
 }

--- a/NebulaNetwork/PacketProcessors/Universe/DysonBlueprintProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/DysonBlueprintProcessor.cs
@@ -20,7 +20,8 @@ namespace NebulaNetwork.PacketProcessors.Universe
             using (Multiplayer.Session.DysonSpheres.IsIncomingRequest.On())
             {
                 DysonSphereLayer layer = sphere.GetLayer(packet.LayerId);
-                DysonBlueprintDataIOError err = new DysonBlueprintData().ContentFromBase64String(packet.StringData, packet.BlueprintType, sphere, layer);
+                string str64Data = new string(packet.CharsData);
+                DysonBlueprintDataIOError err = new DysonBlueprintData().FromBase64String(str64Data, packet.BlueprintType, sphere, layer);
                 if (err != DysonBlueprintDataIOError.OK)
                 {
                     Log.Warn($"DysonBlueprintData IO error: {err}");

--- a/NebulaNetwork/PacketProcessors/Universe/DysonSphereDataProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/DysonSphereDataProcessor.cs
@@ -41,18 +41,15 @@ namespace NebulaNetwork.PacketProcessors.Universe
 
                 case DysonSphereRespondEvent.Load:
                     //Failsafe, if client does not have instantiated sphere for the star, it will create dummy one that will be replaced during import
-                    if (GameMain.data.dysonSpheres[packet.StarIndex] == null)
+                    GameMain.data.dysonSpheres[packet.StarIndex] = new DysonSphere();
+                    GameMain.data.statistics.production.Init(GameMain.data);
+                    //Another failsafe, DysonSphere import requires initialized factory statistics
+                    if (GameMain.data.statistics.production.factoryStatPool[0] == null)
                     {
-                        GameMain.data.dysonSpheres[packet.StarIndex] = new DysonSphere();
-                        GameMain.data.statistics.production.Init(GameMain.data);
-                        //Another failsafe, DysonSphere import requires initialized factory statistics
-                        if (GameMain.data.statistics.production.factoryStatPool[0] == null)
-                        {
-                            GameMain.data.statistics.production.factoryStatPool[0] = new FactoryProductionStat();
-                            GameMain.data.statistics.production.factoryStatPool[0].Init();
-                        }
-                        GameMain.data.dysonSpheres[packet.StarIndex].Init(GameMain.data, GameMain.data.galaxy.stars[packet.StarIndex]);
+                        GameMain.data.statistics.production.factoryStatPool[0] = new FactoryProductionStat();
+                        GameMain.data.statistics.production.factoryStatPool[0].Init();
                     }
+                    GameMain.data.dysonSpheres[packet.StarIndex].Init(GameMain.data, GameMain.data.galaxy.stars[packet.StarIndex]);
 
                     using (BinaryUtils.Reader reader = new BinaryUtils.Reader(packet.BinaryData))
                     {

--- a/NebulaPatcher/Patches/Dynamic/DESelection_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/DESelection_Patch.cs
@@ -43,16 +43,14 @@ namespace NebulaPatcher.Patches.Dynamic
                 }
                 if (starData != null && GameMain.data.dysonSpheres[starData.index] == null)
                 {
-                    if (Multiplayer.Session.DysonSpheres.RequestingIndex != -1)
+                    if (Multiplayer.Session.DysonSpheres.RequestingIndex == -1)
                     {
-                        InGamePopup.ShowInfo("Loading", $"Loading Dyson sphere {starData.displayName}, please wait...", "OK");
-                        return false;
+                        Multiplayer.Session.DysonSpheres.RequestDysonSphere(starData.index);
                     }
-                    Multiplayer.Session.DysonSpheres.RequestingIndex = starData.index;
-                    Log.Info($"Requesting DysonSphere for system {starData.displayName} (Index: {starData.index})");
-                    Multiplayer.Session.Network.SendPacket(new DysonSphereLoadRequest(starData.index, DysonSphereRequestEvent.Load));
-                    __instance.ClearAllSelection();
-                    InGamePopup.ShowInfo("Loading", $"Loading Dyson sphere {starData.displayName}, please wait...", "OK");
+                    else
+                    {
+                        InGamePopup.ShowInfo("Loading", $"Loading Dyson sphere {starData.displayName}, please wait...", null);
+                    }
                     // Restore comboBox back to original star
                     UIComboBox dysonBox = UIRoot.instance.uiGame.dysonEditor.controlPanel.topFunction.dysonBox;
                     int index = dysonBox.ItemsData.FindIndex(x => x == UIRoot.instance.uiGame.dysonEditor.selection.viewStar?.index);

--- a/NebulaPatcher/Patches/Dynamic/DysonBlueprintData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/DysonBlueprintData_Patch.cs
@@ -9,8 +9,8 @@ namespace NebulaPatcher.Patches.Dynamic
     internal class DysonBlueprintData_Patch
     {
         [HarmonyPrefix]
-        [HarmonyPatch(nameof(DysonBlueprintData.ContentFromBase64String))]
-        public static void ContentFromBase64String_Prefix()
+        [HarmonyPatch(nameof(DysonBlueprintData.FromBase64String))]
+        public static void FromBase64String_Prefix()
         {
             if (Multiplayer.IsActive)
             {
@@ -20,17 +20,17 @@ namespace NebulaPatcher.Patches.Dynamic
 
 #pragma warning disable Harmony003
         [HarmonyPostfix]
-        [HarmonyPatch(nameof(DysonBlueprintData.ContentFromBase64String))]
-        public static void ContentFromBase64String_Postfix(DysonBlueprintDataIOError __result, string __0, EDysonBlueprintType __1, DysonSphere __2, DysonSphereLayer __3)
+        [HarmonyPatch(nameof(DysonBlueprintData.FromBase64String))]
+        public static void FromBase64String_Postfix(DysonBlueprintDataIOError __result, string str64Data, EDysonBlueprintType requestType, DysonSphere sphere, DysonSphereLayer layer)
         {
             if (Multiplayer.IsActive)
             {
                 Multiplayer.Session.DysonSpheres.InBlueprint = false;
                 if (!Multiplayer.Session.DysonSpheres.IsIncomingRequest && __result == DysonBlueprintDataIOError.OK)
                 {
-                    int starIndex = __2.starData.index;
-                    int layerId = __3?.id ?? -1;
-                    Multiplayer.Session.Network.SendPacket(new DysonBlueprintPacket(starIndex, layerId, __1, __0));
+                    int starIndex = sphere.starData.index;
+                    int layerId = layer?.id ?? -1;
+                    Multiplayer.Session.Network.SendPacket(new DysonBlueprintPacket(starIndex, layerId, requestType, str64Data));
                 }
             }
         }

--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -203,7 +203,6 @@ namespace NebulaPatcher.Patches.Dynamic
             {
                 if (Multiplayer.IsActive)
                 {
-                    Multiplayer.Session.StationsUI.DecreaseCooldown();
                     Multiplayer.Session.Launch.CollectProjectile();
                 }
                 return;

--- a/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
@@ -91,9 +91,7 @@ namespace NebulaPatcher.Patches.Dynamic
             // Request initial dysonSphere data
             if (GameMain.data.dysonSpheres[star.index] == null)
             {
-                Multiplayer.Session.DysonSpheres.RequestingIndex = star.index;
-                Log.Info($"Requesting DysonSphere for system {star.displayName} (Index: {star.index})");
-                Multiplayer.Session.Network.SendPacket(new DysonSphereLoadRequest(star.index, DysonSphereRequestEvent.Load));
+                Multiplayer.Session.DysonSpheres.RequestDysonSphere(star.index, false);
             }
 
             NebulaModAPI.OnStarLoadRequest?.Invoke(star.index);

--- a/NebulaPatcher/Patches/Dynamic/UIFatalErrorTip_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIFatalErrorTip_Patch.cs
@@ -45,7 +45,7 @@ namespace NebulaPatcher.Patches.Dynamic
         private static string Title()
         {
             StringBuilder stringBuilder = new StringBuilder();
-            stringBuilder.Append("An error occurred! Game version ");
+            stringBuilder.Append("An error has occurred! Game version ");
             stringBuilder.Append(GameConfig.gameVersion.ToString());
             stringBuilder.Append('.');
             stringBuilder.Append(GameConfig.gameVersion.Build);

--- a/NebulaWorld/Chat/ChatCommandRegistry.cs
+++ b/NebulaWorld/Chat/ChatCommandRegistry.cs
@@ -63,6 +63,7 @@ namespace NebulaWorld.Chat.Commands
             RegisterCommand("whisper", new WhisperCommandHandler(), "w", "tell", "t");
             RegisterCommand("info", new InfoCommandHandler(), "server");
             RegisterCommand("clear", new ClearCommandHandler(), "c");
+            RegisterCommand("xconsole", new XConsoleCommandHandler(), "x");
         }
     }
 

--- a/NebulaWorld/Chat/Commands/XConsoleCommandHandler.cs
+++ b/NebulaWorld/Chat/Commands/XConsoleCommandHandler.cs
@@ -1,0 +1,41 @@
+﻿using NebulaModel.DataStructures;
+using NebulaWorld.MonoBehaviours.Local;
+
+namespace NebulaWorld.Chat.Commands
+{
+    public class XConsoleCommandHandler : IChatCommandHandler
+    {
+        private readonly XConsole xConsole = new XConsole();
+
+        public void Execute(ChatWindow window, string[] parameters)
+        {
+            if (parameters.Length > 0)
+            {
+                string commandText = string.Join(" ", parameters);
+                xConsole.ExecuteCommand(commandText);
+                string output = xConsole.consoleText;
+                if (output.EndsWith("Bad command.</color>\r\n"))
+                {
+                    output = $">> {commandText}\n>> Bad command. Use /x -help to get list of known commands.";
+                    window.SendLocalChatMessage(output, ChatMessageType.CommandErrorMessage);
+                }
+                else
+                {
+                    window.SendLocalChatMessage(xConsole.consoleText, ChatMessageType.CommandOutputMessage);
+                }
+                xConsole.consoleText = "";
+                xConsole.history_cmds.Clear();
+            }
+        }
+
+        public string GetDescription()
+        {
+            return "Execute developer console command";
+        }
+
+        public string GetUsage()
+        {
+            return "[XConsole command]";
+        }
+    }
+}

--- a/NebulaWorld/Logistics/StationUIManager.cs
+++ b/NebulaWorld/Logistics/StationUIManager.cs
@@ -6,7 +6,6 @@ namespace NebulaWorld.Logistics
 {
     public class StationUIManager : IDisposable
     {
-        public int UpdateCooldown; // cooldown is reserved for future use
         public bool UIRequestedShipDronWarpChange { get; set; } // when receiving a ship, drone or warp change only take/add items from the one issuing the request
         public StationUI SliderBarPacket { get; set; } // store the change of slider bar temporary, only send it when mouse button is released.
         public int StorageMaxChangeId { get; set; } // index of the storage that its slider value changed by the user. -1: None, -2: Syncing
@@ -19,21 +18,11 @@ namespace NebulaWorld.Logistics
         {
         }
 
-        public void DecreaseCooldown()
-        {
-            // cooldown is reserved for future use
-            if (UpdateCooldown > 0)
-            {
-                UpdateCooldown--;
-            }
-        }
-
         public void UpdateStation(ref StationUI packet)
         {
             StationComponent stationComponent = GetStation(packet.PlanetId, packet.StationId, packet.StationGId);
             if (stationComponent == null)
             {
-                Log.Warn($"StationUI: Unable to find requested station on planet {packet.PlanetId} with id {packet.StationId} and gid of {packet.StationGId}");
                 return;
             }
             UpdateSettingsUI(stationComponent, ref packet);
@@ -43,16 +32,15 @@ namespace NebulaWorld.Logistics
         public void UpdateStorage(StorageUI packet)
         {
             StationComponent stationComponent = GetStation(packet.PlanetId, packet.StationId, packet.StationGId);
-            if (stationComponent == null)
+            if (stationComponent == null || stationComponent.storage == null)
             {
-                Log.Warn($"StorageUI: Unable to find requested station on planet {packet.PlanetId} with id {packet.StationId} and gid of {packet.StationGId}");
                 return;
             }
             UpdateStorageUI(stationComponent, packet);
             RefreshWindow(packet.PlanetId, packet.StationId);
         }
 
-        private void RefreshWindow(int planetId, int stationId)
+        private static void RefreshWindow(int planetId, int stationId)
         {
             // If station window is opened and veiwing the updating station, refresh the window.
             UIStationWindow stationWindow = UIRoot.instance.uiGame.stationWindow;
@@ -68,7 +56,7 @@ namespace NebulaWorld.Logistics
         /**
          * Updates to a given station that should happen in the background.
          */
-        private void UpdateSettingsUI(StationComponent stationComponent, ref StationUI packet)
+        private static void UpdateSettingsUI(StationComponent stationComponent, ref StationUI packet)
         {
             // SetDroneCount, SetShipCount may change packet.SettingValue
             switch (packet.SettingIndex)
@@ -236,12 +224,7 @@ namespace NebulaWorld.Logistics
             }
         }
 
-        /*
-         * Update station settings and drone, ship and warper counts.
-         * 
-         * First determine if the local player has the station window opened and handle that accordingly.
-         */
-        private StationComponent GetStation(int planetId, int stationId, int stationGid)
+        private static StationComponent GetStation(int planetId, int stationId, int stationGid)
         {
             PlanetData planet = GameMain.galaxy.PlanetById(planetId);
 

--- a/NebulaWorld/Universe/DysonSphereManager.cs
+++ b/NebulaWorld/Universe/DysonSphereManager.cs
@@ -145,6 +145,19 @@ namespace NebulaWorld.Universe
             }
         }
 
+        public void RequestDysonSphere(int starIndex, bool showInfo = true)
+        {
+            StarData starData = GameMain.galaxy.stars[starIndex];
+            RequestingIndex = starIndex;
+            Log.Info($"Requesting DysonSphere for system {starData.displayName} (Index: {starData.index})");
+            Multiplayer.Session.Network.SendPacket(new DysonSphereLoadRequest(starData.index, DysonSphereRequestEvent.Load));
+            ClearSelection(starIndex);
+            if (showInfo)
+            {
+                InGamePopup.ShowInfo("Loading", $"Loading Dyson sphere {starData.displayName}, please wait...", null);
+            }
+        }
+
         public void UnloadRemoteDysonSpheres()
         {
             //The editor will throw errors if there are no dyson spheres available
@@ -175,7 +188,7 @@ namespace NebulaWorld.Universe
                 {
                     IsNormal = false;
                     InGamePopup.ShowWarning("Desync", $"Dyson sphere id[{starIndex}] {GameMain.galaxy.stars[starIndex].displayName} is desynced.",
-                        "Reload", () => Multiplayer.Session.Network.SendPacket(new DysonSphereLoadRequest(starIndex, DysonSphereRequestEvent.Load)));
+                        "Reload", () => RequestDysonSphere(starIndex));
                 }
             }
         }


### PR DESCRIPTION
**Improve error log**
Make copied error log look better in discord message. Cut the part below ``NebulaModel.Packets.PacketProcessor``.  
![ini](https://user-images.githubusercontent.com/50672801/155624084-fcebda32-4437-403c-8d96-114fdbdd8dd5.png)

**Add xconsole chat command**
Use ``/xconsole [command]`` or ``/x [command]`` to execute [developer console](https://dsp-wiki.com/Developer_Console) command.  
![xconsole1](https://user-images.githubusercontent.com/50672801/156228080-2725f027-317b-4609-8094-c80f7d4808ef.jpg)

**Changes & Bugfix**
- Fix an issue when sending too large dyson blueprint data string.  
- Fix an issue about reloading dyson sphere not overwrite correctly.
- Change ``StationUIInitialSync`` so it informs client when gid is not matched.
- Make PlanetComputeThreadMain calculation in ``PlanetDataRequestProcessor`` run in the background, so host will not freeze when entering a new star system.  