### PR TITLE
fix for PlanetFactory.Import corruption checker/fixer code.

### DIFF
--- a/NebulaPatcher/Patches/Dynamic/UIEscMenu_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIEscMenu_Patch.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using NebulaPatcher.Patches.Transpiler;
 using NebulaWorld;
 using UnityEngine;
 using UnityEngine.UI;
@@ -40,6 +41,8 @@ namespace NebulaPatcher.Patches.Dynamic
         {
             if (Multiplayer.IsActive)
             {
+                PlanetFactory_Transpiler.CheckPopupPresent.Clear();
+                PlanetFactory_Transpiler.FaultyVeins.Clear();
                 Multiplayer.LeaveGame();
             }
         }


### PR DESCRIPTION
This fixes the code we use to check and fix corruption to the veinPool array when planet factory data is imported.
It produced a large lag and created a large number of popups making it unfeasable to use its intended functionality.