### PR TITLE
fix error when unable to obtain documents folder

### DIFF
--- a/NebulaModel/Utils/CryptoUtils.cs
+++ b/NebulaModel/Utils/CryptoUtils.cs
@@ -7,18 +7,34 @@ namespace NebulaModel.Utils
 {
     public static class CryptoUtils
     {
-        public static string KeyFile = Path.Combine(new string[] { Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), GameConfig.gameName, "player.key" });
+        private static readonly string docPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        private static readonly string dataPath = Path.Combine(docPath, GameConfig.gameName);
+        private static readonly string keyFile = Path.Combine(docPath, dataPath, "player.key");
 
         public static RSA GetOrCreateUserCert()
         {
-            RSA rsa = RSA.Create();
-            if (File.Exists(KeyFile))
+            if(string.IsNullOrEmpty(docPath))
             {
-                rsa.FromXmlString(File.ReadAllText(KeyFile));
+                Logger.Log.Warn("Could not find documents folder! Using game directory.");
+                try
+                {
+                    Directory.CreateDirectory(dataPath);
+                }
+                catch(UnauthorizedAccessException e)
+                {
+                    Logger.Log.Error($"Unable to create directory {dataPath}, permission denied.");
+                    throw e;
+                }
+            }
+
+            RSA rsa = RSA.Create();
+            if (File.Exists(keyFile))
+            {
+                rsa.FromXmlString(File.ReadAllText(keyFile));
             }
             else
             {
-                File.WriteAllText(KeyFile, rsa.ToXmlString(true));
+                File.WriteAllText(keyFile, rsa.ToXmlString(true));
             }
             return rsa;
         }


### PR DESCRIPTION
for some users `Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)` returns an empty string and so Nebula will look for the player's key file within a `Dyson Sphere Program` folder inside of the game root. If this folder does not exist it will cause an error, so in this case let's create the folder first to avoid errors.