### PR TITLE
Add sub tabs in config options settings

### DIFF
--- a/NebulaModel/Logger/Log.cs
+++ b/NebulaModel/Logger/Log.cs
@@ -42,12 +42,17 @@ namespace NebulaModel.Logger
         public static void Warn(string message)
         {
             logger.LogWarning(message);
-            LastWarnMsg = message;
         }
 
         public static void Warn(object message)
         {
             Warn(message?.ToString());
+        }
+
+        public static void WarnInform(string message)
+        {
+            Warn(message);
+            LastWarnMsg = message;
         }
 
         public static void Error(string message)

--- a/NebulaModel/MultiplayerOptions.cs
+++ b/NebulaModel/MultiplayerOptions.cs
@@ -29,6 +29,8 @@ namespace NebulaModel
         [UICharacterLimit(49)]
         public string NgrokAuthtoken { get; set; } = string.Empty;
 
+        [DisplayName("Ngrok Region"), Category("Network")]
+        [Description("Available Regions: us, eu, au, ap, sa, jp, in")]
         public string NgrokRegion { get; set; } = string.Empty;
 
         [DisplayName("Remember Last IP"), Category("Network")]
@@ -40,12 +42,13 @@ namespace NebulaModel
         [DisplayName("Auto accept Discord join requests"), Category("Network")]
         public bool AutoAcceptDiscordJoinRequests { get; set; } = false;
 
+        [DisplayName("IP Configuration"), Category("Network")]
+        [Description("Configure which type of IP should be used by Discord RPC")]
+        public IPUtils.IPConfiguration IPConfiguration { get; set; }
+
         [DisplayName("Show Lobby Hints")]
         public bool ShowLobbyHints { get; set; } = true;
 
-        [DisplayName("Auto Open Chat"), Category("Chat")]
-        [Description("Auto open chat window when receiving message from other players")]
-        public bool AutoOpenChat { get; set; } = true;
         public string LastIP { get; set; } = string.Empty;
 
         [DisplayName("Sync Ups")]
@@ -68,6 +71,16 @@ namespace NebulaModel
                 UpdateNgrokAuthtokenInputFieldContentType(ref ngrokAuthTokenInput);
             }
         }
+
+        [DisplayName("Auto Open Chat"), Category("Chat")]
+        [Description("Auto open chat window when receiving message from other players")]
+        public bool AutoOpenChat { get; set; } = true;
+
+        [DisplayName("Show system warn message"), Category("Chat")]
+        public bool EnableWarnMessage { get; set; } = true;
+
+        [DisplayName("Show system info message"), Category("Chat")]
+        public bool EnableInfoMessage { get; set; } = true;
 
         [DisplayName("Default chat position"), Category("Chat")]
         public ChatPosition DefaultChatPosition { get; set; } = ChatPosition.LeftMiddle;
@@ -118,8 +131,6 @@ namespace NebulaModel
         public bool BuildingWarningEnabled { get; set; } = true;
         public bool BuildingIconEnabled { get; set; } = true;
         public bool GuidingLightEnabled { get; set; } = true;
-
-        public IPUtils.IPConfiguration IPConfiguration { get; set; }
 
         public object Clone()
         {

--- a/NebulaModel/MultiplayerOptions.cs
+++ b/NebulaModel/MultiplayerOptions.cs
@@ -15,37 +15,37 @@ namespace NebulaModel
         [DisplayName("Nickname")]
         public string Nickname { get; set; } = string.Empty;
 
-        [DisplayName("Host Port")]
+        [DisplayName("Host Port"), Category("Network")]
         [UIRange(1, ushort.MaxValue)]
         public ushort HostPort { get; set; } = 8469;
 
-        [DisplayName("Enable Experimental Ngrok support")]
+        [DisplayName("Enable Experimental Ngrok support"), Category("Network")]
         [Description("If enabled, when hosting a server this will automatically download and install the Ngrok client and set up an Ngrok tunnel that provides an address at which the server can be joined")]
         public bool EnableNgrok { get; set; } = false;
 
         private const string _ngrokAuthtokenDisplayname = "Ngrok Authtoken";
-        [DisplayName(_ngrokAuthtokenDisplayname)]
+        [DisplayName(_ngrokAuthtokenDisplayname), Category("Network")]
         [Description("This is required for Ngrok support and can be obtained by creating a free account at https://ngrok.com/")]
         [UICharacterLimit(49)]
         public string NgrokAuthtoken { get; set; } = string.Empty;
 
         public string NgrokRegion { get; set; } = string.Empty;
 
-        [DisplayName("Remember Last IP")]
+        [DisplayName("Remember Last IP"), Category("Network")]
         public bool RememberLastIP { get; set; } = true;
 
-        [DisplayName("Enable Discord RPC (requires restart)")]
+        [DisplayName("Enable Discord RPC (requires restart)"), Category("Network")]
         public bool EnableDiscordRPC { get; set; } = true;
 
-        [DisplayName("Auto accept Discord join requests")]
+        [DisplayName("Auto accept Discord join requests"), Category("Network")]
         public bool AutoAcceptDiscordJoinRequests { get; set; } = false;
 
         [DisplayName("Show Lobby Hints")]
         public bool ShowLobbyHints { get; set; } = true;
 
-        [DisplayName("Auto Open Chat")]
+        [DisplayName("Auto Open Chat"), Category("Chat")]
+        [Description("Auto open chat window when receiving message from other players")]
         public bool AutoOpenChat { get; set; } = true;
-
         public string LastIP { get; set; } = string.Empty;
 
         [DisplayName("Sync Ups")]
@@ -64,18 +64,18 @@ namespace NebulaModel
             set { 
                 _streamerMode = value;
 
-                InputField ngrokAuthTokenInput = GameObject.Find("list/scroll-view/viewport/content/NgrokAuthtoken")?.GetComponentInChildren<InputField>();
+                InputField ngrokAuthTokenInput = GameObject.Find("list/scroll-view/viewport/content/Network/NgrokAuthtoken")?.GetComponentInChildren<InputField>();
                 UpdateNgrokAuthtokenInputFieldContentType(ref ngrokAuthTokenInput);
             }
         }
-        
-        [DisplayName("Default chat position")]
+
+        [DisplayName("Default chat position"), Category("Chat")]
         public ChatPosition DefaultChatPosition { get; set; } = ChatPosition.LeftMiddle;
         
-        [DisplayName("Default chat size")]
+        [DisplayName("Default chat size"), Category("Chat")]
         public ChatSize DefaultChatSize { get; set; } = ChatSize.Medium;
 
-        [DisplayName("Cleanup inactive sessions")]
+        [DisplayName("Cleanup inactive sessions"), Category("Network")]
         [Description("If disabled the underlying networking library will not cleanup inactive connections. This might solve issues with clients randomly disconnecting and hosts having a 'System.ObjectDisposedException'.")]
         public bool CleanupInactiveSessions { get; set; } = true;
 

--- a/NebulaNetwork/Ngrok/NgrokManager.cs
+++ b/NebulaNetwork/Ngrok/NgrokManager.cs
@@ -41,7 +41,7 @@ namespace NebulaNetwork.Ngrok
 
             if (string.IsNullOrEmpty(_authtoken))
             {
-                NebulaModel.Logger.Log.Warn("Ngrok support was enabled, however no Authtoken was provided");
+                NebulaModel.Logger.Log.WarnInform("Ngrok support was enabled, however no Authtoken was provided");
                 return;
             }
 
@@ -49,7 +49,7 @@ namespace NebulaNetwork.Ngrok
             string[] availableRegions = { "us", "eu", "au", "ap", "sa", "jp", "in" };
             if (!string.IsNullOrEmpty(_region) && !availableRegions.Any(_region.Contains))
             {
-                NebulaModel.Logger.Log.Warn("Unsupported Ngrok region was provided, defaulting to autodetection");
+                NebulaModel.Logger.Log.WarnInform("Unsupported Ngrok region was provided, defaulting to autodetection");
                 _region = null;
             }
 
@@ -88,7 +88,7 @@ namespace NebulaNetwork.Ngrok
                     }
                     catch
                     {
-                        NebulaModel.Logger.Log.Warn("Failed to download or install Ngrok!");
+                        NebulaModel.Logger.Log.WarnInform("Failed to download or install Ngrok!");
                         throw;
                     }
 
@@ -96,13 +96,13 @@ namespace NebulaNetwork.Ngrok
 
                 if (!StartNgrok())
                 {
-                    NebulaModel.Logger.Log.Warn($"Failed to start Ngrok tunnel! LastErrorCode: {NgrokLastErrorCode}");
+                    NebulaModel.Logger.Log.WarnInform($"Failed to start Ngrok tunnel! LastErrorCode: {NgrokLastErrorCode}");
                     return;
                 }
 
                 if (!IsNgrokActive())
                 {
-                    NebulaModel.Logger.Log.Warn($"Ngrok tunnel has exited prematurely! LastErrorCode: {NgrokLastErrorCode}");
+                    NebulaModel.Logger.Log.WarnInform($"Ngrok tunnel has exited prematurely! LastErrorCode: {NgrokLastErrorCode}");
                     return;
                 }
 
@@ -122,6 +122,7 @@ namespace NebulaNetwork.Ngrok
                     }
                 }
             }
+            NebulaModel.Logger.Log.WarnInform("Ngrok install completed in the plugin folder");
         }
 
         private bool IsNgrokInstalled()
@@ -207,6 +208,7 @@ namespace NebulaNetwork.Ngrok
                 if (errorCodeMatches.Count > 0)
                 {
                     NgrokLastErrorCode = errorCodeMatches[errorCodeMatches.Count - 1].Value;
+                    NebulaModel.Logger.Log.WarnInform($"Ngrok Error! Code: {NgrokLastErrorCode}");
                 }
             }
         }

--- a/NebulaWorld/MonoBehaviours/Local/Chat/ChatManager.cs
+++ b/NebulaWorld/MonoBehaviours/Local/Chat/ChatManager.cs
@@ -2,6 +2,7 @@
 using CommonAPI.Systems;
 using NebulaModel;
 using NebulaModel.DataStructures;
+using NebulaModel.Logger;
 using NebulaModel.Packets.Players;
 using NebulaModel.Utils;
 using System;
@@ -66,6 +67,12 @@ namespace NebulaWorld.MonoBehaviours.Local
             {
                 Multiplayer.Session.Network?.SendPacket(new NewChatMessagePacket(newMessage.ChatMessageType,
                     newMessage.MessageText, DateTime.Now, GetUserName()));
+            }
+
+            if (Log.LastWarnMsg != null)
+            {
+                SendChatMessage(Log.LastWarnMsg, ChatMessageType.SystemWarnMessage);
+                Log.LastWarnMsg = null;
             }
         }
 

--- a/NebulaWorld/MonoBehaviours/Local/Chat/ChatWindow.cs
+++ b/NebulaWorld/MonoBehaviours/Local/Chat/ChatWindow.cs
@@ -134,9 +134,21 @@ namespace NebulaWorld.MonoBehaviours.Local
 
         public ChatMessage SendLocalChatMessage(string text, ChatMessageType messageType)
         {
+
             if (!messageType.IsCommandMessage())
             {
                 text = ChatUtils.SanitizeText(text);
+            }
+            else
+            {
+                if (messageType == ChatMessageType.SystemInfoMessage && !Config.Options.EnableInfoMessage)
+                {
+                    return null;
+                }
+                if (messageType == ChatMessageType.SystemWarnMessage && !Config.Options.EnableWarnMessage)
+                {
+                    return null;
+                }
             }
 
             text = RichChatLinkRegistry.ExpandRichTextTags(text);
@@ -146,7 +158,6 @@ namespace NebulaWorld.MonoBehaviours.Local
                 messages[0].DestroyMessage();
                 messages.Remove(messages[0]);
             }
-
 
             GameObject textObj = Instantiate(textObject, chatPanel);
             ChatMessage newMsg = new ChatMessage(textObj, text, messageType);


### PR DESCRIPTION
![subtypes](https://user-images.githubusercontent.com/50672801/167840206-69fc64c2-cf3d-4bda-8889-e2fa23c9f0f4.jpg)

Now for displaying config options, if it has a category attribute, it will show in that tab. Else it will show in general tab.  
The tabs will be created automatically.  

Also add `Log.WarnInform(string message)`, this method can show warning message in chat if user has `EnableWarnMessage` (Show system warn message) option enabled.  