### PR TITLE
Add dedicated server argument -newgame + other features

### DIFF
--- a/NebulaModel/MultiplayerOptions.cs
+++ b/NebulaModel/MultiplayerOptions.cs
@@ -75,14 +75,17 @@ namespace NebulaModel
 
         private bool _streamerMode = false;
         [DisplayName("Streamer mode")]
-        [Description("If enabled specific personal information like your IP address is hidden from the ingame chat.")]
+        [Description("If enabled specific personal information like your IP address is hidden from the ingame chat and input fields.")]
         public bool StreamerMode { 
             get => _streamerMode; 
             set { 
                 _streamerMode = value;
 
                 InputField ngrokAuthTokenInput = GameObject.Find("list/scroll-view/viewport/content/Network/NgrokAuthtoken")?.GetComponentInChildren<InputField>();
-                UpdateNgrokAuthtokenInputFieldContentType(ref ngrokAuthTokenInput);
+                UpdateInputFieldContentType(ref ngrokAuthTokenInput);
+
+                InputField hostIpInput = GameObject.Find("UI Root/Overlay Canvas/Nebula - Multiplayer Menu/Host IP Address/InputField")?.GetComponentInChildren<InputField>();
+                UpdateInputFieldContentType(ref hostIpInput);
             }
         }
 
@@ -127,19 +130,19 @@ namespace NebulaModel
             return MemberwiseClone();
         }
 
-        private void UpdateNgrokAuthtokenInputFieldContentType(ref InputField ngrokAuthTokenInput)
+        private void UpdateInputFieldContentType(ref InputField inputField)
         {
-            if (ngrokAuthTokenInput != null)
+            if (inputField != null)
             {
                 if (StreamerMode)
                 {
-                    ngrokAuthTokenInput.contentType = InputField.ContentType.Password;
+                    inputField.contentType = InputField.ContentType.Password;
                 }
                 else
                 {
-                    ngrokAuthTokenInput.contentType = InputField.ContentType.Standard;
+                    inputField.contentType = InputField.ContentType.Standard;
                 }
-                ngrokAuthTokenInput.UpdateLabel();
+                inputField.UpdateLabel();
             }
         }
 
@@ -149,7 +152,7 @@ namespace NebulaModel
             {
                 case _ngrokAuthtokenDisplayname:
                     {
-                        UpdateNgrokAuthtokenInputFieldContentType(ref inputField);
+                        UpdateInputFieldContentType(ref inputField);
                         break;
                     }
             }

--- a/NebulaNetwork/Client.cs
+++ b/NebulaNetwork/Client.cs
@@ -315,6 +315,16 @@ namespace NebulaNetwork
                     return;
                 }
 
+                if (e.Code == (ushort)DisconnectionReason.HostStillLoading)
+                {
+                    InGamePopup.ShowWarning(
+                        "Server Busy",
+                        "Server is not ready to join. Please try again later.",
+                        "OK".Translate(),
+                        Multiplayer.LeaveGame);
+                    return;
+                }
+
                 if (Multiplayer.Session.IsGameLoaded || Multiplayer.Session.IsInLobby)
                 {
                     InGamePopup.ShowWarning(
@@ -331,6 +341,7 @@ namespace NebulaNetwork
                 }
                 else
                 {
+                    Log.Warn("Disconnect code: " + e.Code + ", reason:" + e.Reason);
                     InGamePopup.ShowWarning(
                         "Server Unavailable",
                         $"Could not reach the server, please try again later.",
@@ -349,17 +360,11 @@ namespace NebulaNetwork
             }
         }
 
+        private readonly AccessTools.FieldRef<WebSocket, MemoryStream> fragmentsBufferRef = AccessTools.FieldRefAccess<WebSocket, MemoryStream>("_fragmentsBuffer");
         private int GetFragmentBufferLength()
         {
-            MemoryStream buffer = (MemoryStream)AccessTools.Field(typeof(WebSocket), "_fragmentsBuffer").GetValue(clientSocket);
-            if (buffer != null)
-            {
-                return (int)buffer.Length;
-            }
-            else
-            {
-                return 0;
-            }
+            MemoryStream fragmentsBuffer = fragmentsBufferRef(clientSocket);
+            return (int)(fragmentsBuffer?.Length ?? 0);
         }
     }
 }

--- a/NebulaNetwork/Server.cs
+++ b/NebulaNetwork/Server.cs
@@ -130,6 +130,7 @@ namespace NebulaNetwork
             {
                 InGamePopup.ShowError("Error", "An error occurred while hosting the game: " + e.Message, "Close");
                 Stop();
+                Multiplayer.LeaveGame();
                 return;
             }
 

--- a/NebulaPatcher/Patches/Dynamic/UIGalaxySelect_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIGalaxySelect_Patch.cs
@@ -174,13 +174,19 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPostfix]
         [HarmonyPatch(nameof(UIGalaxySelect._OnUpdate))]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Original Function Name")]
-        public static void _OnUpdate_Postfix()
+        public static void _OnUpdate_Postfix(UIGalaxySelect __instance)
         {
             if (Multiplayer.IsInMultiplayerMenu)
             {
                 // as we need to load and generate planets for the detail view in the lobby, update the loading process here
                 PlanetModelingManager.ModelingPlanetCoroutine();
                 UIRoot.instance.uiGame.planetDetail._OnUpdate();
+                if (Input.mouseScrollDelta.y != 0)
+                {
+                    // zoom in/out when scrolling
+                    float delta = (Input.mouseScrollDelta.y < 0 ? 1f : -1f) * (VFInput.shift ? 1f : 0.1f);
+                    __instance.cameraPoser.distRatio += delta;
+                }
             }
         }
 

--- a/NebulaPatcher/Patches/Dynamic/VFPreload_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/VFPreload_Patch.cs
@@ -15,6 +15,7 @@ namespace NebulaPatcher.Patches.Dynamic
         {
             if (Multiplayer.IsDedicated)
             {
+                VFAudio.audioVolume = 0f;
                 NebulaModel.Utils.NativeInterop.HideWindow();
                 NebulaModel.Utils.NativeInterop.SetConsoleCtrlHandler();
                 // Logging to provide progression to user
@@ -56,7 +57,18 @@ namespace NebulaPatcher.Patches.Dynamic
 
             if (Multiplayer.IsDedicated)
             {
-                NebulaPlugin.StartDedicatedServer(NebulaWorld.GameStates.GameStatesManager.ImportedSaveName);
+                if (GameStatesManager.ImportedSaveName != null)
+                {
+                    NebulaPlugin.StartDedicatedServer(GameStatesManager.ImportedSaveName);
+                }
+                else if (GameStatesManager.NewGameDesc != null)
+                {
+                    NebulaPlugin.StartDedicatedServer(GameStatesManager.NewGameDesc);
+                }
+                else
+                {
+                    Log.Warn("No game start option provided!");
+                }
             }
         }
     }

--- a/NebulaPatcher/Patches/Transpilers/UIVirtualStarmap_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/UIVirtualStarmap_Transpiler.cs
@@ -230,6 +230,24 @@ namespace NebulaPatcher.Patches.Transpilers
                 }
             }));
 
+            // show all star/planet name when alt is pressed
+            matcher.End()
+                .SetOpcodeAndAdvance(OpCodes.Ldarg_0)
+                .Insert(
+                    HarmonyLib.Transpilers.EmitDelegate<Action<UIVirtualStarmap>>((UIVirtualStarmap starmap) =>
+                    {
+                        if (VFInput.alt)
+                        {
+                            int count = starmap.clickText == "" ? starmap.starPool.Count : starmap.starPool[0].starData?.planetCount + 1 ?? 0;
+                            for (int i = 1; i < count; i++)
+                            {
+                                starmap.starPool[i].nameText.gameObject.SetActive(true);
+                            }
+                        }
+                    }),
+                    new CodeInstruction(OpCodes.Ret)
+                );
+
             return matcher.InstructionEnumeration();
         }
 

--- a/NebulaWorld/GameStates/GameStatesManager.cs
+++ b/NebulaWorld/GameStates/GameStatesManager.cs
@@ -20,6 +20,7 @@ namespace NebulaWorld.GameStates
         public static float RealUPS => (float)FPSController.currentUPS;
         public static bool DuringReconnect = false;
         public static string ImportedSaveName { get; set; }
+        public static GameDesc NewGameDesc { get; set; }
         public static int FragmentSize { get; set; }
         private static int bufferLength;
 

--- a/NebulaWorld/InGamePopup.cs
+++ b/NebulaWorld/InGamePopup.cs
@@ -114,7 +114,7 @@ namespace NebulaWorld
 
         private static void CreateInputField(InputField.ContentType contentType, string text)
         {
-            GameObject inputObject = GameObject.Find("UI Root/Overlay Canvas/Nebula - Multiplayer Menu/galaxy-seed/InputField");
+            GameObject inputObject = GameObject.Find("UI Root/Overlay Canvas/Nebula - Multiplayer Menu/Host IP Address/InputField");
             inputObject = UnityEngine.Object.Instantiate(inputObject, displayedMessage.transform.Find("Window/Body/Client"));
             inputObject.name = "InputField";
             inputObject.transform.localPosition = new Vector3(-150, 0, 0);

--- a/NebulaWorld/MonoBehaviours/Remote/RemotePlayerAnimation.cs
+++ b/NebulaWorld/MonoBehaviours/Remote/RemotePlayerAnimation.cs
@@ -27,7 +27,11 @@ namespace NebulaWorld.MonoBehaviours.Remote
                 packetBuffer[i] = packetBuffer[i + 1];
             }
             packetBuffer[packetBuffer.Length - 1] = packet;
-            packet = packetBuffer[0];
+        }
+
+        private void Update()
+        {
+            PlayerMovement packet = packetBuffer[0];
             if (packet == null || PlayerAnimator == null)
             {
                 return;

--- a/NebulaWorld/RemotePlayerModel.cs
+++ b/NebulaWorld/RemotePlayerModel.cs
@@ -94,7 +94,7 @@ namespace NebulaWorld
             PlayerInstance = null;
             if (StarmapTracker != null)
             {
-                Object.Destroy(StarmapTracker);
+                Object.Destroy(StarmapTracker.gameObject);
             }
 
             if (StarmapNameText != null)

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -167,7 +167,8 @@ namespace NebulaWorld
             {
                 player.Data.Mecha.SandCount = GameMain.mainPlayer.sandCount;
             }
-
+            // Set the name of local player in starmap from Icarus to user name
+            GameMain.mainPlayer.mecha.appearance.overrideName = " " + player.Data.Username + " ";
             // Finally we need add the local player components to the player character
             localPlayerMovement = GameMain.mainPlayer.gameObject.AddComponentIfMissing<LocalPlayerMovement>();
             // ChatManager should continuous exsit until the game is closed


### PR DESCRIPTION
1. Add dedicated-server argument `-newgame seed starCount resourceMltiplier`
which will start the game with assigned parameters.
Note that parameters exceeding the acceptable value range may cause errors.
 (close #597 )

2. Fix mecha animation
The update packets are sent every 100ms,

3. Hide ip address in input field when stremer mode is on
Due to the need to reconnect during recording, sensitive information should be hidden during the process.

4. Add zoom in/out and show all star/planet names functions in lobby
The controls are mouse scroll and alt key, same as GS2.

5. Set the name of local player in starmap from Icarus to user name
mecha.appearance.overrideName is originally set when saving in mecha editor.

6. Update disconnection reason
Now client will show Server Busy when trying to join a server that is in full pause mode.