### PR TITLE
Bugfix for dedicated sever sails, and other small changes

### DIFF
--- a/NebulaModel/DataStructures/Chat/ChatMessage.cs
+++ b/NebulaModel/DataStructures/Chat/ChatMessage.cs
@@ -1,10 +1,10 @@
-﻿using NebulaModel.Packets.Players;
-using NebulaModel.Utils;
+﻿using NebulaModel.Utils;
 using System;
 using TMPro;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
+#pragma warning disable IDE1006
 namespace NebulaModel.DataStructures
 {
     /// <summary>
@@ -67,3 +67,4 @@ namespace NebulaModel.DataStructures
         }
     }
 }
+#pragma warning restore IDE1006

--- a/NebulaNetwork/Client.cs
+++ b/NebulaNetwork/Client.cs
@@ -104,13 +104,20 @@ namespace NebulaNetwork
                 Config.SaveOptions();
             }
 
-            if(Config.Options.RememberLastClientPassword && !string.IsNullOrWhiteSpace(serverPassword))
+            if (Config.Options.RememberLastClientPassword && !string.IsNullOrWhiteSpace(serverPassword))
             {
                 Config.Options.LastClientPassword = serverPassword;
                 Config.SaveOptions();
             }
 
-            NebulaModAPI.OnMultiplayerGameStarted?.Invoke();
+            try
+            {
+                NebulaModAPI.OnMultiplayerGameStarted?.Invoke();
+            }
+            catch (System.Exception e)
+            {
+                Log.Error("NebulaModAPI.OnMultiplayerGameStarted error:\n" + e);
+            }
         }
 
         public override void Stop()
@@ -119,7 +126,14 @@ namespace NebulaNetwork
 
             // load settings again to dispose the temp soil setting that could have been received from server
             Config.LoadOptions();
-            NebulaModAPI.OnMultiplayerGameEnded?.Invoke();
+            try
+            {
+                NebulaModAPI.OnMultiplayerGameEnded?.Invoke();
+            }
+            catch (System.Exception e)
+            {
+                Log.Error("NebulaModAPI.OnMultiplayerGameEnded error:\n" + e);
+            }
         }
 
         public override void Dispose()

--- a/NebulaNetwork/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Entity/BuildEntityRequestProcessor.cs
@@ -41,8 +41,8 @@ namespace NebulaNetwork.PacketProcessors.Factory.Entity
                     GameMain.gpuiManager.specifyPlanet = GameMain.galaxy.PlanetById(packet.PlanetId);
                     if (packet.EntityId != -1 && packet.EntityId != NebulaWorld.Factory.FactoryManager.GetNextEntityId(planet.factory))
                     {
-                        string warningText = $"EntityId mismatch {packet.EntityId} != {NebulaWorld.Factory.FactoryManager.GetNextEntityId(planet.factory)} on planet {planet.id}";
-                        Log.Warn(warningText);
+                        string warningText = $"(Desync) EntityId mismatch {packet.EntityId} != {NebulaWorld.Factory.FactoryManager.GetNextEntityId(planet.factory)} on planet {planet.id}. Clients should reconnect!";
+                        Log.WarnInform(warningText);
                         NebulaWorld.Warning.WarningManager.DisplayTemporaryWarning(warningText, 5000);
                     }
                     planet.factory.BuildFinally(GameMain.mainPlayer, packet.PrebuildId);

--- a/NebulaNetwork/PacketProcessors/Universe/DysonSphereDataProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/DysonSphereDataProcessor.cs
@@ -76,7 +76,14 @@ namespace NebulaNetwork.PacketProcessors.Universe
                     Multiplayer.Session.DysonSpheres.RequestingIndex = -1;
                     Multiplayer.Session.DysonSpheres.IsNormal = true;
 
-                    NebulaModAPI.OnDysonSphereLoadFinished?.Invoke(star.index);
+                    try
+                    {
+                        NebulaModAPI.OnDysonSphereLoadFinished?.Invoke(star.index);
+                    }
+                    catch (System.Exception e)
+                    {
+                        Log.Error("NebulaModAPI.OnDysonSphereLoadFinished error:\n" + e);
+                    }
                     break;
                 case DysonSphereRespondEvent.Desync:
                     Multiplayer.Session.DysonSpheres.HandleDesync(packet.StarIndex, conn);

--- a/NebulaNetwork/Server.cs
+++ b/NebulaNetwork/Server.cs
@@ -10,7 +10,6 @@ using NebulaModel.Utils;
 using NebulaWorld;
 using Open.Nat;
 using NebulaWorld.SocialIntegration;
-using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Reflection;
@@ -19,7 +18,6 @@ using UnityEngine;
 using WebSocketSharp;
 using WebSocketSharp.Net;
 using WebSocketSharp.Server;
-using System;
 
 namespace NebulaNetwork
 {
@@ -125,7 +123,7 @@ namespace NebulaNetwork
             try
             {
                 // Set wait time higher for high latency network
-                socket.WaitTime = TimeSpan.FromSeconds(20);
+                socket.WaitTime = System.TimeSpan.FromSeconds(20);
                 socket.KeepClean = Config.Options.CleanupInactiveSessions;
                 socket.Start();
             }catch(System.InvalidOperationException e)
@@ -162,7 +160,14 @@ namespace NebulaNetwork
                 }
             });
 
-            NebulaModAPI.OnMultiplayerGameStarted?.Invoke();
+            try
+            {
+                NebulaModAPI.OnMultiplayerGameStarted?.Invoke();
+            }
+            catch (System.Exception e)
+            {
+                Log.Error("NebulaModAPI.OnMultiplayerGameStarted error:\n" + e);
+            }
         }
 
         public override void Stop()
@@ -171,7 +176,14 @@ namespace NebulaNetwork
 
             ngrokManager?.StopNgrok();
 
-            NebulaModAPI.OnMultiplayerGameEnded?.Invoke();
+            try
+            {
+                NebulaModAPI.OnMultiplayerGameEnded?.Invoke();
+            }
+            catch (System.Exception e)
+            {
+                Log.Error("NebulaModAPI.OnMultiplayerGameEnded error:\n" + e);
+            }
         }
 
         public override void Dispose()

--- a/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
@@ -79,6 +79,7 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPrefix]
         [HarmonyPatch(typeof(ComputeShader), nameof(ComputeShader.FindKernel))]
         [HarmonyPatch(typeof(ComputeShader), nameof(ComputeShader.GetKernelThreadGroupSizes))]
+        [HarmonyPatch(typeof(ComputeShader), nameof(ComputeShader.Dispatch))]
         public static bool ComputeShader_Prefix()
         {
             return false;
@@ -111,6 +112,21 @@ namespace NebulaPatcher.Patches.Dynamic
             {
                 Log.Error("DysonSwarmGameTick_Transpiler failed. Mod version not compatible with game version.");
                 return instructions;
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(DysonSwarm), nameof(DysonSwarm.SetSailCapacity))]
+        public static void DysonSwarmSetSailCapacity_Prefix(DysonSwarm __instance)
+        {
+            // Skip the part of computeShader in if (this.swarmBuffer != null)
+            // (this.computeShader.SetBuffer(...), this.Dispatch_BlitBuffer())
+            if (__instance.swarmBuffer != null)
+            {
+                __instance.swarmBuffer.Release();
+                __instance.swarmInfoBuffer.Release();
+                __instance.swarmBuffer = null;
+                __instance.swarmInfoBuffer = null;
             }
         }
     }

--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -209,7 +209,15 @@ namespace NebulaPatcher.Patches.Dynamic
                     Thread.Sleep(1000);
                     RefreshMissingMeshes();
                 });
-                NebulaModAPI.OnPlanetLoadFinished?.Invoke(planet.id);
+                
+                try
+                {
+                    NebulaModAPI.OnPlanetLoadFinished?.Invoke(planet.id);
+                }
+                catch (Exception e) 
+                {
+                    Log.Error("NebulaModAPI.OnPlanetLoadFinished error:\n" + e); 
+                }
             }
 
             // call this here as it would not be called normally on the client, but its needed to set GameMain.data.galacticTransport.stationCursor

--- a/NebulaPatcher/Patches/Dynamic/PlanetData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetData_Patch.cs
@@ -20,6 +20,21 @@ namespace NebulaPatcher.Patches.Dynamic
         }
 
         [HarmonyPrefix]
+        [HarmonyPatch(nameof(PlanetData.UpdateDirtyMesh))]
+        public static bool UpdateDirtyMesh_Prefix(PlanetData __instance, int dirtyIdx, ref bool __result)
+        {
+            // Temporary fix: skip function when the mesh is null
+            if (__instance.dirtyFlags[dirtyIdx] && __instance.meshes[dirtyIdx] == null)
+            {
+                Log.Warn(__instance == GameMain.localPlanet ? "Local" : "Remote" + $" PlanetData.UpdateDirtyMesh: meshes[{dirtyIdx}] is null");
+                __result = false;
+                return false;
+            }
+
+            return true;
+        }
+
+        [HarmonyPrefix]
         [HarmonyPatch(nameof(PlanetData.UnloadMeshes))]
         public static bool UnloadMeshes_Prefix(PlanetData __instance)
         {

--- a/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetModelingManager_Patch.cs
@@ -46,7 +46,14 @@ namespace NebulaPatcher.Patches.Dynamic
                 PlanetModelingManager.currentFactingStage = 0;
                 return false;
             }
-            NebulaModAPI.OnPlanetLoadRequest?.Invoke(planet.id);
+            try
+            {
+                NebulaModAPI.OnPlanetLoadRequest?.Invoke(planet.id);
+            }
+            catch (System.Exception e)
+            {
+                Log.Error("NebulaModAPI.OnPlanetLoadRequest error:\n" + e);
+            }
 
             // Request factory
             Log.Info($"Requested factory for planet {planet.name} (ID: {planet.id}) from host");
@@ -93,7 +100,14 @@ namespace NebulaPatcher.Patches.Dynamic
                 Multiplayer.Session.DysonSpheres.RequestDysonSphere(star.index, false);
             }
 
-            NebulaModAPI.OnStarLoadRequest?.Invoke(star.index);
+            try
+            {
+                NebulaModAPI.OnStarLoadRequest?.Invoke(star.index);
+            }
+            catch (System.Exception e)
+            {
+                Log.Error("NebulaModAPI.OnStarLoadRequest error:\n" + e);
+            }
 
             return false;
         }

--- a/NebulaPatcher/Patches/Transpilers/UIVirtualStarmap_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/UIVirtualStarmap_Transpiler.cs
@@ -18,11 +18,13 @@ namespace NebulaPatcher.Patches.Transpilers
         private delegate bool IsBirthStar2(StarData starData, UIVirtualStarmap starmap);
         private delegate void TrackPlayerClick(UIVirtualStarmap starmap, int starIndex);
 
+#pragma warning disable IDE1006
         public static bool pressSpamProtector = false;
         private static readonly float orbitScaler = 5f;
 
         public static int customBirthStar = -1;
         public static int customBirthPlanet = -1;
+#pragma warning restore IDE1006
         /*
         if (flag2 && flag)
 		{

--- a/NebulaWorld/Factory/BuildToolManager.cs
+++ b/NebulaWorld/Factory/BuildToolManager.cs
@@ -115,9 +115,9 @@ namespace NebulaWorld.Factory
                     {
                         if (packet.PrebuildId != Multiplayer.Session.Factories.GetNextPrebuildId(packet.PlanetId))
                         {
-                            string warningText = $"PrebuildId mismatch on {packet.PlanetId} planet: {packet.PrebuildId} != {Multiplayer.Session.Factories.GetNextPrebuildId(planet.factory)}";
-                            Log.WarnInform(warningText + ". Consider reconnecting");
-                            NebulaWorld.Warning.WarningManager.DisplayTemporaryWarning(warningText, 5000);
+                            string warningText = $"(Desync) PrebuildId mismatch on {packet.PlanetId} planet: {packet.PrebuildId} != {Multiplayer.Session.Factories.GetNextPrebuildId(planet.factory)}. Please reconnect!";
+                            Log.WarnInform(warningText);
+                            NebulaWorld.Warning.WarningManager.DisplayTemporaryWarning(warningText, 15000);
                         }
                     }
 

--- a/NebulaWorld/MonoBehaviours/Local/Chat/ChatManager.cs
+++ b/NebulaWorld/MonoBehaviours/Local/Chat/ChatManager.cs
@@ -40,7 +40,7 @@ namespace NebulaWorld.MonoBehaviours.Local
             }
 
             chatWindow = chatGo.transform.GetComponentInChildren<ChatWindow>();
-            chatWindow.userName = GetUserName();
+            chatWindow.UserName = GetUserName();
             chatWindow.Toggle(true);
             Config.OnConfigApplied += UpdateChatPosition;
         }

--- a/NebulaWorld/MonoBehaviours/Local/Chat/ChatWindow.cs
+++ b/NebulaWorld/MonoBehaviours/Local/Chat/ChatWindow.cs
@@ -23,15 +23,15 @@ namespace NebulaWorld.MonoBehaviours.Local
         [SerializeField] private RectTransform notifierMask;
         
         [SerializeField] private GameObject chatWindow;
-        
-        
+
+
+        internal string UserName;
         internal UIWindowDrag DragTrigger;
         private readonly Queue<QueuedMessage> outgoingMessages = new Queue<QueuedMessage>(5);
         private readonly List<ChatMessage> messages = new List<ChatMessage>();
         private readonly List<string> inputHistory = new() { "" };
         private int inputHistoryCursor = 0;
 
-        public string userName;
 
         private void Awake()
         {
@@ -166,7 +166,7 @@ namespace NebulaWorld.MonoBehaviours.Local
         private void BroadcastChatMessage(string message, ChatMessageType chatMessageType = ChatMessageType.PlayerMessage)
         {
             QueueOutgoingChatMessage(message, chatMessageType);
-            string formattedMessage = $"[{DateTime.Now:HH:mm}] [{userName}] : {message}";
+            string formattedMessage = $"[{DateTime.Now:HH:mm}] [{UserName}] : {message}";
             SendLocalChatMessage(formattedMessage, chatMessageType);
         }
 

--- a/NebulaWorld/MonoBehaviours/Local/Chat/NotificationMessage.cs
+++ b/NebulaWorld/MonoBehaviours/Local/Chat/NotificationMessage.cs
@@ -11,8 +11,8 @@ namespace NebulaWorld.MonoBehaviours.Local
         private const long NOTIFICATION_DURATION_TICKS = TimeSpan.TicksPerSecond;
         private const long FADE_DURATION = TimeSpan.TicksPerSecond * 2;
         
-        public long notifierEndTime;
-        public TMP_Text text;
+        private long notifierEndTime;
+        private TMP_Text text;
 
         public void Init(int duration)
         {

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -188,7 +188,14 @@ namespace NebulaWorld
 
             // (Host only) Trigger when a new client added to connected players
             Log.Info($"Client{player.Data.PlayerId} - {player.Data.Username} joined");
-            NebulaModAPI.OnPlayerJoinedGame?.Invoke(player.Data);
+            try
+            {
+                NebulaModAPI.OnPlayerJoinedGame?.Invoke(player.Data);
+            }
+            catch (Exception e)
+            {
+                Log.Error("NebulaModAPI.OnPlayerJoinedGame error:\n" + e);
+            }
         }
 
         public void OnPlayerLeftGame(INebulaPlayer player)
@@ -204,7 +211,14 @@ namespace NebulaWorld
 
             // (Host only) Trigger when a connected client leave the game
             Log.Info($"Client{player.Data.PlayerId} - {player.Data.Username} left");
-            NebulaModAPI.OnPlayerLeftGame?.Invoke(player.Data);
+            try
+            {
+                NebulaModAPI.OnPlayerLeftGame?.Invoke(player.Data);
+            }
+            catch (Exception e)
+            {
+                Log.Error("NebulaModAPI.OnPlayerLeftGame error:\n" + e);
+            }
         }
 
         public void OnAllPlayersSyncCompleted()
@@ -678,7 +692,7 @@ namespace NebulaWorld
             return level;
         }
 
-        public void SendChatMessage(string text, ChatMessageType messageType)
+        public void SendChatMessage(string text, ChatMessageType messageType = ChatMessageType.SystemInfoMessage)
         {
             ChatManager.Instance?.SendChatMessage(text, messageType);
         }


### PR DESCRIPTION
Bugfix
- Fix error when sail capacity increases in dedicated server
- Save player.key to .\Dyson Sphere Program folder when it cannot save to document folder

Others:
- Temporary fix for UpdateDirtyMesh
Now it will skip updating colliders when the mesh is null. Need to investigate why mesh is null in the future
- Add try-catch for NebulaAPI hooked event so it will not break processing flow if it error.

Unsolved Issue:
- Dyson sails are not normal in sandbox mode on dedicated server.

