### PR TITLE
Fix for discord rich presence not working with ngrok enabled

### DIFF
--- a/NebulaNetwork/Ngrok/NgrokManager.cs
+++ b/NebulaNetwork/Ngrok/NgrokManager.cs
@@ -238,19 +238,19 @@ namespace NebulaNetwork.Ngrok
             return !_ngrokProcess.HasExited;
         }
 
-        public async Task<string> GetNgrokAddressAsync()
+        public Task<string> GetNgrokAddress()
         {
             if (!IsNgrokActive())
             {
                 throw new Exception($"Not able to get Ngrok tunnel address because Ngrok is not started (or exited prematurely)! LastErrorCode: {NgrokLastErrorCode}");
             }
 
-            if (!_ngrokAddressObtained.Wait(15000))
+            if (!_ngrokAddressObtained.Wait(TimeSpan.FromSeconds(15)))
             {
                 throw new TimeoutException($"Not able to get Ngrok tunnel address because 15s timeout was exceeded! LastErrorCode: {NgrokLastErrorCode}");
             }
 
-            return NgrokAddress;
+            return Task.FromResult(NgrokAddress);
 
         }
 

--- a/NebulaNetwork/Ngrok/NgrokManager.cs
+++ b/NebulaNetwork/Ngrok/NgrokManager.cs
@@ -238,20 +238,22 @@ namespace NebulaNetwork.Ngrok
             return !_ngrokProcess.HasExited;
         }
 
-        public Task<string> GetNgrokAddress()
+        public Task<string> GetNgrokAddressAsync()
         {
-            if (!IsNgrokActive())
+            return Task.Run(() =>
             {
-                throw new Exception($"Not able to get Ngrok tunnel address because Ngrok is not started (or exited prematurely)! LastErrorCode: {NgrokLastErrorCode}");
-            }
+                if (!IsNgrokActive())
+                {
+                    throw new Exception($"Not able to get Ngrok tunnel address because Ngrok is not started (or exited prematurely)! LastErrorCode: {NgrokLastErrorCode}");
+                }
 
-            if (!_ngrokAddressObtained.Wait(TimeSpan.FromSeconds(15)))
-            {
-                throw new TimeoutException($"Not able to get Ngrok tunnel address because 15s timeout was exceeded! LastErrorCode: {NgrokLastErrorCode}");
-            }
+                if (!_ngrokAddressObtained.Wait(TimeSpan.FromSeconds(15)))
+                {
+                    throw new TimeoutException($"Not able to get Ngrok tunnel address because 15s timeout was exceeded! LastErrorCode: {NgrokLastErrorCode}");
+                }
 
-            return Task.FromResult(NgrokAddress);
-
+                return NgrokAddress;
+            });
         }
 
         public async Task<string> GetTunnelAddressFromAPI()

--- a/NebulaNetwork/Ngrok/NgrokManager.cs
+++ b/NebulaNetwork/Ngrok/NgrokManager.cs
@@ -76,7 +76,7 @@ namespace NebulaNetwork.Ngrok
                         );
                     });
 
-                    hasDownloadAndInstallBeenConfirmed = await await Task.WhenAny(downloadAndInstallConfirmation, downloadAndInstallRejection);
+                    hasDownloadAndInstallBeenConfirmed = (await Task.WhenAny(downloadAndInstallConfirmation, downloadAndInstallRejection)).Result;
                     if (!hasDownloadAndInstallBeenConfirmed)
                     {
                         NebulaModel.Logger.Log.Warn("Failed to download or install Ngrok, because user rejected Ngrok download and install confirmation!");
@@ -245,8 +245,13 @@ namespace NebulaNetwork.Ngrok
                 throw new Exception($"Not able to get Ngrok tunnel address because Ngrok is not started (or exited prematurely)! LastErrorCode: {NgrokLastErrorCode}");
             }
 
-            await await Task.WhenAny(_ngrokAddressObtained);
+            if (!_ngrokAddressObtained.Wait(15000))
+            {
+                throw new TimeoutException($"Not able to get Ngrok tunnel address because 15s timeout was exceeded! LastErrorCode: {NgrokLastErrorCode}");
+            }
+
             return NgrokAddress;
+
         }
 
         public async Task<string> GetTunnelAddressFromAPI()

--- a/NebulaNetwork/Server.cs
+++ b/NebulaNetwork/Server.cs
@@ -105,7 +105,8 @@ namespace NebulaNetwork
             {
                 if(ngrokManager.IsNgrokActive())
                 {
-                    DiscordManager.UpdateRichPresence(ip: NgrokAddress, updateTimestamp: true);
+                    //DiscordManager.UpdateRichPresence(ip: NgrokAddress, updateTimestamp: true);
+                    DiscordManager.UpdateRichPresence(ip: await ngrokManager.GetNgrokAddressAsync(), updateTimestamp: true);
                 }
                 else
                 {

--- a/NebulaNetwork/Server.cs
+++ b/NebulaNetwork/Server.cs
@@ -105,7 +105,6 @@ namespace NebulaNetwork
             {
                 if(ngrokManager.IsNgrokActive())
                 {
-                    //DiscordManager.UpdateRichPresence(ip: NgrokAddress, updateTimestamp: true);
                     DiscordManager.UpdateRichPresence(ip: await ngrokManager.GetNgrokAddressAsync(), updateTimestamp: true);
                 }
                 else

--- a/NebulaNetwork/Server.cs
+++ b/NebulaNetwork/Server.cs
@@ -105,7 +105,7 @@ namespace NebulaNetwork
             {
                 if(ngrokManager.IsNgrokActive())
                 {
-                    DiscordManager.UpdateRichPresence(ip: await ngrokManager.GetNgrokAddress(), updateTimestamp: true);
+                    DiscordManager.UpdateRichPresence(ip: await ngrokManager.GetNgrokAddressAsync(), updateTimestamp: true);
                 }
                 else
                 {

--- a/NebulaNetwork/Server.cs
+++ b/NebulaNetwork/Server.cs
@@ -105,7 +105,7 @@ namespace NebulaNetwork
             {
                 if(ngrokManager.IsNgrokActive())
                 {
-                    DiscordManager.UpdateRichPresence(ip: await ngrokManager.GetNgrokAddressAsync(), updateTimestamp: true);
+                    DiscordManager.UpdateRichPresence(ip: await ngrokManager.GetNgrokAddress(), updateTimestamp: true);
                 }
                 else
                 {


### PR DESCRIPTION
Because I changed the way how ngrok address fetching worked, it created a problem with the address not being available yet when the discord rich presence update was being sent, this is fixed now.