### PR TITLE
Add connect/disconnect message in chat, logging clean up

### DIFF
--- a/NebulaModel/DataStructures/Chat/ChatMessageType.cs
+++ b/NebulaModel/DataStructures/Chat/ChatMessageType.cs
@@ -3,10 +3,11 @@
     public enum ChatMessageType
     {
         PlayerMessage = 0,
-        SystemMessage = 1,
-        CommandUsageMessage = 2,
-        CommandOutputMessage = 3,
-        CommandErrorMessage = 4,
-        PlayerMessagePrivate = 5
+        SystemInfoMessage = 1,
+        SystemWarnMessage = 2,
+        CommandUsageMessage = 3,
+        CommandOutputMessage = 4,
+        CommandErrorMessage = 5,
+        PlayerMessagePrivate = 6
     }
 }

--- a/NebulaModel/Logger/Log.cs
+++ b/NebulaModel/Logger/Log.cs
@@ -5,7 +5,9 @@ namespace NebulaModel.Logger
 {
     public static class Log
     {
-        public static string MessageInfo { get; private set; }
+        public static string LastInfoMsg { get; set; }
+        public static string LastWarnMsg { get; set; }
+        public static string LastErrorMsg { get; set; }
 
         private static ILogger logger;
 
@@ -29,7 +31,7 @@ namespace NebulaModel.Logger
         public static void Info(string message)
         {
             logger.LogInfo(message);
-            MessageInfo = message;
+            LastInfoMsg = message;
         }
 
         public static void Info(object message)
@@ -40,6 +42,7 @@ namespace NebulaModel.Logger
         public static void Warn(string message)
         {
             logger.LogWarning(message);
+            LastWarnMsg = message;
         }
 
         public static void Warn(object message)
@@ -50,7 +53,11 @@ namespace NebulaModel.Logger
         public static void Error(string message)
         {
             logger.LogError(message);
-            UIFatalErrorTip.instance.ShowError("[Nebula Error] " + message, "");
+            LastErrorMsg = message;
+            if (UIFatalErrorTip.instance != null)
+            {
+                UIFatalErrorTip.instance.ShowError("[Nebula Error] " + message, "");
+            }
         }
 
         public static void Error(Exception ex)

--- a/NebulaModel/Networking/PacketUtils.cs
+++ b/NebulaModel/Networking/PacketUtils.cs
@@ -14,9 +14,17 @@ namespace NebulaModel.Networking
         public static void RegisterAllPacketNestedTypesInAssembly(Assembly assembly, NetPacketProcessor packetProcessor)
         {
             System.Collections.Generic.IEnumerable<Type> nestedTypes = AssembliesUtils.GetTypesWithAttributeInAssembly<RegisterNestedTypeAttribute>(assembly);
+            bool isAPIAssemblies = NebulaModAPI.TargetAssemblies.Contains(assembly);
             foreach (Type type in nestedTypes)
             {
-                Log.Info($"Registering Nested Type: {type.Name}");
+                if (isAPIAssemblies)
+                {
+                    Log.Info($"Registering Nested Type: {type.Name}");
+                }
+                else
+                {
+                    Log.Debug($"Registering Nested Type: {type.Name}");
+                }
                 if (type.IsClass)
                 {
                     MethodInfo registerMethod = packetProcessor.GetType().GetMethods()
@@ -66,12 +74,20 @@ namespace NebulaModel.Networking
                 .Where(m => m.IsGenericMethod && m.GetGenericArguments().Length == 2)
                 .FirstOrDefault();
 
+            bool isAPIAssemblies = NebulaModAPI.TargetAssemblies.Contains(assembly);
             foreach (Type type in processors)
             {
                 if (IsSubclassOfRawGeneric(typeof(BasePacketProcessor<>), type))
                 {
                     Type packetType = type.BaseType.GetGenericArguments().FirstOrDefault();
-                    Log.Info($"Registering {type.Name} to process packet of type: {packetType.Name}");
+                    if (isAPIAssemblies)
+                    {
+                        Log.Info($"Registering {type.Name} to process packet of type: {packetType.Name}");
+                    }
+                    else
+                    {
+                        Log.Debug($"Registering {type.Name} to process packet of type: {packetType.Name}");
+                    }
 
                     // Create instance of the processor
                     Type delegateType = typeof(Action<,>).MakeGenericType(packetType, typeof(INebulaConnection));

--- a/NebulaModel/Utils/ChatUtils.cs
+++ b/NebulaModel/Utils/ChatUtils.cs
@@ -94,8 +94,11 @@ namespace NebulaModel.Utils
             {
                 case ChatMessageType.PlayerMessage:
                     return Color.white;
-                
-                case ChatMessageType.SystemMessage:
+
+                case ChatMessageType.SystemInfoMessage:
+                    return Color.cyan;
+
+                case ChatMessageType.SystemWarnMessage:
                     return new Color(1,0.95f,0,1);
                 
                 case ChatMessageType.CommandUsageMessage:
@@ -121,7 +124,8 @@ namespace NebulaModel.Utils
             return type == ChatMessageType.CommandOutputMessage ||
                    type == ChatMessageType.CommandUsageMessage ||
                    type == ChatMessageType.CommandErrorMessage ||
-                   type == ChatMessageType.SystemMessage;
+                   type == ChatMessageType.SystemWarnMessage ||
+                   type == ChatMessageType.SystemInfoMessage;
         }
         
         public static bool Contains(this string source, string toCheck, StringComparison comp)

--- a/NebulaPatcher/Patches/Dynamic/GameLoader_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameLoader_Patch.cs
@@ -11,7 +11,7 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPatch(nameof(GameLoader.FixedUpdate))]
         public static void FixedUpdate_Postfix(int ___frame)
         {
-            InGamePopup.UpdateMessage("Loading", "Loading state from server, please wait\n" + Log.MessageInfo);
+            InGamePopup.UpdateMessage("Loading", "Loading state from server, please wait\n" + Log.LastInfoMsg);
             if (Multiplayer.IsActive && ___frame >= 11)
             {
                 Multiplayer.Session.OnGameLoadCompleted();

--- a/NebulaPatcher/Patches/Dynamic/StationComponent_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/StationComponent_Patch.cs
@@ -68,7 +68,7 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPatch(nameof(StationComponent.Reset))]
         public static bool Reset_Prefix(StationComponent __instance)
         {
-            Log.Warn($"Reset called on gid {__instance.gid}");
+            Log.Info($"Reset called on gid {__instance.gid}");
             return true;
         }
     }

--- a/NebulaPatcher/Patches/Dynamic/UIFatalErrorTip_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIFatalErrorTip_Patch.cs
@@ -1,5 +1,4 @@
-﻿using BepInEx;
-using BepInEx.Bootstrap;
+﻿using BepInEx.Bootstrap;
 using HarmonyLib;
 using NebulaModel.Logger;
 using NebulaWorld;
@@ -14,6 +13,19 @@ namespace NebulaPatcher.Patches.Dynamic
     internal class UIFatalErrorTip_Patch
     {
         static GameObject button;
+
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(UIFatalErrorTip._OnRegEvent))]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Original Function Name")]
+        public static void _OnRegEvent_Postfix()
+        {
+            // If there is errer message before game begin, we will show to user here
+            if (Log.LastErrorMsg != null)
+            {
+                UIFatalErrorTip.instance.ShowError("[Nebula Error] " + Log.LastErrorMsg, "");
+                Log.LastErrorMsg = null;
+            }
+        }
 
         [HarmonyPostfix]
         [HarmonyPatch(nameof(UIFatalErrorTip._OnOpen))]

--- a/NebulaPatcher/Patches/Dynamic/UIGalaxySelect_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIGalaxySelect_Patch.cs
@@ -70,7 +70,7 @@ namespace NebulaPatcher.Patches.Dynamic
 
                 if(UIVirtualStarmap_Transpiler.customBirthPlanet != -1)
                 {
-                    Debug.Log((GameMain.data.galaxy.PlanetById(UIVirtualStarmap_Transpiler.customBirthPlanet) == null) ? "null" : "not null");
+                    Log.Debug((GameMain.data.galaxy.PlanetById(UIVirtualStarmap_Transpiler.customBirthPlanet) == null) ? "null" : "not null");
                     GameMain.data.galaxy.PlanetById(UIVirtualStarmap_Transpiler.customBirthPlanet)?.UnloadFactory();
                 }
 

--- a/NebulaPatcher/Patches/Dynamic/UniverseGen_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UniverseGen_Patch.cs
@@ -1,7 +1,7 @@
 ﻿using HarmonyLib;
+using NebulaModel.Logger;
 using NebulaPatcher.Patches.Transpilers;
 using NebulaWorld;
-using UnityEngine;
 
 namespace NebulaPatcher.Patches.Dynamic
 {
@@ -15,7 +15,7 @@ namespace NebulaPatcher.Patches.Dynamic
         {
             if (Multiplayer.IsActive && UIVirtualStarmap_Transpiler.customBirthStar != -1)
             {
-                Debug.Log("Overwriting with " + __result.PlanetById(UIVirtualStarmap_Transpiler.customBirthPlanet) + " and " + __result.StarById(UIVirtualStarmap_Transpiler.customBirthStar));
+                Log.Debug("Overwriting with " + __result.PlanetById(UIVirtualStarmap_Transpiler.customBirthPlanet) + " and " + __result.StarById(UIVirtualStarmap_Transpiler.customBirthStar));
                 __result.birthPlanetId = UIVirtualStarmap_Transpiler.customBirthPlanet;
                 __result.birthStarId = UIVirtualStarmap_Transpiler.customBirthStar;
             }

--- a/NebulaPatcher/Patches/Transpilers/UIVirtualStarmap_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/UIVirtualStarmap_Transpiler.cs
@@ -262,7 +262,7 @@ namespace NebulaPatcher.Patches.Transpilers
             AddStarToStarmap(starmap, starData);
 
             starmap.clickText = starData.id.ToString();
-            Debug.Log("Setting it to " + starmap.clickText + " " + starData.id);
+            Log.Debug("Setting it to " + starmap.clickText + " " + starData.id);
 
             for (int i = 0; i < starData.planetCount; i++)
             {

--- a/NebulaWorld/MonoBehaviours/Local/Chat/ChatManager.cs
+++ b/NebulaWorld/MonoBehaviours/Local/Chat/ChatManager.cs
@@ -11,8 +11,6 @@ namespace NebulaWorld.MonoBehaviours.Local
 {
     public class ChatManager : MonoBehaviour
     {
-        private int attemptsToGetLocationCountDown = 25;
-        private bool sentLocation;
         private ChatWindow chatWindow;
         public static ChatManager Instance;
 
@@ -69,8 +67,6 @@ namespace NebulaWorld.MonoBehaviours.Local
                 Multiplayer.Session.Network?.SendPacket(new NewChatMessagePacket(newMessage.ChatMessageType,
                     newMessage.MessageText, DateTime.Now, GetUserName()));
             }
-
-            SendPostConnectionPlanetInfoMessage();
         }
 
         private static string GetUserName()
@@ -78,20 +74,7 @@ namespace NebulaWorld.MonoBehaviours.Local
             return Multiplayer.Session?.LocalPlayer?.Data?.Username ?? "Unknown";
         }
 
-        private void SendPostConnectionPlanetInfoMessage()
-        {
-            if (sentLocation || !Multiplayer.IsActive || Multiplayer.Session.IsInLobby || Multiplayer.IsInMultiplayerMenu)
-                return;
-            if (GameMain.localPlanet == null && attemptsToGetLocationCountDown-- > 0)
-            {
-                return;
-            }
 
-            string locationStr = GameMain.localPlanet == null ? "In Space" : GameMain.localPlanet.displayName;
-            Multiplayer.Session.Network.SendPacket(new NewChatMessagePacket(ChatMessageType.SystemMessage,
-                $"connected ({locationStr})", DateTime.Now, GetUserName()));
-            sentLocation = true;
-        }
 
         // Queue a message to appear in chat window
         public void SendChatMessage(string text, ChatMessageType messageType)

--- a/NebulaWorld/MonoBehaviours/Local/Chat/ChatWindow.cs
+++ b/NebulaWorld/MonoBehaviours/Local/Chat/ChatWindow.cs
@@ -160,7 +160,7 @@ namespace NebulaWorld.MonoBehaviours.Local
 
             if (!chatWindow.activeSelf)
             {
-                if (Config.Options.AutoOpenChat)
+                if (Config.Options.AutoOpenChat && !ChatUtils.IsCommandMessage(messageType))
                 {
                     Toggle(false, false);
                 }

--- a/NebulaWorld/Statistics/StatisticsManager.cs
+++ b/NebulaWorld/Statistics/StatisticsManager.cs
@@ -5,7 +5,6 @@ using NebulaModel.Packets.Statistics;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using UnityEngine;
 
 namespace NebulaWorld.Statistics
 {
@@ -191,7 +190,6 @@ namespace NebulaWorld.Statistics
             //Export production statistics for every planet
             for (int i = 0; i < GameMain.data.factoryCount; i++)
             {
-                Debug.Log("Exporting data for " + i);
                 Stats.production.factoryStatPool[i].Export(bw);
             }
 


### PR DESCRIPTION
**Show error message before game start**
Log.Error message before game start will be shown in `UIFatalErrorTip`, so user will know what thing goes wrong.  


**Add connect/disconnect message in chat**
The message is shown when a remote player model is created or destroyed.  
![chat](https://user-images.githubusercontent.com/50672801/166943453-152a2606-2cb1-429d-829d-cc247f1fb920.jpg)

**Expose ChatManager.SendChatMessage**
Now can use `Multiplayer.Session.World.ShowChatMessage(string text, ChatMessageType messageType)` to show text in chat.

**Clean up logging**
- Make packet registering message for Nebula packets show in debug message, make others show in info message, so it is easier to know which packets are added by API.  
- Remove unneeded debug message