### PR TITLE
Add OnPlayerJoin and OnPlayerLeft events to API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+0.8.4:
+
+- @kremnev8: add two new events to Nebula API
+
 0.8.3:
 
 - @kremnev8: improved ingame chat

--- a/NebulaAPI/CHANGELOG.md
+++ b/NebulaAPI/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+1.2.0:
+
+- @kremnev8: add two new events to Nebula API for players joining and leaving the game
 
 1.1.4:
 

--- a/NebulaAPI/NebulaModAPI.cs
+++ b/NebulaAPI/NebulaModAPI.cs
@@ -86,6 +86,19 @@ namespace NebulaAPI
         /// </summary>
         public static Action<int> OnPlanetLoadFinished;
 
+        /// <summary>
+        /// Subscribe to receive even when a new player joins the game.
+        /// The event fires right after the player starts to load in the save data
+        /// <see cref="IPlayerData"/>> player - info about the player
+        /// </summary>
+        public static Action<IPlayerData> OnPlayerJoinedGame;
+        
+        /// <summary>
+        /// Subscribe to receive even when a new player leaves the game
+        /// <see cref="IPlayerData"/>> player - info about the player
+        /// </summary>
+        public static Action<IPlayerData> OnPlayerLeftGame;
+
         private void Awake()
         {
             nebulaIsInstalled = false;

--- a/NebulaAPI/version.json
+++ b/NebulaAPI/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "assemblyVersion": {
     "precision": "build"
   },

--- a/NebulaNetwork/PacketProcessors/Session/LobbyRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Session/LobbyRequestProcessor.cs
@@ -164,6 +164,7 @@ namespace NebulaNetwork.PacketProcessors.Session
                 }
 
                 Multiplayer.Session.World.OnPlayerJoining(player.Data.Username);
+                NebulaModAPI.OnPlayerJoinedGame?.Invoke(player.Data);
 
                 // Make sure that each player that is currently in the game receives that a new player as join so they can create its RemotePlayerCharacter
                 PlayerJoining pdata = new PlayerJoining((PlayerData)player.Data.CreateCopyWithoutMechaData()); // Remove inventory from mecha data

--- a/NebulaNetwork/PacketProcessors/Session/StartGameMessageProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Session/StartGameMessageProcessor.cs
@@ -46,6 +46,7 @@ namespace NebulaNetwork.PacketProcessors.Session
                     }
 
                     Multiplayer.Session.World.OnPlayerJoining(player.Data.Username);
+                    NebulaModAPI.OnPlayerJoinedGame?.Invoke(player.Data);
 
                     // Make sure that each player that is currently in the game receives that a new player as join so they can create its RemotePlayerCharacter
                     PlayerJoining pdata = new PlayerJoining((PlayerData)player.Data.CreateCopyWithoutMechaData()); // Remove inventory from mecha data

--- a/NebulaNetwork/PlayerManager.cs
+++ b/NebulaNetwork/PlayerManager.cs
@@ -288,6 +288,7 @@ namespace NebulaNetwork
             if (player != null)
             {
                 SendPacketToOtherPlayers(new PlayerDisconnected(player.Id), player);
+                NebulaModAPI.OnPlayerLeftGame?.Invoke(player.Data);
                 Multiplayer.Session.World.DestroyRemotePlayerModel(player.Id);
                 using (threadSafe.availablePlayerIds.GetLocked(out Queue<ushort> availablePlayerIds))
                 {

--- a/SharedConfig.targets
+++ b/SharedConfig.targets
@@ -44,7 +44,7 @@
           DestinationFolder="..\NebulaUnity\Assets\Assemblies\" />
   </Target>
 
-  <Target Name="CopyBundleToOutDir" AfterTargets="Build">
+  <Target Name="CopyBundleToOutDir" AfterTargets="Build" Condition=" '$(MSBuildProjectName)' != 'NebulaAPI' ">
     <Copy SourceFiles="..\NebulaWorld\Assets\nebulabundle" DestinationFolder="$(OutDir)" />
   </Target>
   

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
I'm currently making a new feature of BlueprintTweaks Nebula compatible: Factory Undo. But I found that I'm missing these two events to successfully make compatibility code. 
This PR adds two events that any mod can subscribe to and receive calls:
- When player is joining the game
- When player leaves the game. 

Together with the call `IPlayerData` is provided, which gives all needed data.