### PR TITLE
Fix 3D beacon visuals not rendering on client join

### DIFF
--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -219,6 +219,10 @@ internal class GameData_Patch
             Multiplayer.Session.Combat.OnFactoryLoadFinished(planet.factory);
             Multiplayer.Session.Enemies.OnFactoryLoadFinished(planet.factory);
 
+            // Rebuild markerCursor and recycle list so MarkerRenderer iterates pre-existing beacons.
+            // Same pattern as galacticTransport.Arragement() below (and vanilla GameData.Import line 936).
+            GameMain.data.galacticDigital?.Arragement();
+
             try
             {
                 NebulaModAPI.OnPlanetLoadFinished?.Invoke(planet.id);


### PR DESCRIPTION
## Summary

- Pre-existing beacon holograms (3D visuals) were invisible to clients joining a game
- Call `galacticDigital.Arragement()` after factory load to rebuild `markerCursor` and recycle list
- Without this, `MarkerRenderer.Update()` never iterates the marker pool so beacons have no 3D hologram

## Root Cause

When a client joins and loads a planet factory, the `GalacticDigitalSystem.markerCursor` is not updated to reflect markers already in the pool. `MarkerRenderer.Update()` iterates `markerPool[1..markerCursor-1]`, so with cursor stuck at 1, no beacons render.

## Fix

Same pattern as the existing `galacticTransport.Arragement()` call for ship rendering, and vanilla `GameData.Import()` (line 936).

## Test plan

- [x] Host creates beacons, client joins → client sees 3D beacon holograms
- [x] Beacons placed after join still render normally