### PR TITLE
Bugfix for nebula 0.8.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 ## Changelog
 
+0.8.14:
+- @starfi5h: Fix mecha animation when player count > 2  
+- @starfi5h: Fix UIPerformance save test in multiplayer  
+- @starfi5h: Disable build/dismantle sounds when too far away  
+- @starfi5h: Convert strings to string.Translate() to enable translation  
+
+<details>
+<summary>All changes</summary>
+
 0.8.13:
 
 - @starfi5h: Fix compilation with 0.9.27.15466  
 - @starfi5h: Add -newgame launch option for dedicated server   
-
-<details>
-<summary>All changes</summary>
 
 0.8.12:
 

--- a/NebulaNetwork/PacketProcessors/Factory/Foundation/FoundationBuildUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Foundation/FoundationBuildUpdateProcessor.cs
@@ -11,7 +11,7 @@ namespace NebulaNetwork.PacketProcessors.Factory.Foundation
     [RegisterPacketProcessor]
     internal class FoundationBuildUpdateProcessor : PacketProcessor<FoundationBuildUpdatePacket>
     {
-        private readonly Vector3[] reformPoints = new Vector3[100];
+        private Vector3[] reformPoints = new Vector3[100];
 
         public override void ProcessPacket(FoundationBuildUpdatePacket packet, NebulaConnection conn)
         {
@@ -19,6 +19,11 @@ namespace NebulaNetwork.PacketProcessors.Factory.Foundation
             PlanetFactory factory = IsHost ? GameMain.data.GetOrCreateFactory(planet) : planet?.factory;
             if (factory != null)
             {
+                // Increase reformPoints for mods that increase brush size over 10
+                if (packet.ReformSize * packet.ReformSize > reformPoints.Length)
+                {
+                    reformPoints = new Vector3[packet.ReformSize * packet.ReformSize];
+                }
                 Array.Clear(reformPoints, 0, reformPoints.Length);
 
                 //Check if some mandatory variables are missing

--- a/NebulaPatcher/Patches/Dynamic/FactoryAudio_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/FactoryAudio_Patch.cs
@@ -1,0 +1,51 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+using UnityEngine;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(FactoryAudio))]
+    class FactoryAudio_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(FactoryAudio.OnEntityBuild))]
+        public static bool OnEntityBuild_Prefix(FactoryAudio __instance, int objId)
+        {
+            if (Multiplayer.IsActive && Multiplayer.Session.Factories.IsIncomingRequest.Value && objId > 0)
+            {
+                Vector3 pos = __instance.planet.factory.entityPool[objId].pos;
+                NebulaModel.Logger.Log.Debug((pos - GameMain.mainPlayer.position).sqrMagnitude + " " + (__instance.planet.radius * __instance.planet.radius / 4));
+                if ((pos - GameMain.mainPlayer.position).sqrMagnitude > (__instance.planet.radius * __instance.planet.radius / 4))
+                {
+                    // Don't make sounds if distance is over half of the planet radius
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(FactoryAudio.OnEntityDismantle))]
+        public static bool OnEntityDismantle_Prefix(FactoryAudio __instance, int objId)
+        {
+            if (Multiplayer.IsActive && Multiplayer.Session.Factories.IsIncomingRequest.Value)
+            {
+                Vector3 pos;
+                if (objId > 0)
+                {
+                    pos = __instance.planet.factory.entityPool[objId].pos;
+                }
+                else
+                {
+                    pos = __instance.planet.factory.prebuildPool[-objId].pos;
+                }
+                if ((pos - GameMain.mainPlayer.position).sqrMagnitude > (__instance.planet.radius * __instance.planet.radius / 4))
+                {
+                    // Don't make sounds if distance is over half of the planet radius
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/FactoryAudio_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/FactoryAudio_Patch.cs
@@ -14,7 +14,6 @@ namespace NebulaPatcher.Patches.Dynamic
             if (Multiplayer.IsActive && Multiplayer.Session.Factories.IsIncomingRequest.Value && objId > 0)
             {
                 Vector3 pos = __instance.planet.factory.entityPool[objId].pos;
-                NebulaModel.Logger.Log.Debug((pos - GameMain.mainPlayer.position).sqrMagnitude + " " + (__instance.planet.radius * __instance.planet.radius / 4));
                 if ((pos - GameMain.mainPlayer.position).sqrMagnitude > (__instance.planet.radius * __instance.planet.radius / 4))
                 {
                     // Don't make sounds if distance is over half of the planet radius

--- a/NebulaPatcher/Patches/Dynamic/GameSave_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameSave_Patch.cs
@@ -25,7 +25,7 @@ namespace NebulaPatcher.Patches.Dynamic
             }
 
             // Only save if in single player or if you are the host
-            return (!Multiplayer.IsActive && !Multiplayer.IsLeavingGame) || Multiplayer.Session.LocalPlayer.IsHost;
+            return !Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost;
         }
 
         [HarmonyPostfix]

--- a/NebulaPatcher/Patches/Dynamic/UIPerformancePanel_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIPerformancePanel_Patch.cs
@@ -1,0 +1,23 @@
+﻿using HarmonyLib;
+using NebulaWorld;
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(UIPerformancePanel))]
+    internal class UIPerformancePanel_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(UIPerformancePanel.OnDataActiveButtonClick))]
+        public static bool OnDataActiveButtonClick_Prefix(UIPerformancePanel __instance)
+        {
+            if (Multiplayer.IsActive && Multiplayer.Session.LocalPlayer.IsHost)
+            {
+                // Replace SaveAsLastExit() because it only triggers on UI exit in multiplayer mode
+                GameSave.SaveCurrentGame(GameSave.LastExit);
+                __instance.RefreshDataStatTexts();
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/NebulaWorld/MonoBehaviours/Remote/RemotePlayerAnimation.cs
+++ b/NebulaWorld/MonoBehaviours/Remote/RemotePlayerAnimation.cs
@@ -6,11 +6,25 @@ namespace NebulaWorld.MonoBehaviours.Remote
     // TODO: Missing client side interpolation
     public class RemotePlayerAnimation : MonoBehaviour
     {
+        public struct Snapshot
+        {
+            public EMovementState MovementState { get; set; }
+            public float HorzSpeed { get; set; }
+            public float VertSpeed { get; set; }
+            public float Turning { get; set; }
+            public float JumpWeight { get; set; }
+            public float JumpNormalizedTime { get; set; }
+            public byte IdleAnimIndex { get; set; }
+            public byte MiningAnimIndex { get; set; }
+            public float MiningWeight { get; set; }
+            public PlayerMovement.EFlags Flags { get; set; }
+        }
+
         public PlayerAnimator PlayerAnimator;
         private RemotePlayerMovement rootMovement;
         private RemotePlayerEffects remotePlayerEffects;
         private float altitudeFactor;
-        private readonly PlayerMovement[] packetBuffer = new PlayerMovement[3];
+        private readonly Snapshot[] packetBuffer = new Snapshot[3];
 
         private void Awake()
         {
@@ -26,13 +40,25 @@ namespace NebulaWorld.MonoBehaviours.Remote
             {
                 packetBuffer[i] = packetBuffer[i + 1];
             }
-            packetBuffer[packetBuffer.Length - 1] = packet;
+            packetBuffer[packetBuffer.Length - 1] = new Snapshot()
+            {
+                MovementState = packet.MovementState,
+                HorzSpeed = packet.HorzSpeed,
+                VertSpeed = packet.VertSpeed,
+                Turning = packet.Turning,
+                JumpWeight = packet.JumpWeight,
+                JumpNormalizedTime = packet.JumpNormalizedTime,
+                IdleAnimIndex = packet.IdleAnimIndex,
+                MiningAnimIndex = packet.MiningAnimIndex,
+                MiningWeight = packet.MiningWeight,
+                Flags = packet.Flags
+            };
         }
 
         private void Update()
         {
-            PlayerMovement packet = packetBuffer[0];
-            if (packet == null || PlayerAnimator == null)
+            ref Snapshot packet = ref packetBuffer[0];
+            if (PlayerAnimator == null)
             {
                 return;
             }
@@ -72,7 +98,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
             PlayerAnimator.AnimateSkills(deltaTime);
             AnimateRenderers(PlayerAnimator);
 
-            remotePlayerEffects.UpdateState(packet);
+            remotePlayerEffects.UpdateState(ref packet);
         }
 
         private void CalculateMovementStateWeights(PlayerAnimator animator, float dt)

--- a/NebulaWorld/MonoBehaviours/Remote/RemotePlayerEffects.cs
+++ b/NebulaWorld/MonoBehaviours/Remote/RemotePlayerEffects.cs
@@ -474,7 +474,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
         }
 
         // collision with vegetation, landing sound effect
-        private void UpdateExtraSoundEffects(PlayerMovement packet)
+        private void UpdateExtraSoundEffects(ref RemotePlayerAnimation.Snapshot packet)
         {
             if (rootMovement.localPlanetId < 0)
             {
@@ -550,7 +550,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
             vegeCollideColdTime = (vegeCollideColdTime > 0) ? vegeCollideColdTime - Time.deltaTime * 2 : 0;
         }
 
-        public void UpdateState(PlayerMovement packet)
+        public void UpdateState(ref RemotePlayerAnimation.Snapshot packet)
         {
             bool runActive = rootAnimation.runWeight > 0.001f;
             bool driftActive = rootAnimation.driftWeight > 0.001f;
@@ -562,7 +562,7 @@ namespace NebulaWorld.MonoBehaviours.Remote
 
             if (runActive || !isGrounded || maxAltitude > 0)
             {
-                UpdateExtraSoundEffects(packet);
+                UpdateExtraSoundEffects(ref packet);
             }
             if (runActive && isGrounded)
             {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
- Allow reform brush to have size over 10  
Mods like MechaDronesTweaks will make reform brush size bigger than 10.
- Fix mecha animation when player count > 2  
Packets in the buffer get interfered when there are 3 or more players, so use a snapshot struct to store the values instead.
- Fix UIPerformance save test in multiplayer  
Let the host be able to use save test button to save in `_lastexit_`
- Disable build/dismantle sounds when too far away  
If events are triggered by other players, mute them if the distance > 1/2 planet radius.