### PR TITLE
Headless mode improvement

### DIFF
--- a/NebulaModel/MultiplayerOptions.cs
+++ b/NebulaModel/MultiplayerOptions.cs
@@ -146,7 +146,8 @@ namespace NebulaModel
         public bool BuildingIconEnabled { get; set; } = true;
         public bool GuidingLightEnabled { get; set; } = true;
 
-        public bool EnableRemoteSaveAccess { get; set; } = false;
+        public bool RemoteAccessEnabled { get; set; } = false;
+        public string RemoteAccessPassword { get; set; } = "";
         public bool AutoPauseEnabled { get; set; } = true;
 
 

--- a/NebulaModel/Packets/Chat/RemoteSaveCommandPacket.cs
+++ b/NebulaModel/Packets/Chat/RemoteSaveCommandPacket.cs
@@ -18,6 +18,7 @@
     {
         ServerList = 0,
         ServerSave = 1,
-        ServerLoad = 2
+        ServerLoad = 2,
+        Login = 3
     }
 }

--- a/NebulaModel/Packets/Chat/RemoteSaveCommandPacket.cs
+++ b/NebulaModel/Packets/Chat/RemoteSaveCommandPacket.cs
@@ -16,9 +16,10 @@
 
     public enum RemoteSaveCommand
     {
-        ServerList = 0,
-        ServerSave = 1,
-        ServerLoad = 2,
-        Login = 3
+        Login,
+        ServerList,
+        ServerSave,
+        ServerLoad,
+        ServerInfo
     }
 }

--- a/NebulaModel/Utils/CryptoUtils.cs
+++ b/NebulaModel/Utils/CryptoUtils.cs
@@ -50,6 +50,12 @@ namespace NebulaModel.Utils
             return Convert.ToBase64String(hash);
         }
 
+        public static string Hash(string input)
+        {
+            byte[] hash = SHA256.Create().ComputeHash(Encoding.UTF8.GetBytes(input));
+            return Convert.ToBase64String(hash);
+        }
+
         public static string GetCurrentUserPublicKeyHash()
         {
             return Hash(GetPublicKey(GetOrCreateUserCert()));

--- a/NebulaNetwork/PacketProcessors/Chat/RemoteSaveCommmandProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Chat/RemoteSaveCommmandProcessor.cs
@@ -83,7 +83,7 @@ namespace NebulaNetwork.PacketProcessors.Players
         {
             if (allowedConnections.Contains(conn))
             {
-                return "You have already login";
+                return "You have already logged in";
             }
             if (!string.IsNullOrWhiteSpace(Config.Options.RemoteAccessPassword))
             {

--- a/NebulaNetwork/PlayerManager.cs
+++ b/NebulaNetwork/PlayerManager.cs
@@ -55,8 +55,17 @@ namespace NebulaNetwork
             using (GetConnectedPlayers(out Dictionary<INebulaConnection, INebulaPlayer> connectedPlayers))
             {
                 int i = 0;
-                IPlayerData[] result = new IPlayerData[1 + connectedPlayers.Count];
-                result[i++] = Multiplayer.Session.LocalPlayer.Data;
+                IPlayerData[] result;
+                if (Multiplayer.IsDedicated)
+                {
+                    // If host is dedicated server, don't include it
+                    result = new IPlayerData[connectedPlayers.Count];
+                }
+                else
+                {
+                    result = new IPlayerData[1 + connectedPlayers.Count];
+                    result[i++] = Multiplayer.Session.LocalPlayer.Data;
+                }
                 foreach (KeyValuePair<INebulaConnection, INebulaPlayer> kvp in connectedPlayers)
                 {
                     result[i++] = kvp.Value.Data;

--- a/NebulaNetwork/Server.cs
+++ b/NebulaNetwork/Server.cs
@@ -142,7 +142,12 @@ namespace NebulaNetwork
             {
                 if(ngrokManager.IsNgrokActive())
                 {
-                    DiscordManager.UpdateRichPresence(ip: await ngrokManager.GetNgrokAddressAsync(), updateTimestamp: true);
+                    string ip = await ngrokManager.GetNgrokAddressAsync();
+                    DiscordManager.UpdateRichPresence(ip: ip, updateTimestamp: true);
+                    if (Multiplayer.IsDedicated)
+                    {
+                        NebulaModel.Logger.Log.Info($">> Ngrok address: {ip}");
+                    }
                 }
                 else
                 {

--- a/NebulaPatcher/NebulaPlugin.cs
+++ b/NebulaPatcher/NebulaPlugin.cs
@@ -43,7 +43,7 @@ namespace NebulaPatcher
                 if (args[i] == "-server")
                 {
                     Multiplayer.IsDedicated = true;
-                    Log.Info($">> Initial dedicated server");
+                    Log.Info($">> Initializing dedicated server");
                 }
 
                 if (args[i] == "-load" && i + 1 < args.Length)
@@ -55,12 +55,12 @@ namespace NebulaPatcher
                     }
                     if (GameSave.SaveExist(saveName))
                     {
-                        Log.Info($">> Load save {saveName}");
+                        Log.Info($">> Loading save {saveName}");
                         NebulaWorld.GameStates.GameStatesManager.ImportedSaveName = saveName;
                     }
                     else
                     {
-                        Log.Warn($">> Can't find save {saveName}! Exiting...");
+                        Log.Warn($">> Can't find save with name {saveName}! Exiting...");
                         Application.Quit();
                     }
                 }
@@ -74,7 +74,7 @@ namespace NebulaPatcher
                     }
                     else
                     {
-                        Log.Warn($">> Can't set UPS, {args[i + 1]} is not a number");
+                        Log.Warn($">> Can't set UPS, {args[i + 1]} is not a valid number");
                     }
                 }
             }
@@ -104,7 +104,7 @@ namespace NebulaPatcher
             if (GameSave.SaveExist(saveName))
             {
                 // Modified from DoLoadSelectedGame
-                Log.Info($"Start dedicated server, loading save : {saveName}");
+                Log.Info($"Starting dedicated server, loading save : {saveName}");
                 DSPGame.StartGame(saveName);
                 Log.Info($"Listening server on port {NebulaModel.Config.Options.HostPort}");
                 Multiplayer.HostGame(new Server(NebulaModel.Config.Options.HostPort, true));

--- a/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
@@ -28,10 +28,18 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPrefix]
         [HarmonyPatch(typeof(GameData), nameof(GameData.OnDraw))]
         [HarmonyPatch(typeof(GameData), nameof(GameData.OnPostDraw))]
-        [HarmonyPatch(typeof(GameMain), nameof(GameMain.LateUpdate))]
         [HarmonyPatch(typeof(FactoryModel), nameof(FactoryModel.LateUpdate))]
         public static bool OnDraw_Prefix()
         {
+            return false;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(GameMain), nameof(GameMain.LateUpdate))]
+        public static bool OnLateUpdate()
+        {
+            // Because UIRoot._LateUpdate() doesn't run in headless mode, we need this to enable autosave
+            UIRoot.instance.uiGame.autoSave._LateUpdate();
             return false;
         }
 

--- a/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
@@ -17,10 +17,15 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPatch(typeof(GameMain), nameof(GameMain.Begin))]
         public static void GameMainBegin_Postfix()
         {
-            if (Multiplayer.IsActive && Config.Options.AutoPauseEnabled)
+            if (Multiplayer.IsActive)
             {
-                Log.Info("AutoPauseEnabled");
-                GameMain.Pause();
+                Log.Info($">> RemoteAccessEnabled: {Config.Options.RemoteAccessEnabled}");
+                Log.Info($">> RemoteAccessPassword: " + (string.IsNullOrWhiteSpace(Config.Options.RemoteAccessPassword) ? "None" : "Protected"));
+                Log.Info($">> AutoPauseEnabled: {Config.Options.AutoPauseEnabled}");
+                if (Config.Options.AutoPauseEnabled)
+                {
+                    GameMain.Pause();
+                }
             }
         }
 

--- a/NebulaWorld/Chat/Commands/InfoCommandHandler.cs
+++ b/NebulaWorld/Chat/Commands/InfoCommandHandler.cs
@@ -54,7 +54,7 @@ namespace NebulaWorld.Chat.Commands
             
         }
 
-        private static string GetServerInfoText(IServer server, IPUtils.IpInfo ipInfo, bool full)
+        public static string GetServerInfoText(IServer server, IPUtils.IpInfo ipInfo, bool full)
         {
             StringBuilder sb = new("Server info:");
 

--- a/NebulaWorld/Chat/Commands/ServerSaveCommandHandler.cs
+++ b/NebulaWorld/Chat/Commands/ServerSaveCommandHandler.cs
@@ -40,9 +40,14 @@ namespace NebulaWorld.Chat.Commands
                 string saveName = parameters.Length > 1 ? parameters[1] : "";
                 Multiplayer.Session.Network.SendPacket(new RemoteSaveCommandPacket(RemoteSaveCommand.ServerLoad, saveName));
             }
+            else if (parameters[0] == "info")
+            {
+                string parameter = parameters.Length > 1 ? parameters[1] : "";
+                Multiplayer.Session.Network.SendPacket(new RemoteSaveCommandPacket(RemoteSaveCommand.ServerInfo, parameter));
+            }
             else
             {
-                throw new ChatCommandUsageException("Unknown command! Available commands: {login, list, save, load}");
+                throw new ChatCommandUsageException("Unknown command! Available commands: {login, list, save, load, info}");
             }
         }
 
@@ -53,7 +58,7 @@ namespace NebulaWorld.Chat.Commands
 
         public string[] GetUsage()
         {
-            return new string[] { "login <password>", "list [saveNum]" , "save [saveName]", "load <saveName>" };
+            return new string[] { "login <password>", "list [saveNum]" , "save [saveName]", "load <saveName>", "info" };
         }
     }
 }

--- a/NebulaWorld/Chat/Commands/ServerSaveCommandHandler.cs
+++ b/NebulaWorld/Chat/Commands/ServerSaveCommandHandler.cs
@@ -1,5 +1,7 @@
 ﻿using NebulaModel.Packets.Players;
 using NebulaWorld.MonoBehaviours.Local;
+using NebulaModel.Utils;
+using NebulaAPI;
 
 namespace NebulaWorld.Chat.Commands
 {
@@ -11,7 +13,15 @@ namespace NebulaWorld.Chat.Commands
             {
                 throw new ChatCommandUsageException("Not enough arguments!");
             }
-            if (parameters[0] == "list")
+            if (parameters[0] == "login")
+            {
+                string password = parameters.Length > 1 ? parameters[1] : "";
+                IPlayerData playerData = Multiplayer.Session.LocalPlayer.Data;
+                string salt = playerData.Username + playerData.PlayerId;
+                string hash = CryptoUtils.Hash(password + salt);
+                Multiplayer.Session.Network.SendPacket(new RemoteSaveCommandPacket(RemoteSaveCommand.Login, hash));
+            }
+            else if (parameters[0] == "list")
             {
                 string saveNum = parameters.Length > 1 ? parameters[1] : "";
                 Multiplayer.Session.Network.SendPacket(new RemoteSaveCommandPacket(RemoteSaveCommand.ServerList, saveNum));
@@ -32,7 +42,7 @@ namespace NebulaWorld.Chat.Commands
             }
             else
             {
-                throw new ChatCommandUsageException("Unknown command! Available commands: {list, save, load}");
+                throw new ChatCommandUsageException("Unknown command! Available commands: {login, list, save, load}");
             }
         }
 
@@ -43,7 +53,7 @@ namespace NebulaWorld.Chat.Commands
 
         public string[] GetUsage()
         {
-            return new string[] { "list [saveNum]" , "save [saveName]", "load <saveName>" };
+            return new string[] { "login <password>", "list [saveNum]" , "save [saveName]", "load <saveName>" };
         }
     }
 }


### PR DESCRIPTION
Continue #553 

**Config options**
Add `RemoteAccessPassword`
Change `EnableRemoteSaveAccess` to `RemoteAccessEnabled`

**Chat commands**
`/server login <password>` : if server's `RemoteAccessPassword` is not empty or whitespace, it will require the user to put in password before doing remote access actions. CD is 2 seconds.  
![login](https://user-images.githubusercontent.com/50672801/168723708-632e2298-b5c5-44c1-afe4-ab81a545b489.jpg)
`/server info [full]`: this will return server's info to the user.

**Bugfix**
Fix a bug that autosave doesn't work on headless server.  
Make the mecha model of headless server doesn't show up on clients' world.   

**Others**
Log Ngrok address and config options during the game startup.  
Chat now support 10 command history, switch by up and down arrow key.  
